### PR TITLE
feat: add Claude-Mem-like session management hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See [docs/cli-reference.md](docs/cli-reference.md) for all commands.
 
 ## Claude Code Setup
 
-LeanKG auto-triggers in Claude Code sessions via PreToolUse hooks that route search intents to LeanKG tools instead of native tools.
+LeanKG auto-triggers in Claude Code sessions via lifecycle hooks that route search intents to LeanKG tools instead of native tools.
 
 ```bash
 # Install LeanKG with Claude Code hooks and plugin
@@ -132,13 +132,16 @@ leankg setup
 
 **What `leankg setup` installs:**
 - `.claude-plugin/` - Plugin manifest for Claude Code validation
-- `hooks/` - PreToolUse, SessionStart, PostToolUse hooks
+- `hooks/` - Full lifecycle hooks: Setup, SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop
 - Adds `leankg@local` to `enabledPlugins` in `~/.claude/settings.json`
 
-**Auto-trigger behavior:**
-- `SessionStart` hook injects tool selection hierarchy into every session
-- `PreToolUse` hook nudges toward LeanKG when you use Grep/Read/Bash for code analysis
-- LeanKG returns token-optimized context instead of scanning entire files
+**Hook lifecycle:**
+- `Setup` - Version gating on startup
+- `SessionStart` - Injects tool selection hierarchy into every session
+- `UserPromptSubmit` - Initializes session context with LeanKG patterns
+- `PreToolUse` - Nudges toward LeanKG when you use Grep/Read/Bash for code analysis
+- `PostToolUse` - Logs LeanKG MCP tool usage for analytics
+- `Stop` - Captures session summary for future context retrieval
 
 ---
 
@@ -188,15 +191,15 @@ See [docs/architecture.md](docs/architecture.md) for system design and data mode
 
 ## Supported AI Tools
 
-| Tool | Auto-Setup | Session Hook | Plugin |
-|------|------------|--------------|--------|
-| Cursor | Yes | session-start | - |
-| Claude Code | Yes | session-start | Yes |
-| OpenCode | Yes | - | Yes |
-| Kilo Code | Yes | - | - |
-| Gemini CLI | Yes | - | - |
-| Google Antigravity | Yes | - | - |
-| Codex | Yes | - | - |
+| Tool | Auto-Setup | Session Hook | Plugin | Full Lifecycle Hooks |
+|------|------------|--------------|--------|---------------------|
+| Cursor | Yes | session-start | - | - |
+| Claude Code | Yes | session-start | Yes | Setup, SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop |
+| OpenCode | Yes | - | Yes | - |
+| Kilo Code | Yes | - | - | - |
+| Gemini CLI | Yes | - | - | - |
+| Google Antigravity | Yes | - | - | - |
+| Codex | Yes | - | - | - |
 
 > **Note:** Cursor requires per-project installation. The AI features work on a per-workspace basis, so LeanKG should be installed in each project directory where you want AI context injection.
 

--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -1,0 +1,71 @@
+{
+  "description": "LeanKG hooks - enforces LeanKG usage and provides Claude-Mem-like session management",
+  "hooks": {
+    "Setup": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/version-check.mjs\""
+          }
+        ]
+      }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/sessionstart.mjs\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-init.mjs\""
+          }
+        ]
+      }
+    ],
+    "PreToolUse": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/leankg-pretooluse.mjs\""
+          }
+        ]
+      }
+    ],
+    "PostToolUse": [
+      {
+        "matcher": "mcp__leankg__*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/leankg-posttooluse.mjs\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/summarize.mjs\""
+          }
+        ]
+      }
+    ]
+  }
+}

--- a/hooks/session-init.mjs
+++ b/hooks/session-init.mjs
@@ -1,0 +1,152 @@
+#!/usr/bin/env node
+/**
+ * UserPromptSubmit hook for LeanKG (session-init)
+ * Initializes session context and injects LeanKG usage patterns
+ * Replaces what Claude-Mem's session-init handler does
+ */
+import { readFileSync, existsSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || __dirname;
+const SESSION_STORE = join(process.env.HOME || "~", ".cache", "leankg-hooks", "sessions.db");
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.on("readable", () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        data += chunk;
+      }
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+// Detect project type from directory structure
+function detectProjectType(cwd) {
+  const indicators = [
+    { pattern: "Cargo.toml", type: "rust", weight: 10 },
+    { pattern: "package.json", type: "node", weight: 8 },
+    { pattern: "go.mod", type: "go", weight: 9 },
+    { pattern: "pyproject.toml", type: "python", weight: 7 },
+    { pattern: "requirements.txt", type: "python", weight: 6 },
+    { pattern: "pom.xml", type: "java", weight: 7 },
+    { pattern: "build.gradle", type: "java", weight: 8 },
+    { pattern: ".venv", type: "python", weight: 5 },
+    { pattern: "node_modules", type: "node", weight: 4 },
+    { pattern: "src/main.rs", type: "rust", weight: 6 },
+    { pattern: "src/lib.rs", type: "rust", weight: 6 },
+  ];
+
+  let bestType = "unknown";
+  let bestScore = 0;
+
+  for (const { pattern, type, weight } of indicators) {
+    if (existsSync(join(cwd, pattern))) {
+      if (weight > bestScore) {
+        bestScore = weight;
+        bestType = type;
+      }
+    }
+  }
+
+  return bestType;
+}
+
+// Get LeanKG tool routing based on project type
+function getToolRouting(projectType) {
+  const baseRouting = `
+<tool_selection_hierarchy>
+  1. ORCHESTRATE: mcp__leankg__orchestrate(intent)
+     - Natural language: "show me impact of changing function X"
+
+  2. CODE DISCOVERY: mcp__leankg__search_code(query, element_type)
+     - Primary search. ONE call replaces many Grep/Bash commands.
+
+  3. IMPACT ANALYSIS: mcp__leankg__get_impact_radius(file, depth)
+     - Calculate blast radius BEFORE making changes.
+
+  4. CONTEXT: mcp__leankg__get_context(file)
+     - Get minimal token-optimized context for a file.
+
+  5. DEPENDENCIES: mcp__leankg__get_dependencies(file) | mcp__leankg__get_dependents(file)
+
+  6. CALLERS: mcp__leankg__get_callers(function) | mcp__leankg__find_function(name)
+
+  7. DOCUMENTATION: mcp__leankg__get_doc_for_file(file) | mcp__leankg__get_traceability(element)
+
+  8. TESTING: mcp__leankg__get_tested_by(file) | mcp__leankg__detect_changes(scope)
+</tool_selection_hierarchy>`;
+
+  const projectSpecific = projectType !== "unknown" ? `\n<project_context>
+Project type detected: ${projectType}
+- Ensure LeanKG index is up to date for this project type
+- Use mcp__leankg__mcp_status to verify readiness
+</project_context>` : "";
+
+  return baseRouting + projectSpecific;
+}
+
+// Get forbidden actions
+function getForbiddenActions() {
+  return `<forbidden_actions>
+  - DO NOT use Grep for code search (use mcp__leankg__search_code instead)
+  - DO NOT use Bash find/grep for file search (use mcp__leankg__query_file instead)
+  - DO NOT use raw grep/rg/fd/fzf in Bash for code discovery
+</forbidden_actions>`;
+}
+
+// Build session initialization context
+function buildSessionContext(input) {
+  const cwd = input.cwd || process.cwd();
+  const projectType = detectProjectType(cwd);
+
+  let context = getToolRouting(projectType);
+  context += "\n\n" + getForbiddenActions();
+
+  // Add LeanKG status reminder
+  context += `
+
+<leankg_reminder>
+- Run: mcp__leankg__mcp_status to verify LeanKG is ready
+- Run: mcp__leankg__mcp_index to index code if needed
+- LeanKG is 10-100x faster than raw grep on large codebases
+</leankg_reminder>`;
+
+  return context;
+}
+
+async function main() {
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) process.exit(0);
+
+    const input = JSON.parse(raw);
+    const toolName = input.tool_name || "";
+
+    // This hook only activates on UserPromptSubmit
+    // Check if this is a prompt submission
+    if (!input.prompt && !input.user_prompt) {
+      process.exit(0);
+    }
+
+    const sessionContext = buildSessionContext(input);
+
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: sessionContext,
+      },
+    }) + "\n");
+
+  } catch (err) {
+    console.error("SessionInit error:", err.message);
+    process.exit(0);
+  }
+}
+
+main();

--- a/hooks/summarize.mjs
+++ b/hooks/summarize.mjs
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+/**
+ * Stop hook for LeanKG (summarize)
+ * Captures session summary and stores for future context injection
+ * Replaces what Claude-Mem's summarize handler does
+ */
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || __dirname;
+const SESSION_DIR = join(process.env.HOME || "~", ".cache", "leankg-hooks", "sessions");
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.on("readable", () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        data += chunk;
+      }
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+// Extract tool usage from session
+function extractToolUsage(input) {
+  const tools = [];
+
+  // Check various input formats for tool usage
+  if (input.tool_calls) {
+    for (const call of input.tool_calls) {
+      tools.push({
+        name: call.name || call.tool_name || "unknown",
+        args: call.arguments || call.args || {},
+      });
+    }
+  }
+
+  if (input.tools_used) {
+    tools.push(...input.tools_used);
+  }
+
+  if (input.mcp_tools) {
+    tools.push(...input.mcp_tools.map(t => ({ name: t })));
+  }
+
+  return tools;
+}
+
+// Generate session summary
+function generateSummary(input) {
+  const timestamp = new Date().toISOString();
+  const cwd = input.cwd || process.cwd() || "unknown";
+  const tools = extractToolUsage(input);
+
+  // Categorize tools used
+  const mcpTools = tools.filter(t => t.name.startsWith("mcp__leankg__")).map(t => t.name.replace("mcp__leankg__", ""));
+  const bashCommands = tools.filter(t => t.name === "Bash").length;
+  const otherTools = tools.filter(t => !t.name.startsWith("mcp__leankg__") && t.name !== "Bash");
+
+  const summary = {
+    timestamp,
+    cwd,
+    tools_used: {
+      total: tools.length,
+      mcp_leankg: mcpTools.length,
+      bash_commands: bashCommands,
+      other: otherTools.length,
+    },
+    leankg_tools: [...new Set(mcpTools)], // unique
+    session_duration_ms: input.duration_ms || 0,
+  };
+
+  return summary;
+}
+
+// Save session summary to file
+function saveSessionSummary(summary) {
+  try {
+    // Ensure directory exists
+    if (!existsSync(SESSION_DIR)) {
+      mkdirSync(SESSION_DIR, { recursive: true });
+    }
+
+    // Use timestamp as filename component
+    const ts = new Date().getTime();
+    const filename = `session-${ts}.json`;
+    const filepath = join(SESSION_DIR, filename);
+
+    writeFileSync(filepath, JSON.stringify(summary, null, 2));
+
+    // Also update a "latest" symlink/reference
+    const latestPath = join(SESSION_DIR, "latest.json");
+    writeFileSync(latestPath, JSON.stringify(summary, null, 2));
+
+    return filepath;
+  } catch (err) {
+    console.error("Failed to save session summary:", err.message);
+    return null;
+  }
+}
+
+// Build output for stop hook
+function buildStopOutput(summary) {
+  const toolList = summary.leankg_tools.length > 0
+    ? `\n\nLeanKG tools used this session:\n${summary.leankg_tools.map(t => `  - ${t}`).join("\n")}`
+    : "";
+
+  return `Session Summary:
+- Working directory: ${summary.cwd}
+- Total tools used: ${summary.tools_used.total}
+- LeanKG MCP calls: ${summary.tools_used.mcp_leankg}
+- Bash commands: ${summary.tools_used.bash_commands}${toolList}
+
+This summary will be available for context injection in future sessions.`;
+}
+
+async function main() {
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) process.exit(0);
+
+    const input = JSON.parse(raw);
+
+    // This hook activates on Stop
+    const hookName = input.hook_name || input.hook_event_name || "";
+    if (hookName !== "Stop") {
+      process.exit(0);
+    }
+
+    const summary = generateSummary(input);
+    const savedPath = saveSessionSummary(summary);
+
+    const summaryText = buildStopOutput(summary);
+
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "Stop",
+        sessionSummary: summary,
+        summaryText,
+        savedTo: savedPath,
+      },
+    }) + "\n");
+
+  } catch (err) {
+    console.error("Summarize error:", err.message);
+    process.exit(0);
+  }
+}
+
+main();

--- a/hooks/version-check.mjs
+++ b/hooks/version-check.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+/**
+ * Setup hook for LeanKG - version check
+ * Runs at plugin startup to verify version requirements
+ */
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || __dirname;
+
+// Minimum required version
+const MIN_VERSION = "0.16.0";
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.on("readable", () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        data += chunk;
+      }
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function getInstalledVersion() {
+  try {
+    // Try to get version from Cargo.toml in the plugin or workspace
+    const cargoPath = join(PLUGIN_ROOT, "..", "..", "Cargo.toml");
+    const content = readFileSync(cargoPath, "utf-8");
+    const match = content.match(/version\s*=\s*"([^"]+)"/);
+    return match ? match[1] : null;
+  } catch {
+    // Fallback: run cargo to get version
+    try {
+      const result = spawnSync("cargo", ["pkgid"], {
+        cwd: PLUGIN_ROOT,
+        timeout: 5000,
+      });
+      if (result.status === 0) {
+        const match = result.stdout.toString().match(/#1\.0\.0\.(\d+)/);
+        return match ? `0.1.0.${match[1]}` : null;
+      }
+    } catch {
+      // ignore
+    }
+    return null;
+  }
+}
+
+function compareVersions(a, b) {
+  const partsA = a.split(".").map(Number);
+  const partsB = b.split(".").map(Number);
+
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const pA = partsA[i] || 0;
+    const pB = partsB[i] || 0;
+    if (pA > pB) return 1;
+    if (pA < pB) return -1;
+  }
+  return 0;
+}
+
+async function main() {
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) {
+      // No input means skip (hook not triggered properly)
+      process.exit(0);
+    }
+
+    const input = JSON.parse(raw);
+    const hookName = input.hookName || input.hook_event_name || "Setup";
+
+    if (hookName !== "Setup") {
+      process.exit(0);
+    }
+
+    const installedVersion = getInstalledVersion();
+
+    if (!installedVersion) {
+      console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "Setup",
+          versionCheck: "warning",
+          message: "Could not determine LeanKG version. Version gating skipped.",
+        },
+      }));
+      process.exit(0);
+    }
+
+    const versionOk = compareVersions(installedVersion, MIN_VERSION) >= 0;
+
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "Setup",
+        versionCheck: versionOk ? "pass" : "fail",
+        installedVersion,
+        minimumVersion: MIN_VERSION,
+        message: versionOk
+          ? `LeanKG v${installedVersion} ready`
+          : `LeanKG v${installedVersion} does not meet minimum v${MIN_VERSION}`,
+      },
+    }) + "\n");
+
+  } catch (err) {
+    console.error("Version check error:", err.message);
+    process.exit(0);
+  }
+}
+
+main();

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -370,18 +370,41 @@ setup_claude_hooks() {
 
     mkdir -p "$plugin_dir/hooks"
 
-    # Write hooks.json with PreToolUse, PostToolUse, and SessionStart
-    # Using "*" matcher for PreToolUse to intercept ALL tools (context-mode pattern)
+    # Write hooks.json with all Claude-Mem-equivalent hooks
+    # Setup, SessionStart, UserPromptSubmit, PreToolUse, PostToolUse, Stop
     cat > "$plugin_dir/hooks/hooks.json" <<'EOF'
 {
+  "description": "LeanKG hooks - enforces LeanKG usage and provides Claude-Mem-like session management",
   "hooks": {
+    "Setup": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/version-check.mjs\""
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
-        "matcher": "startup|clear|compact",
+        "matcher": "*",
         "hooks": [
           {
             "type": "command",
             "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/sessionstart.mjs\""
+          }
+        ]
+      }
+    ],
+    "UserPromptSubmit": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/session-init.mjs\""
           }
         ]
       }
@@ -392,18 +415,29 @@ setup_claude_hooks() {
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/leankg-pretooluse.mjs\""
           }
         ]
       }
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__leankg__",
+        "matcher": "mcp__leankg__*",
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/leankg-posttooluse.mjs\""
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/summarize.mjs\""
           }
         ]
       }
@@ -667,7 +701,307 @@ async function main() {
 main();
 HOOKEOF
 
-    chmod +x "$plugin_dir/hooks/sessionstart.mjs" "$plugin_dir/hooks/pretooluse.mjs" "$plugin_dir/hooks/posttooluse.mjs"
+    cat > "$plugin_dir/hooks/version-check.mjs" <<'HOOKEOF'
+#!/usr/bin/env node
+/**
+ * Setup hook for LeanKG - version check
+ * Runs at plugin startup to verify version requirements
+ */
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { spawnSync } from "node:child_process";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PLUGIN_ROOT = process.env.CLAUDE_PLUGIN_ROOT || __dirname;
+const MIN_VERSION = "0.16.0";
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.on("readable", () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        data += chunk;
+      }
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function getInstalledVersion() {
+  try {
+    const cargoPath = join(PLUGIN_ROOT, "..", "..", "Cargo.toml");
+    const content = readFileSync(cargoPath, "utf-8");
+    const match = content.match(/version\s*=\s*"([^"]+)"/);
+    return match ? match[1] : null;
+  } catch {
+    return null;
+  }
+}
+
+function compareVersions(a, b) {
+  const partsA = a.split(".").map(Number);
+  const partsB = b.split(".").map(Number);
+  for (let i = 0; i < Math.max(partsA.length, partsB.length); i++) {
+    const pA = partsA[i] || 0;
+    const pB = partsB[i] || 0;
+    if (pA > pB) return 1;
+    if (pA < pB) return -1;
+  }
+  return 0;
+}
+
+async function main() {
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) process.exit(0);
+
+    const input = JSON.parse(raw);
+    const hookName = input.hookName || input.hook_event_name || "Setup";
+    if (hookName !== "Setup") process.exit(0);
+
+    const installedVersion = getInstalledVersion();
+    if (!installedVersion) {
+      console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "Setup",
+          versionCheck: "warning",
+          message: "Could not determine LeanKG version. Version gating skipped.",
+        },
+      }));
+      process.exit(0);
+    }
+
+    const versionOk = compareVersions(installedVersion, MIN_VERSION) >= 0;
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "Setup",
+        versionCheck: versionOk ? "pass" : "fail",
+        installedVersion,
+        minimumVersion: MIN_VERSION,
+        message: versionOk ? `LeanKG v${installedVersion} ready` : `LeanKG v${installedVersion} does not meet minimum v${MIN_VERSION}`,
+      },
+    }) + "\n");
+  } catch (err) {
+    console.error("Version check error:", err.message);
+    process.exit(0);
+  }
+}
+
+main();
+HOOKEOF
+
+    cat > "$plugin_dir/hooks/session-init.mjs" <<'HOOKEOF'
+#!/usr/bin/env node
+/**
+ * UserPromptSubmit hook for LeanKG (session-init)
+ * Initializes session context and injects LeanKG usage patterns
+ */
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.on("readable", () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        data += chunk;
+      }
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function detectProjectType(cwd) {
+  const indicators = [
+    { pattern: "Cargo.toml", type: "rust", weight: 10 },
+    { pattern: "package.json", type: "node", weight: 8 },
+    { pattern: "go.mod", type: "go", weight: 9 },
+    { pattern: "pyproject.toml", type: "python", weight: 7 },
+    { pattern: "pom.xml", type: "java", weight: 7 },
+  ];
+  let bestType = "unknown";
+  let bestScore = 0;
+  for (const { pattern, type, weight } of indicators) {
+    if (existsSync(join(cwd, pattern))) {
+      if (weight > bestScore) {
+        bestScore = weight;
+        bestType = type;
+      }
+    }
+  }
+  return bestType;
+}
+
+function buildSessionContext(input) {
+  const cwd = input.cwd || process.cwd();
+  const projectType = detectProjectType(cwd);
+
+  const context = `<tool_selection_hierarchy>
+  1. ORCHESTRATE: mcp__leankg__orchestrate(intent)
+  2. CODE DISCOVERY: mcp__leankg__search_code(query, element_type)
+  3. IMPACT ANALYSIS: mcp__leankg__get_impact_radius(file, depth)
+  4. CONTEXT: mcp__leankg__get_context(file)
+  5. DEPENDENCIES: mcp__leankg__get_dependencies(file) | mcp__leankg__get_dependents(file)
+  6. CALLERS: mcp__leankg__get_callers(function) | mcp__leankg__find_function(name)
+  7. DOCUMENTATION: mcp__leankg__get_doc_for_file(file) | mcp__leankg__get_traceability(element)
+  8. TESTING: mcp__leankg__get_tested_by(file) | mcp__leankg__detect_changes(scope)
+</tool_selection_hierarchy>
+
+<forbidden_actions>
+  - DO NOT use Grep for code search (use mcp__leankg__search_code instead)
+  - DO NOT use Bash find/grep for file search (use mcp__leankg__query_file instead)
+</forbidden_actions>
+
+<project_context>
+Project type detected: ${projectType}
+</project_context>
+
+<leankg_reminder>
+- Run: mcp__leankg__mcp_status to verify LeanKG is ready
+- Run: mcp__leankg__mcp_index to index code if needed
+</leankg_reminder>`;
+
+  return context;
+}
+
+async function main() {
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) process.exit(0);
+
+    const input = JSON.parse(raw);
+    if (!input.prompt && !input.user_prompt) process.exit(0);
+
+    const sessionContext = buildSessionContext(input);
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "UserPromptSubmit",
+        additionalContext: sessionContext,
+      },
+    }) + "\n");
+  } catch (err) {
+    console.error("SessionInit error:", err.message);
+    process.exit(0);
+  }
+}
+
+main();
+HOOKEOF
+
+    cat > "$plugin_dir/hooks/summarize.mjs" <<'HOOKEOF'
+#!/usr/bin/env node
+/**
+ * Stop hook for LeanKG (summarize)
+ * Captures session summary and stores for future context injection
+ */
+import { writeFileSync, existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+function readStdin() {
+  return new Promise((resolve, reject) => {
+    let data = "";
+    process.stdin.on("readable", () => {
+      let chunk;
+      while ((chunk = process.stdin.read()) !== null) {
+        data += chunk;
+      }
+    });
+    process.stdin.on("end", () => resolve(data));
+    process.stdin.on("error", reject);
+  });
+}
+
+function extractToolUsage(input) {
+  const tools = [];
+  if (input.tool_calls) {
+    for (const call of input.tool_calls) {
+      tools.push({ name: call.name || call.tool_name || "unknown" });
+    }
+  }
+  if (input.tools_used) tools.push(...input.tools_used);
+  if (input.mcp_tools) tools.push(...input.mcp_tools.map(t => ({ name: t })));
+  return tools;
+}
+
+function generateSummary(input) {
+  const timestamp = new Date().toISOString();
+  const cwd = input.cwd || process.cwd() || "unknown";
+  const tools = extractToolUsage(input);
+  const mcpTools = tools.filter(t => t.name.startsWith("mcp__leankg__")).map(t => t.name.replace("mcp__leankg__", ""));
+  const bashCommands = tools.filter(t => t.name === "Bash").length;
+
+  return {
+    timestamp,
+    cwd,
+    tools_used: { total: tools.length, mcp_leankg: mcpTools.length, bash_commands: bashCommands },
+    leankg_tools: [...new Set(mcpTools)],
+    session_duration_ms: input.duration_ms || 0,
+  };
+}
+
+function saveSessionSummary(summary) {
+  try {
+    const SESSION_DIR = join(process.env.HOME || "~", ".cache", "leankg-hooks", "sessions");
+    if (!existsSync(SESSION_DIR)) mkdirSync(SESSION_DIR, { recursive: true });
+    const ts = new Date().getTime();
+    const filepath = join(SESSION_DIR, `session-${ts}.json`);
+    writeFileSync(filepath, JSON.stringify(summary, null, 2));
+    const latestPath = join(SESSION_DIR, "latest.json");
+    writeFileSync(latestPath, JSON.stringify(summary, null, 2));
+    return filepath;
+  } catch (err) {
+    console.error("Failed to save session summary:", err.message);
+    return null;
+  }
+}
+
+async function main() {
+  try {
+    const raw = await readStdin();
+    if (!raw.trim()) process.exit(0);
+
+    const input = JSON.parse(raw);
+    const hookName = input.hook_name || input.hook_event_name || "";
+    if (hookName !== "Stop") process.exit(0);
+
+    const summary = generateSummary(input);
+    const savedPath = saveSessionSummary(summary);
+
+    const toolList = summary.leankg_tools.length > 0
+      ? summary.leankg_tools.map(t => `  - ${t}`).join("\n")
+      : "none";
+
+    const summaryText = `Session Summary:
+- Working directory: ${summary.cwd}
+- Total tools used: ${summary.tools_used.total}
+- LeanKG MCP calls: ${summary.tools_used.mcp_leankg}
+- Bash commands: ${summary.tools_used.bash_commands}
+- LeanKG tools used: ${summary.leankg_tools.join(", ") || "none"}
+- Saved to: ${savedPath}`;
+
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: "Stop",
+        sessionSummary: summary,
+        summaryText,
+        savedTo: savedPath,
+      },
+    }) + "\n");
+  } catch (err) {
+    console.error("Summarize error:", err.message);
+    process.exit(0);
+  }
+}
+
+main();
+HOOKEOF
+
+    chmod +x "$plugin_dir/hooks/sessionstart.mjs" "$plugin_dir/hooks/pretooluse.mjs" "$plugin_dir/hooks/posttooluse.mjs" "$plugin_dir/hooks/version-check.mjs" "$plugin_dir/hooks/session-init.mjs" "$plugin_dir/hooks/summarize.mjs"
     
     if [ ! -f "$plugin_dir/leankg-bootstrap.md" ]; then
         cat > "$plugin_dir/leankg-bootstrap.md" <<'BOOTSTRAPEOF'


### PR DESCRIPTION
## Summary

Implements full lifecycle hooks to match Claude-Mem behavior:

- **Setup** (`version-check.mjs`): Version gating on plugin startup
- **UserPromptSubmit** (`session-init.mjs`): Session initialization with LeanKG usage patterns
- **Stop** (`summarize.mjs`): Session summary capture for future context retrieval

### Hook Coverage

| Hook | Claude-Mem | LeanKG (Before) | LeanKG (After) |
|------|------------|-----------------|----------------|
| Setup | ✅ | ❌ | ✅ |
| SessionStart | ✅ | ✅ | ✅ |
| UserPromptSubmit | ✅ | ❌ | ✅ |
| PreToolUse | ✅ | ✅ | ✅ |
| PostToolUse | ✅ | ✅ | ✅ |
| Stop | ✅ | ❌ | ✅ |

### Files Changed

- `hooks/` - New hook scripts (hooks.json, session-init.mjs, summarize.mjs, version-check.mjs)
- `scripts/install.sh` - Updated `setup_claude_hooks()` to deploy all 6 hooks
- `README.md` - Updated Claude Code Setup section and Supported AI Tools table

### Test plan

- [ ] Run `/reload-plugins` in Claude Code to activate hooks
- [ ] Verify Setup hook runs version check on startup
- [ ] Verify SessionStart injects tool selection hierarchy
- [ ] Verify UserPromptSubmit initializes session context
- [ ] Verify PreToolUse blocks raw grep/find commands
- [ ] Verify PostToolUse logs LeanKG MCP usage
- [ ] Verify Stop hook captures session summary