### PR TITLE
fix: prevent self-termination during leankg update

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2497,6 +2497,10 @@ fn kill_old_processes() -> Result<(), Box<dyn std::error::Error>> {
 
             // Kill each process directly
             for pid in &matching_pids {
+                // SAFETY: Never kill ourselves - double-check even though filter should catch this
+                if *pid == current_pid {
+                    continue;
+                }
                 let kill_output = std::process::Command::new("kill")
                     .args(["-9", &pid.to_string()])
                     .output();


### PR DESCRIPTION
## Summary

- Add explicit PID self-check before sending SIGKILL in `kill_old_processes()`
- Prevents the update process from killing itself when shell wrappers match the "leankg" pattern

## Bug

When running `leankg update`, the current process was sometimes killed because the shell wrapper (PID ~98127) matched the "leankg" pattern and was killed before the actual update binary (PID ~97437) could execute.

## Test plan

- [ ] Run `leankg update` from a shell that has a leankg alias/function and verify it doesn't kill itself