### PR TITLE
fix: validate required parameters before dispatching to handlers

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -710,6 +710,29 @@ impl MCPServer {
         Ok(current_dir)
     }
 
+    fn validate_required_params(
+        &self,
+        tool_name: &str,
+        arguments: &serde_json::Map<String, serde_json::Value>,
+    ) -> Option<String> {
+        let tools = ToolRegistry::list_tools();
+        let tool = tools.iter().find(|t| t.name == tool_name)?;
+
+        let required_params = tool.input_schema.get("required")?.as_array()?;
+        for param in required_params {
+            let param_name = param.as_str()?;
+            if !arguments.contains_key(param_name)
+                || arguments.get(param_name).is_none_or(|v| v.is_null())
+            {
+                return Some(format!(
+                    "Missing required parameter '{}' for tool '{}'",
+                    param_name, tool_name
+                ));
+            }
+        }
+        None
+    }
+
     async fn execute_tool(
         &self,
         tool_name: &str,
@@ -721,6 +744,11 @@ impl MCPServer {
             project_root.display(),
             self.get_db_path().display()
         );
+
+        // Validate required parameters before dispatching to handler
+        if let Some(err) = self.validate_required_params(tool_name, &arguments) {
+            return Err(err);
+        }
 
         if tool_name == "mcp_init" {
             if let Some(path) = arguments.get("path").and_then(|v| v.as_str()) {


### PR DESCRIPTION
## Summary

- Validate required parameters at MCP server entry point before dispatching to handlers
- Return clear error messages like `"Missing required parameter 'file' for tool 'get_dependencies'"` instead of cryptic handler errors

## Root Cause

When Cursor called LeanKG MCP tools (e.g., `get_dependencies`, `get_dependents`) without the required `file` parameter, the error surfaced deep in handler code instead of being caught early.

## Test plan

- [ ] Verify `get_dependencies` without `file` param returns clear error
- [ ] Verify `get_dependents` without `file` param returns clear error  
- [ ] Verify all other tools with required params behave correctly
- [ ] Run `cargo test --lib` to confirm no regressions