### PR TITLE
fix: improve orchestrate tool to resolve module names

### DIFF
--- a/src/orchestrator/intent.rs
+++ b/src/orchestrator/intent.rs
@@ -170,6 +170,46 @@ impl IntentParser {
             }
         }
 
+        // Try to find a module-like name (lowercase with underscores, e.g., "orchestrator", "cache_module")
+        // This helps when user says "show me the orchestrator module" without a marker
+        let words: Vec<&str> = text.split_whitespace().collect();
+
+        // First priority: any word with a file extension
+        for word in &words {
+            let cleaned = word.trim_matches(|c: char| c.is_ascii_punctuation());
+            if file_extensions.iter().any(|ext| cleaned.ends_with(ext)) {
+                return Some(cleaned.to_string());
+            }
+        }
+
+        // Second priority: module names with underscores (e.g., "cache_module")
+        for word in &words {
+            let cleaned = word.trim_matches(|c: char| c.is_ascii_punctuation());
+            if cleaned.len() >= 3
+                && cleaned.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                && cleaned.contains('_')
+            {
+                return Some(cleaned.to_string());
+            }
+        }
+
+        // Third priority: single lowercase words that might be module names (e.g., "orchestrator")
+        for word in &words {
+            let cleaned = word.trim_matches(|c: char| c.is_ascii_punctuation());
+            // Skip common words, look for likely module names
+            if cleaned.len() >= 4
+                && cleaned.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                && !["the", "for", "with", "from", "this", "that", "file", "module", "show"].contains(&cleaned)
+            {
+                // Check if it looks like a module/class name (camelCase or snake_case)
+                if cleaned.contains('_')
+                    || (cleaned.chars().all(|c| c.is_lowercase()) && cleaned.len() > 6)
+                {
+                    return Some(cleaned.to_string());
+                }
+            }
+        }
+
         // Try to extract identifier after function/class keywords
         let func_markers = ["function ", "class ", "struct ", "enum ", "trait ", "impl "];
         for marker in &func_markers {

--- a/src/orchestrator/intent.rs
+++ b/src/orchestrator/intent.rs
@@ -186,7 +186,11 @@ impl IntentParser {
         for word in &words {
             let cleaned = word.trim_matches(|c: char| c.is_ascii_punctuation());
             if cleaned.len() >= 3
-                && cleaned.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
+                && cleaned
+                    .chars()
+                    .next()
+                    .map(|c| c.is_lowercase())
+                    .unwrap_or(false)
                 && cleaned.contains('_')
             {
                 return Some(cleaned.to_string());
@@ -198,8 +202,15 @@ impl IntentParser {
             let cleaned = word.trim_matches(|c: char| c.is_ascii_punctuation());
             // Skip common words, look for likely module names
             if cleaned.len() >= 4
-                && cleaned.chars().next().map(|c| c.is_lowercase()).unwrap_or(false)
-                && !["the", "for", "with", "from", "this", "that", "file", "module", "show"].contains(&cleaned)
+                && cleaned
+                    .chars()
+                    .next()
+                    .map(|c| c.is_lowercase())
+                    .unwrap_or(false)
+                && ![
+                    "the", "for", "with", "from", "this", "that", "file", "module", "show",
+                ]
+                .contains(&cleaned)
             {
                 // Check if it looks like a module/class name (camelCase or snake_case)
                 if cleaned.contains('_')

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -62,8 +62,10 @@ impl QueryOrchestrator {
         let intent = self.intent_parser.parse(intent_str);
         // Use intent target as fallback when file is not explicitly provided
         let target_file = file.or(intent.target.as_deref());
-        let effective_file = target_file
-            .map(|t| self.resolve_module_to_file(t).unwrap_or_else(|| t.to_string()));
+        let effective_file = target_file.map(|t| {
+            self.resolve_module_to_file(t)
+                .unwrap_or_else(|| t.to_string())
+        });
         let cache_key = self.compute_cache_key(&intent, effective_file.as_deref(), mode);
 
         if !fresh {
@@ -136,9 +138,9 @@ impl QueryOrchestrator {
         file: Option<&str>,
         mode: Option<&str>,
     ) -> Result<CachedContent, String> {
-        let target_file = file.ok_or_else(|| {
+        let target_file = file.ok_or(
             "File required for context query. Example: 'context for src/main.rs' or 'show me context for ./src/main.rs'"
-        })?;
+        )?;
         let read_mode = self.resolve_mode(mode, target_file);
 
         let file_elements = self

--- a/src/orchestrator/mod.rs
+++ b/src/orchestrator/mod.rs
@@ -60,7 +60,11 @@ impl QueryOrchestrator {
         fresh: bool,
     ) -> Result<OrchestratedResult, String> {
         let intent = self.intent_parser.parse(intent_str);
-        let cache_key = self.compute_cache_key(&intent, file, mode);
+        // Use intent target as fallback when file is not explicitly provided
+        let target_file = file.or(intent.target.as_deref());
+        let effective_file = target_file
+            .map(|t| self.resolve_module_to_file(t).unwrap_or_else(|| t.to_string()));
+        let cache_key = self.compute_cache_key(&intent, effective_file.as_deref(), mode);
 
         if !fresh {
             if let Some(cached) = self.cache.lock().get(&cache_key) {
@@ -79,7 +83,7 @@ impl QueryOrchestrator {
             }
         }
 
-        let result = self.execute_intent(&intent, file, mode)?;
+        let result = self.execute_intent(&intent, effective_file.as_deref(), mode)?;
         self.cache.lock().insert(cache_key.clone(), result.clone());
 
         Ok(OrchestratedResult {
@@ -132,7 +136,9 @@ impl QueryOrchestrator {
         file: Option<&str>,
         mode: Option<&str>,
     ) -> Result<CachedContent, String> {
-        let target_file = file.ok_or("File required for context query")?;
+        let target_file = file.ok_or_else(|| {
+            "File required for context query. Example: 'context for src/main.rs' or 'show me context for ./src/main.rs'"
+        })?;
         let read_mode = self.resolve_mode(mode, target_file);
 
         let file_elements = self
@@ -315,6 +321,24 @@ impl QueryOrchestrator {
             file.unwrap_or("*"),
             mode.unwrap_or("auto")
         )
+    }
+
+    /// Try to resolve a module name to a file path.
+    /// E.g., "orchestrator" -> "src/orchestrator/mod.rs"
+    fn resolve_module_to_file(&self, target: &str) -> Option<String> {
+        let candidates = [
+            format!("src/{}/mod.rs", target),
+            format!("src/{}.rs", target),
+            format!("{}/mod.rs", target),
+            format!("{}.rs", target),
+        ];
+
+        for candidate in &candidates {
+            if std::path::Path::new(candidate).exists() {
+                return Some(candidate.clone());
+            }
+        }
+        None
     }
 }
 


### PR DESCRIPTION
## Summary

Improves the `orchestrate` MCP tool to work with natural language without requiring explicit file paths.

### Problem
- `"show me the orchestrator module structure"` returned error "File required for context query"
- Users had to explicitly say `"context for src/orchestrator/mod.rs"`

### Solution
1. **Intent parser** (`intent.rs`): Added fallback logic to extract module-like names from natural language (e.g., "orchestrator" extracted from "the orchestrator")
2. **Module resolution** (`mod.rs`): Added `resolve_module_to_file()` to map bare module names to file paths (e.g., "orchestrator" → "src/orchestrator/mod.rs")
3. **Error message**: Improved to show usage example

### Test results
```
=== orchestrate: "show me the orchestrator module structure" ===
Elapsed: 11ms
cache_key: context:src/orchestrator/mod.rs:auto
content: (file content returned correctly)
```

All 20 orchestrator tests pass.

## Test plan
- [x] Unit tests pass (20/20)
- [x] MCP tool test with natural language intent
- [x] Existing explicit file path intents still work