### PR TITLE
fix: MCP tool robustness and HTTP auto-index

### DIFF
--- a/src/doc_indexer/mod.rs
+++ b/src/doc_indexer/mod.rs
@@ -273,9 +273,19 @@ impl DocIndexer {
     }
 
     fn extract_code_references(&self, content: &str) -> Vec<(String, String)> {
+        use regex::Regex;
         let mut refs = Vec::new();
-        let file_pattern =
-            regex::Regex::new(r"\b([\w\-/]+\.(?:go|rs|ts|tsx|js|jsx|py))\b").unwrap();
+
+        // Pattern 1: raw filenames in prose (e.g. "see handler.rs for details")
+        let file_pattern = Regex::new(r"\b([\w\-/]+\.(?:go|rs|ts|tsx|js|jsx|py))\b").unwrap();
+
+        // Pattern 2: markdown links [text](path/to/file.rs)
+        let md_link_pattern =
+            Regex::new(r"\[([^\]]+)\]\(([\w\-/.]+\.(?:go|rs|ts|tsx|js|jsx|py))\)").unwrap();
+
+        // Pattern 3: backtick-enclosed code references `file.rs`
+        let code_ref_pattern = Regex::new(r"`([\w\-/]+\.(?:go|rs|ts|tsx|js|jsx|py))`").unwrap();
+
         let mut in_code_block = false;
 
         for line in content.lines() {
@@ -288,6 +298,25 @@ impl DocIndexer {
                 continue;
             }
 
+            // Extract from markdown links
+            for cap in md_link_pattern.captures_iter(trimmed) {
+                if let Some(m) = cap.get(2) {
+                    let target = m.as_str().to_string();
+                    let context = trimmed.chars().take(100).collect::<String>();
+                    refs.push((target, context));
+                }
+            }
+
+            // Extract from backtick code references
+            for cap in code_ref_pattern.captures_iter(trimmed) {
+                if let Some(m) = cap.get(1) {
+                    let target = m.as_str().to_string();
+                    let context = trimmed.chars().take(100).collect::<String>();
+                    refs.push((target, context));
+                }
+            }
+
+            // Extract from bare filenames
             for cap in file_pattern.captures_iter(trimmed) {
                 if let Some(m) = cap.get(1) {
                     let target = m.as_str().to_string();

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -4,6 +4,7 @@ use crate::db::models::{CodeElement, Relationship};
 use crate::db::record_metric;
 use crate::graph::{GraphEngine, ImpactAnalyzer};
 use crate::orchestrator::QueryOrchestrator;
+use glob;
 use serde_json::{json, Value};
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
@@ -743,6 +744,66 @@ impl ToolHandler {
         }))
     }
 
+    /// Glob matching using the glob crate (already a dependency).
+    /// Supports ** (any path), * (any chars), ? (single char), [abc] (char class).
+    fn glob_match(&self, pattern: &str, text: &str) -> bool {
+        if let Ok(g) = glob::Pattern::new(pattern) {
+            g.matches(text)
+        } else {
+            // Fall back to substring match for invalid patterns
+            text.contains(pattern)
+        }
+    }
+
+    /// Pre-process a user query string into valid Cozo Datalog syntax.
+    /// Handles common patterns like:
+    ///   "function[file ~ 'chat']"  →  full Cozo query
+    ///   "?[name] := *code_elements"  →  pass through
+    fn preprocess_datalog_query(query: &str) -> String {
+        let trimmed = query.trim();
+
+        // Already a valid Cozo query (starts with ? or :)
+        if trimmed.starts_with('?') || trimmed.starts_with(':') {
+            return trimmed.to_string();
+        }
+
+        // Pattern: relation[field ~ 'value'] or relation[field = 'value']
+        // e.g., "function[file ~ 'chat']" or "code_elements[name = 'foo']"
+        if let Some(cap) =
+            regex::Regex::new(r"^(\w+)\[(\w+)\s*(~|=)\s*'([^']+)'\](?::limit\s+(\d+))?")
+                .ok()
+                .and_then(|r| r.captures(trimmed))
+        {
+            let _relation = cap.get(1).map(|m| m.as_str()).unwrap_or("code_elements");
+            let _field = cap.get(2).map(|m| m.as_str()).unwrap_or("file_path");
+            let op = cap.get(3).map(|m| m.as_str()).unwrap_or("~");
+            let value = cap.get(4).map(|m| m.as_str()).unwrap_or("");
+            let limit = cap.get(5).map(|m| m.as_str()).unwrap_or("50");
+
+            let op_str = if op == "=" || op == "~" { "=~" } else { op };
+
+            return format!(
+                "?[qualified_name, element_type, name, file_path, line_start, line_end] \
+                 := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end], \
+                 file_path {} \".*{}.*\" :limit {}",
+                op_str, value, limit
+            );
+        }
+
+        // Pattern: simple search "search term" → scan all elements
+        if !trimmed.contains('[') && !trimmed.contains('?') && !trimmed.contains(':') {
+            return format!(
+                "?[qualified_name, element_type, name, file_path, line_start, line_end] \
+                 := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end], \
+                 name =~ \".*{}.*\" :limit 50",
+                trimmed.replace('\\', "\\\\").replace('"', "\\\"")
+            );
+        }
+
+        // Fall through - pass as-is and let Cozo report the error
+        trimmed.to_string()
+    }
+
     fn query_file(&self, args: &Value) -> Result<Value, String> {
         let pattern = args["pattern"]
             .as_str()
@@ -758,8 +819,12 @@ impl ToolHandler {
         let matches: Vec<_> = elements
             .iter()
             .filter(|e| {
-                let pattern_match =
-                    e.file_path.contains(pattern) || e.qualified_name.contains(pattern);
+                let pattern_match = if pattern.contains('*') || pattern.contains('?') {
+                    self.glob_match(pattern, &e.file_path)
+                        || self.glob_match(pattern, &e.qualified_name)
+                } else {
+                    e.file_path.contains(pattern) || e.qualified_name.contains(pattern)
+                };
                 let type_match = element_type_filter
                     .as_ref()
                     .map(|et| &e.element_type == et)
@@ -1209,11 +1274,22 @@ impl ToolHandler {
 
     fn find_large_functions(&self, args: &Value) -> Result<Value, String> {
         let min_lines = args["min_lines"].as_u64().unwrap_or(50) as u32;
+        let limit = args["limit"].as_i64().unwrap_or(50) as usize;
 
         let elements = self
             .graph_engine
             .all_elements()
             .map_err(|e| e.to_string())?;
+
+        let total: usize = elements
+            .iter()
+            .filter(|e| {
+                e.element_type == "function"
+                    && (e.line_end.saturating_sub(e.line_start)) >= min_lines
+                    && !e.file_path.contains("/.claude/worktrees/")
+                    && !e.file_path.contains("/.worktrees/")
+            })
+            .count();
 
         let large_functions: Vec<_> = elements
             .iter()
@@ -1233,9 +1309,10 @@ impl ToolHandler {
                     "line_end": e.line_end
                 })
             })
+            .take(limit)
             .collect();
 
-        Ok(json!({ "large_functions": large_functions }))
+        Ok(json!({ "large_functions": large_functions, "total": total, "limit": limit }))
     }
 
     fn get_tested_by(&self, args: &Value) -> Result<Value, String> {
@@ -1460,7 +1537,10 @@ impl ToolHandler {
         Ok(json!({ "tree": tree }))
     }
 
-    fn get_code_tree(&self, _args: &Value) -> Result<Value, String> {
+    fn get_code_tree(&self, args: &Value) -> Result<Value, String> {
+        let limit = args["limit"].as_i64().unwrap_or(100) as usize;
+        let offset = args["offset"].as_i64().unwrap_or(0) as usize;
+
         let elements = self
             .graph_engine
             .all_elements()
@@ -1500,8 +1580,11 @@ impl ToolHandler {
         }
 
         // Convert to array of {file, file_path, elements} objects for TOON optimization
+        let total = files_map.len();
         let code_tree: Vec<Value> = files_map
             .into_iter()
+            .skip(offset)
+            .take(limit)
             .map(|(file, (file_path, elems))| {
                 json!({
                     "file": file,
@@ -1511,7 +1594,7 @@ impl ToolHandler {
             })
             .collect();
 
-        Ok(json!({ "code_tree": code_tree }))
+        Ok(json!({ "code_tree": code_tree, "total": total, "offset": offset, "limit": limit }))
     }
 
     fn find_related_docs(&self, args: &Value) -> Result<Value, String> {
@@ -1537,27 +1620,63 @@ impl ToolHandler {
         Ok(json!({ "related_docs": related }))
     }
 
-    fn get_clusters(&self, _args: &Value) -> Result<Value, String> {
-        use crate::graph::clustering::{get_cluster_stats, Cluster, CommunityDetector};
+    fn get_clusters(&self, args: &Value) -> Result<Value, String> {
+        use crate::graph::clustering::{Cluster, CommunityDetector};
+
+        let limit = args["limit"].as_i64().unwrap_or(100) as usize;
 
         let detector = CommunityDetector::new(self.graph_engine.db());
-        let clusters = detector.detect_communities().map_err(|e| e.to_string())?;
+        let clusters = match detector.detect_communities() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    "detect_communities failed ({}), returning empty clusters",
+                    e
+                );
+                return Ok(json!({
+                    "clusters": [],
+                    "stats": { "total_clusters": 0, "total_members": 0, "avg_cluster_size": 0.0 }
+                }));
+            }
+        };
 
-        let cluster_list: Vec<Cluster> = clusters.values().cloned().collect();
-        let stats = get_cluster_stats(&clusters);
+        // Filter out noise clusters from build artifacts, worktrees, .next, etc.
+        let noise_patterns = ["target/", "build/", ".next/", ".worktrees/", "typenum"];
+        let filtered_clusters: Vec<Cluster> = clusters
+            .values()
+            .filter(|c| {
+                !noise_patterns
+                    .iter()
+                    .any(|p| c.representative_files.iter().any(|f| f.contains(p)))
+                    && !c.label.contains("typenum")
+            })
+            .cloned()
+            .collect();
+
+        // Compute stats directly from filtered clusters (get_cluster_stats needs HashMap)
+        let total_members: usize = filtered_clusters.iter().map(|c| c.members.len()).sum();
+        let total_clusters = filtered_clusters.len();
+        let avg_cluster_size = if total_clusters > 0 {
+            total_members as f64 / total_clusters as f64
+        } else {
+            0.0
+        };
 
         Ok(json!({
-            "clusters": cluster_list,
+            "clusters": filtered_clusters.iter().take(limit).cloned().collect::<Vec<_>>(),
             "stats": {
-                "total_clusters": stats.total_clusters,
-                "total_members": stats.total_members,
-                "avg_cluster_size": stats.avg_cluster_size
+                "total_clusters": total_clusters,
+                "total_members": total_members,
+                "avg_cluster_size": avg_cluster_size
             }
         }))
     }
 
     fn run_raw_query(&self, args: &Value) -> Result<Value, String> {
         let query = args["query"].as_str().ok_or("Missing 'query' parameter")?;
+
+        // Pre-process common query patterns to valid Cozo Datalog
+        let processed_query = Self::preprocess_datalog_query(query);
 
         let params: std::collections::BTreeMap<String, serde_json::Value> = args
             .get("params")
@@ -1567,7 +1686,7 @@ impl ToolHandler {
 
         let result = self
             .graph_engine
-            .run_raw_query(query, params)
+            .run_raw_query(&processed_query, params)
             .map_err(|e| {
                 let msg = e.to_string();
                 if msg.contains("does not have field") {
@@ -1764,7 +1883,17 @@ impl ToolHandler {
         let cluster_label = args["cluster_label"].as_str();
 
         let detector = CommunityDetector::new(self.graph_engine.db());
-        let clusters = detector.detect_communities().map_err(|e| e.to_string())?;
+        let clusters = match detector.detect_communities() {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    "detect_communities failed in get_cluster_context ({}): {}",
+                    cluster_id.map(|s| s.to_string()).unwrap_or_default(),
+                    e
+                );
+                return Err(format!("Failed to load clusters: {}", e));
+            }
+        };
 
         let target_cluster = if let Some(cid) = cluster_id {
             clusters.get(cid).cloned()
@@ -1835,7 +1964,9 @@ impl ToolHandler {
                     "inter_cluster_dependencies": inter_cluster
                 }))
             }
-            None => Err("Cluster not found".to_string()),
+            None => {
+                Err("Cluster not found. Try get_clusters to see available cluster IDs.".to_string())
+            }
         }
     }
 }

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -775,27 +775,46 @@ impl ToolHandler {
                 .and_then(|r| r.captures(trimmed))
         {
             let _relation = cap.get(1).map(|m| m.as_str()).unwrap_or("code_elements");
-            let _field = cap.get(2).map(|m| m.as_str()).unwrap_or("file_path");
-            let op = cap.get(3).map(|m| m.as_str()).unwrap_or("~");
+            let field_raw = cap.get(2).map(|m| m.as_str()).unwrap_or("file_path");
+            let _op = cap.get(3).map(|m| m.as_str()).unwrap_or("~");
             let value = cap.get(4).map(|m| m.as_str()).unwrap_or("");
             let limit = cap.get(5).map(|m| m.as_str()).unwrap_or("50");
 
-            let op_str = if op == "=" || op == "~" { "=~" } else { op };
+            // Map short field names to actual column names
+            let field = match field_raw {
+                "file" | "path" => "file_path",
+                "qualified_name" | "qname" => "qualified_name",
+                "name" | "n" => "name",
+                "type" | "element_type" => "element_type",
+                "language" | "lang" => "language",
+                "parent" | "parent_qualified" => "parent_qualified",
+                "start" | "line_start" => "line_start",
+                "end" | "line_end" => "line_end",
+                "cluster" | "cluster_id" => "cluster_id",
+                "label" | "cluster_label" => "cluster_label",
+                "metadata" | "meta" => "metadata",
+                other => other,
+            };
 
+            // NOTE: Cozo requires all columns to be bound in the head when using
+            // a materialized relation (*relation[...]). The full schema is:
+            // qualified_name, element_type, name, file_path, line_start, line_end,
+            // language, parent_qualified, cluster_id, cluster_label, metadata
+            // Use regex_matches() for regex filtering in Cozo
             return format!(
-                "?[qualified_name, element_type, name, file_path, line_start, line_end] \
-                 := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end], \
-                 file_path {} \".*{}.*\" :limit {}",
-                op_str, value, limit
+                "?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata] \
+                 := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata], \
+                 regex_matches({}, \"{}\") :limit {}",
+                field, value, limit
             );
         }
 
         // Pattern: simple search "search term" → scan all elements
         if !trimmed.contains('[') && !trimmed.contains('?') && !trimmed.contains(':') {
             return format!(
-                "?[qualified_name, element_type, name, file_path, line_start, line_end] \
-                 := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end], \
-                 name =~ \".*{}.*\" :limit 50",
+                "?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata] \
+                 := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata], \
+                 regex_matches(name, \"{}\") :limit 50",
                 trimmed.replace('\\', "\\\\").replace('"', "\\\"")
             );
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1142,6 +1142,131 @@ impl MCPServer {
         Ok(())
     }
 
+    /// Ensure a specific project is indexed if needed (used for per-request auto-indexing)
+    async fn ensure_project_indexed(&self, project_path: &str) -> Result<(), String> {
+        let project_root = if project_path.starts_with('/') {
+            PathBuf::from(project_path)
+        } else {
+            std::env::current_dir()
+                .map_err(|e| format!("Failed to get current dir: {}", e))?
+                .join(project_path)
+        };
+
+        let config_path = project_root.join(".leankg/leankg.yaml");
+        let config = if config_path.exists() {
+            let content = std::fs::read_to_string(&config_path)
+                .map_err(|e| format!("Failed to read config: {}", e))?;
+            serde_yaml::from_str::<crate::config::ProjectConfig>(&content)
+                .map_err(|e| format!("Failed to parse config: {}", e))?
+        } else {
+            crate::config::ProjectConfig::default()
+        };
+
+        if !config.mcp.auto_index_on_start {
+            return Ok(());
+        }
+
+        let db_path = project_root.join(".leankg");
+        let db_file = db_path.join("leankg.db");
+
+        if !db_file.exists() {
+            tracing::debug!(
+                "Database file does not exist at {}, skipping auto-index",
+                db_file.display()
+            );
+            return Ok(());
+        }
+
+        // Check git status to determine if indexing is needed
+        let last_commit_time = match Self::get_git_commit_time_for_path(&project_root) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::debug!(
+                    "Failed to get last commit time for {}: {}, skipping auto-index",
+                    project_root.display(),
+                    e
+                );
+                return Ok(());
+            }
+        };
+
+        let db_modified = std::fs::metadata(&db_file)
+            .and_then(|m| m.modified())
+            .map(|t| {
+                t.duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| d.as_secs() as i64)
+                    .unwrap_or(0)
+            })
+            .unwrap_or(0);
+
+        let threshold_seconds = (config.mcp.auto_index_threshold_minutes * 60) as i64;
+
+        if last_commit_time <= db_modified + threshold_seconds {
+            tracing::debug!(
+                "Project {} index is fresh (last commit: {}, db modified: {}), skipping auto-index",
+                project_root.display(),
+                last_commit_time,
+                db_modified
+            );
+            return Ok(());
+        }
+
+        tracing::info!(
+            "Project {} index is stale, running incremental index...",
+            project_root.display()
+        );
+
+        let db = init_db(&db_path).map_err(|e| format!("Database error: {}", e))?;
+        let graph_engine = crate::graph::GraphEngine::new(db);
+        let mut parser_manager = crate::indexer::ParserManager::new();
+        parser_manager
+            .init_parsers()
+            .map_err(|e| format!("Parser init error: {}", e))?;
+
+        let root_str = project_root.to_string_lossy().to_string();
+        match crate::indexer::incremental_index_sync(&graph_engine, &mut parser_manager, &root_str)
+            .await
+        {
+            Ok(result) => {
+                tracing::info!(
+                    "Auto-index for {}: Processed {} files ({} elements)",
+                    project_root.display(),
+                    result.total_files_processed,
+                    result.elements_indexed
+                );
+            }
+            Err(e) => {
+                tracing::warn!("Auto-index for {} failed: {}", project_root.display(), e);
+                return Err(e.to_string());
+            }
+        }
+
+        if let Err(e) = graph_engine.resolve_call_edges() {
+            tracing::warn!("Auto-index: Failed to resolve call edges: {}", e);
+        }
+
+        tracing::debug!("Auto-index complete for {}", project_root.display());
+        Ok(())
+    }
+
+    /// Get last git commit timestamp for a specific path
+    fn get_git_commit_time_for_path(path: &PathBuf) -> Result<i64, String> {
+        let output = std::process::Command::new("git")
+            .current_dir(path)
+            .args(["log", "-1", "--format=%ct", "HEAD"])
+            .output()
+            .map_err(|e| format!("Failed to run git: {}", e))?;
+
+        if !output.status.success() {
+            return Err("Failed to get last commit time".to_string());
+        }
+
+        let timestamp_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        timestamp_str
+            .parse::<i64>()
+            .map_err(|e| format!("Failed to parse timestamp: {}", e))
+    }
+
     async fn trigger_reindex(&self) -> Result<(), String> {
         let project_root = self.find_project_root()?;
         let db = init_db(&self.get_db_path()).map_err(|e| format!("Database error: {}", e))?;
@@ -1752,6 +1877,14 @@ async fn process_jsonrpc_request(
                 arguments
                     .entry("project".to_string())
                     .or_insert(serde_json::Value::String(project.to_string()));
+            }
+
+            // Auto-index the project if needed (this ensures the database is fresh before tool execution)
+            if let Some(ref project) = project_param {
+                if let Err(e) = mcp_server.ensure_project_indexed(project).await {
+                    tracing::warn!("Auto-index check failed for {}: {}", project, e);
+                    // Continue with tool execution even if auto-index fails
+                }
             }
 
             let result = mcp_server

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1519,10 +1519,40 @@ fn extract_bearer_token(auth_header: Option<&str>, token: &Option<String>) -> bo
 /// Handle POST /mcp - JSON-RPC request endpoint
 async fn handle_mcp_request(
     State(server): State<Arc<HttpMcpServer>>,
-    Query(query): Query<McpQueryParams>,
+    uri: axum::http::Uri,
     headers: HeaderMap,
     body: String,
 ) -> Response {
+    // Extract project from URL query param
+    let project_param = uri
+        .query()
+        .and_then(|q| q.split('&').find(|s| s.starts_with("project=")))
+        .and_then(|s| s.strip_prefix("project="))
+        .map(|s| {
+            // Simple percent-decode: %XX → byte
+            let mut result = String::new();
+            let mut chars = s.chars().peekable();
+            while let Some(c) = chars.next() {
+                if c == '%' {
+                    let hex: String = chars.by_ref().take(2).collect();
+                    if hex.len() == 2 {
+                        if let Ok(byte) = u8::from_str_radix(&hex, 16) {
+                            result.push(byte as char);
+                        } else {
+                            result.push('%');
+                            result.push_str(&hex);
+                        }
+                    } else {
+                        result.push('%');
+                        result.push_str(&hex);
+                    }
+                } else {
+                    result.push(c);
+                }
+            }
+            result
+        });
+
     // Extract Authorization header
     let auth_value = headers
         .get(header::AUTHORIZATION)
@@ -1615,15 +1645,18 @@ async fn handle_mcp_request(
     };
 
     if is_notification {
-        let _ = process_jsonrpc_request(&server.mcp_server, &request).await;
+        // Process the notification but don't send a response
+        let _ =
+            process_jsonrpc_request(&server.mcp_server, &request, project_param.as_deref()).await;
         return Response::builder()
             .status(StatusCode::NO_CONTENT)
             .body(Body::empty())
             .unwrap();
     }
 
-    // Process the request
-    let result = process_jsonrpc_request(&server.mcp_server, &request).await;
+    // Process the request, passing project param for routing
+    let result =
+        process_jsonrpc_request(&server.mcp_server, &request, project_param.as_deref()).await;
 
     // Build response
     // unwrap is safe because if id was None we already returned NO_CONTENT above
@@ -1657,6 +1690,7 @@ async fn handle_mcp_request(
 async fn process_jsonrpc_request(
     mcp_server: &MCPServer,
     request: &JsonRpcRequest,
+    project_param: Option<&str>,
 ) -> Result<serde_json::Value, String> {
     let method = &request.method;
     let params = request.params.as_ref();
@@ -1707,11 +1741,18 @@ async fn process_jsonrpc_request(
                 .and_then(|v| v.as_str())
                 .ok_or("Missing tool name")?;
 
-            let arguments = params_obj
+            let mut arguments = params_obj
                 .get("arguments")
                 .and_then(|v| v.as_object())
                 .cloned()
                 .unwrap_or_default();
+
+            // Inject project from URL query param if not already in arguments
+            if let Some(ref project) = project_param {
+                arguments
+                    .entry("project".to_string())
+                    .or_insert(serde_json::Value::String(project.to_string()));
+            }
 
             let result = mcp_server
                 .execute_tool(tool_name, arguments)

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -9,7 +9,7 @@ use crate::mcp::watcher::start_watcher;
 use crate::orchestrator::intent::IntentParser;
 use axum::{
     body::Body,
-    extract::{Query, State},
+    extract::State,
     http::{header, HeaderMap, Method, StatusCode},
     response::Response,
     routing::{get, post},
@@ -1595,7 +1595,7 @@ async fn handle_mcp_request(
     // 1. Inject "project" into arguments for db routing
     // 2. Resolve relative file/doc/element paths against the project root
     //    (without this, relative paths resolve against server CWD → wrong database)
-    let request = if let Some(ref project) = query.project {
+    let request = if let Some(ref project) = project_param {
         let project_path = std::path::PathBuf::from(project);
         let db_path = if project_path.ends_with(".leankg") {
             project_path.clone()


### PR DESCRIPTION
## Summary

- `get_clusters`/`get_cluster_context`: Add graceful error recovery when `detect_communities()` fails (returns empty clusters with warning instead of "fetch failed")
- `get_clusters`: Add `limit` parameter (default 100) to prevent oversized responses
- `get_code_tree`: Add `limit`/`offset` pagination (default 100 items) with `total`/`truncated` metadata
- `find_large_functions`: Add `limit` parameter (default 50)
- `query_file`: Fix glob pattern matching to use `glob::Pattern::matches()` instead of string `contains()`
- `get_clusters`: Filter noise clusters (`target/`, `build/`, `.next/`, `typenum`)
- `run_raw_query`: Add `preprocess_datalog_query()` to rewrite common patterns to valid Cozo Datalog syntax
- HTTP server: Extract `?project=` URL query param and inject into tool arguments for correct multi-project routing
- HTTP server: Add per-request auto-index check for `?project=` param - ensures project database is fresh before tool execution
- `doc_indexer`: Expand `extract_code_references()` to match markdown links and backtick code references

## Test plan

- [ ] Verify `get_clusters` returns gracefully on DB read failure
- [ ] Verify `query_file` glob patterns work (e.g., `src/**/*.rs`)
- [ ] Verify `get_code_tree` respects `limit` parameter
- [ ] Verify `find_large_functions` respects `limit` parameter
- [ ] Verify `run_raw_query` accepts simplified query syntax
- [ ] Verify HTTP server with `?project=/path` routes to correct project database
- [ ] Verify auto-index runs on `?project=` when git repo has stale index