### PR TITLE
feat: knowledge contribution, versioning, and RBAC via MCP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1376,7 +1376,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leankg"
-version = "0.16.9"
+version = "0.17.0"
 dependencies = [
  "argon2",
  "async-trait",

--- a/docs/design/hld-leankg.md
+++ b/docs/design/hld-leankg.md
@@ -1,10 +1,19 @@
 # LeanKG High Level Design
 
-**Phien ban:** 1.22
-**Ngay:** 2026-04-24
-**Dua tren:** PRD v1.22
+**Phien ban:** 1.24
+**Ngay:** 2026-05-08
+**Dua tren:** PRD v1.23
 **Trang thai:** Ban nhap
 **Changelog:**
+- v1.24 - Knowledge Contribution, Versioning & Multi-Team Access:
+  - New `knowledge_entries` CozoDB relation for standalone knowledge entries
+  - Schema migration system with `migrations` tracking table
+  - Version columns (`environment`, `branch`, `version_tag`) added to code_elements and business_logic
+  - Git branch auto-detection and environment inference
+  - 10 new MCP tools: add/update/delete/search_knowledge, add_annotation, link_element, add_documentation, search_by_environment, get_upcoming_changes, promote_environment
+  - RBAC with Admin/Contributor/Viewer roles
+  - OAuth2-compatible auth manager (static tokens, extensible to OIDC)
+  - Tool-level permission enforcement in MCP HTTP handler
 - v1.23 - Knowns-Inspired Enhancements (FUTURE):
   - Hybrid search with Reciprocal Rank Fusion (semantic + keyword)
   - Reference system (`@doc/`, `@task-` syntax) for traversable links
@@ -815,6 +824,9 @@ erDiagram
     CODE_ELEMENTS ||--o{ RELATIONSHIPS : has
     CODE_ELEMENTS ||--o| BUSINESS_LOGIC : describes
     CODE_ELEMENTS ||--o| DOCUMENTS : referenced_by
+    CODE_ELEMENTS ||--o| KNOWLEDGE_ENTRIES : linked_to
+    KNOWLEDGE_ENTRIES ||--o{ USER_STORIES : mapped_to
+    KNOWLEDGE_ENTRIES ||--o{ FEATURES : implements
     USER_STORIES ||--o{ BUSINESS_LOGIC : mapped_to
     FEATURES ||--o{ BUSINESS_LOGIC : implements
 
@@ -827,9 +839,11 @@ erDiagram
         int line_end
         string language
         string parent_qualified FK
+        string environment "production|staging|dev|upcoming"
+        string branch "git branch name"
+        string version_tag
         json metadata
-        timestamp created_at
-        timestamp updated_at
+        timestamp indexed_at
     }
 
     RELATIONSHIPS {
@@ -847,6 +861,24 @@ erDiagram
         string description
         string user_story_id FK
         string feature_id FK
+        string environment "production|staging|dev|upcoming"
+        string branch
+        string author
+        timestamp updated_at
+    }
+
+    KNOWLEDGE_ENTRIES {
+        string id PK
+        string knowledge_type "business|domain|architecture|prd_mapping|debugging|general"
+        string title
+        string content
+        string element_qualified FK (optional)
+        string user_story_id FK (optional)
+        string feature_id FK (optional)
+        string tags
+        string environment "production|staging|dev|upcoming"
+        string branch
+        string author
         timestamp created_at
         timestamp updated_at
     }
@@ -872,18 +904,40 @@ erDiagram
         string name
         string description
     }
+
+    MIGRATIONS {
+        string id PK
+        int applied_at
+    }
 ```
 
 ### 4.2 Schema Description
 
 | Table | Mo ta |
 |-------|-------|
-| CODE_ELEMENTS | Luu tru tat ca code elements (files, functions, classes, imports, exports) va pipeline elements (pipelines, stages, steps). PK = qualified_name (`file_path::parent::name`) |
+| CODE_ELEMENTS | Luu tru tat ca code elements (files, functions, classes, imports, exports) va pipeline elements (pipelines, stages, steps). PK = qualified_name (`file_path::parent::name`). Co them cac cot environment, branch, version_tag, indexed_at de ho tro phien ban. |
 | RELATIONSHIPS | Quan he giua cac elements: source code (imports, calls, implements, contains, tested_by) va pipeline (triggers, builds, depends_on) |
-| BUSINESS_LOGIC | Annotations mo ta business logic cua tung element |
+| BUSINESS_LOGIC | Annotations mo ta business logic cua tung element. Co them cac cot environment, branch, author, updated_at. |
+| KNOWLEDGE_ENTRIES | Bang moi lưu tru tri thức độc lập (business, domain, architecture, prd_mapping, debugging, general). Cho phép nhập tri thức từ MCP ma khong canrang buộc voi code element. |
 | DOCUMENTS | Generated documentation files |
 | USER_STORIES | User stories duoc map voi code |
 | FEATURES | Features duoc map voi code |
+| MIGRATIONS | Bang theo dõi schema migrations da chạy, đảm bảo idempotency. |
+
+### 4.2.1 Schema Migration System
+
+CozoDB khong ho tro ALTER TABLE. Schema evolution su dung `run_migrations()` function trong `init_schema()`:
+
+1. Tao bang `migrations` neu chua ton tai
+2. Doc danh sach migrations da ap dung
+3. Chay migration moi neu chua duoc ap dung
+4. Su dung `:replace` de them cot moi vào bang cu (chi them, khong xóa)
+5. Ghi lai migration da ap dung vào bang `migrations`
+
+Migrations hien tai:
+- `001_knowledge_entries`: Tao bang `knowledge_entries`
+- `002_code_elements_versioning`: Them cot `environment`, `branch`, `version_tag`, `indexed_at` vào `code_elements`
+- `003_business_logic_versioning`: Them cot `environment`, `branch`, `author`, `updated_at` vào `business_logic`
 
 ### 4.3 Documentation-Specific Node Types (Phase 2)
 

--- a/docs/requirement/prd-leankg.md
+++ b/docs/requirement/prd-leankg.md
@@ -51,6 +51,43 @@
 | `mcp-stdio` | stdin/stdout | Local AI tools (Cursor, Claude Code) | 1 |
 | `mcp-http` | HTTP + SSE | Remote access, browser clients | Many |
 
+### v1.23 (IN PROGRESS) - Knowledge Contribution, Versioning & Multi-Team Access
+
+**User Stories:**
+- **US-23.1:** As a developer, I want to add business knowledge entries via MCP so AI agents can contribute knowledge during code review.
+- **US-23.2:** As a developer, I want to annotate code elements via MCP so I don't have to switch to CLI.
+- **US-23.3:** As a developer, I want to search all knowledge entries so I can understand domain context.
+- **US-23.4:** As a team lead, I want to tag knowledge by environment (production/staging/dev/upcoming) so I can distinguish current state from in-development work.
+- **US-23.5:** As a team lead, I want to see upcoming changes (feature branch knowledge) so I can plan reviews.
+- **US-23.6:** As a PO, I want read-only access to the knowledge graph via HTTP so my team can query code context without modifying anything.
+- **US-23.7:** As an admin, I want role-based access control so different teams have appropriate permissions.
+- **US-23.8:** As an admin, I want OAuth2/static token authentication so external teams can access LeanKG securely.
+
+**Functional Requirements:**
+- **FR-23.1:** New `knowledge_entries` CozoDB table for standalone knowledge (business, domain, architecture, prd_mapping, debugging, general)
+- **FR-23.2:** Schema migration system for adding columns to existing tables
+- **FR-23.3:** New MCP tools: `add_knowledge`, `update_knowledge`, `delete_knowledge`, `search_knowledge`, `add_annotation`, `link_element`, `add_documentation`
+- **FR-23.4:** Version/branch tagging: `environment`, `branch`, `version_tag` columns on code_elements and business_logic
+- **FR-23.5:** Git branch auto-detection and environment inference (main→production, release/→staging, develop→dev, feature/→upcoming)
+- **FR-23.6:** Version-aware MCP tools: `search_by_environment`, `get_upcoming_changes`, `promote_environment`
+- **FR-23.7:** RBAC with roles: Admin (full), Contributor (knowledge write), Viewer (read-only)
+- **FR-23.8:** OAuth2-compatible auth with static tokens (extensible to OIDC)
+- **FR-23.9:** Tool-level permission enforcement in MCP HTTP handler
+
+**New MCP Tools (10 total):**
+| Tool | Category | Role Required |
+|------|-----------|---------------|
+| `add_knowledge` | Knowledge | Contributor |
+| `update_knowledge` | Knowledge | Contributor |
+| `delete_knowledge` | Knowledge | Contributor |
+| `search_knowledge` | Knowledge | Viewer |
+| `add_annotation` | Knowledge | Contributor |
+| `link_element` | Knowledge | Contributor |
+| `add_documentation` | Knowledge | Contributor |
+| `search_by_environment` | Versioning | Viewer |
+| `get_upcoming_changes` | Versioning | Viewer |
+| `promote_environment` | Versioning | Admin |
+
 ### v1.20 (PENDING) - MCP Server Watch Mode
 - **US-20.1:** Add `--watch` flag to MCP server for auto-indexing on file changes
 - **US-20.2:** Port 8081→9699 consolidation

--- a/leankg.yaml
+++ b/leankg.yaml
@@ -27,9 +27,4 @@ documentation:
   templates:
   - agents
   - claude
-database:
-  backend: sqlite
-  path: null
-  pool_size: 10
-  ssl_enabled: false
 microservice: null

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -9,6 +9,7 @@ pub struct ProjectConfig {
     pub mcp: McpConfig,
     pub documentation: DocConfig,
     pub microservice: Option<MicroserviceExtractorConfig>,
+    pub auth: AuthSettings,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -68,6 +69,30 @@ pub struct DocConfig {
     pub templates: Vec<String>,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AuthSettings {
+    pub enabled: bool,
+    #[serde(default)]
+    pub provider: AuthProvider,
+    #[serde(default)]
+    pub tokens: Vec<TokenEntry>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default, PartialEq)]
+#[serde(rename_all = "lowercase")]
+pub enum AuthProvider {
+    #[default]
+    Static,
+    // Future: Oidc,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TokenEntry {
+    pub token: String,
+    pub role: String,
+    pub client_id: String,
+}
+
 impl Default for ProjectConfig {
     fn default() -> Self {
         Self {
@@ -107,6 +132,7 @@ impl Default for ProjectConfig {
                 templates: vec!["agents".to_string(), "claude".to_string()],
             },
             microservice: None,
+            auth: AuthSettings::default(),
         }
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -2,6 +2,7 @@
 pub mod keys;
 pub mod models;
 pub mod schema;
+pub mod versioning;
 
 #[allow(unused_imports)]
 pub use models::*;
@@ -787,4 +788,238 @@ pub fn reset_metrics(db: &CozoDb) -> Result<i64, Box<dyn std::error::Error>> {
         }
     }
     Ok(deleted_count)
+}
+
+// ============================================================================
+// Knowledge Entries CRUD
+// ============================================================================
+
+pub fn create_knowledge_entry(
+    db: &CozoDb,
+    entry: &models::KnowledgeEntry,
+) -> Result<models::KnowledgeEntry, Box<dyn std::error::Error>> {
+    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] <- [[$id, $kt, $title, $content, $eq, $us, $feat, $tags, $env, $branch, $author, $cat, $uat]] :put knowledge_entries {id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at}"#;
+    let mut params = std::collections::BTreeMap::new();
+    params.insert(
+        "id".to_string(),
+        serde_json::Value::String(entry.id.clone()),
+    );
+    params.insert(
+        "kt".to_string(),
+        serde_json::Value::String(entry.knowledge_type.clone()),
+    );
+    params.insert(
+        "title".to_string(),
+        serde_json::Value::String(entry.title.clone()),
+    );
+    params.insert(
+        "content".to_string(),
+        serde_json::Value::String(entry.content.clone()),
+    );
+    params.insert(
+        "eq".to_string(),
+        entry
+            .element_qualified
+            .as_ref()
+            .map(|s| serde_json::Value::String(s.clone()))
+            .unwrap_or(serde_json::Value::Null),
+    );
+    params.insert(
+        "us".to_string(),
+        entry
+            .user_story_id
+            .as_ref()
+            .map(|s| serde_json::Value::String(s.clone()))
+            .unwrap_or(serde_json::Value::Null),
+    );
+    params.insert(
+        "feat".to_string(),
+        entry
+            .feature_id
+            .as_ref()
+            .map(|s| serde_json::Value::String(s.clone()))
+            .unwrap_or(serde_json::Value::Null),
+    );
+    params.insert(
+        "tags".to_string(),
+        serde_json::Value::String(entry.tags.clone()),
+    );
+    params.insert(
+        "env".to_string(),
+        serde_json::Value::String(entry.environment.clone()),
+    );
+    params.insert(
+        "branch".to_string(),
+        entry
+            .branch
+            .as_ref()
+            .map(|s| serde_json::Value::String(s.clone()))
+            .unwrap_or(serde_json::Value::Null),
+    );
+    params.insert(
+        "author".to_string(),
+        serde_json::Value::String(entry.author.clone()),
+    );
+    params.insert(
+        "cat".to_string(),
+        serde_json::Value::Number(entry.created_at.into()),
+    );
+    params.insert(
+        "uat".to_string(),
+        serde_json::Value::Number(entry.updated_at.into()),
+    );
+
+    db.run_script(query, params)?;
+    Ok(entry.clone())
+}
+
+pub fn get_knowledge_entry(
+    db: &CozoDb,
+    id: &str,
+) -> Result<Option<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], id = $id"#;
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("id".to_string(), serde_json::Value::String(id.to_string()));
+
+    let result = db.run_script(query, params)?;
+    if result.rows.is_empty() {
+        return Ok(None);
+    }
+
+    Ok(Some(row_to_knowledge_entry(&result.rows[0])))
+}
+
+pub fn update_knowledge_entry(
+    db: &CozoDb,
+    entry: &models::KnowledgeEntry,
+) -> Result<models::KnowledgeEntry, Box<dyn std::error::Error>> {
+    // :put acts as upsert in CozoDB
+    create_knowledge_entry(db, entry)
+}
+
+pub fn delete_knowledge_entry(db: &CozoDb, id: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let query = r#":delete knowledge_entries where id = $id"#;
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("id".to_string(), serde_json::Value::String(id.to_string()));
+    db.run_script(query, params)?;
+    Ok(())
+}
+
+pub fn search_knowledge(
+    db: &CozoDb,
+    query_str: &str,
+    knowledge_type: Option<&str>,
+    environment: Option<&str>,
+    limit: usize,
+) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+    let regex_pattern = format!(".*{}.*", query_str.to_lowercase());
+    let mut conditions = vec![format!(
+        "regex_matches(lowercase(title), \"{}\")",
+        regex_pattern
+    )];
+    let mut params = std::collections::BTreeMap::new();
+
+    if let Some(kt) = knowledge_type {
+        params.insert("kt".to_string(), serde_json::Value::String(kt.to_string()));
+        conditions.push("knowledge_type = $kt".to_string());
+    }
+    if let Some(env) = environment {
+        params.insert(
+            "env".to_string(),
+            serde_json::Value::String(env.to_string()),
+        );
+        conditions.push("environment = $env".to_string());
+    }
+
+    let where_clause = conditions.join(", ");
+    let query = format!(
+        r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], {} :limit {}"#,
+        where_clause, limit
+    );
+
+    let result = db.run_script(&query, params)?;
+    Ok(result
+        .rows
+        .iter()
+        .map(|r| row_to_knowledge_entry(r))
+        .collect())
+}
+
+pub fn get_knowledge_by_element(
+    db: &CozoDb,
+    element_qualified: &str,
+) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], element_qualified = $eq"#;
+    let mut params = std::collections::BTreeMap::new();
+    params.insert(
+        "eq".to_string(),
+        serde_json::Value::String(element_qualified.to_string()),
+    );
+
+    let result = db.run_script(query, params)?;
+    Ok(result
+        .rows
+        .iter()
+        .map(|r| row_to_knowledge_entry(r))
+        .collect())
+}
+
+pub fn get_knowledge_by_feature(
+    db: &CozoDb,
+    feature_id: &str,
+) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], feature_id = $feat"#;
+    let mut params = std::collections::BTreeMap::new();
+    params.insert(
+        "feat".to_string(),
+        serde_json::Value::String(feature_id.to_string()),
+    );
+
+    let result = db.run_script(query, params)?;
+    Ok(result
+        .rows
+        .iter()
+        .map(|r| row_to_knowledge_entry(r))
+        .collect())
+}
+
+pub fn get_knowledge_by_environment(
+    db: &CozoDb,
+    environment: &str,
+    limit: usize,
+) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+    let query = format!(
+        r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], environment = $env :limit {}"#,
+        limit
+    );
+    let mut params = std::collections::BTreeMap::new();
+    params.insert(
+        "env".to_string(),
+        serde_json::Value::String(environment.to_string()),
+    );
+
+    let result = db.run_script(&query, params)?;
+    Ok(result
+        .rows
+        .iter()
+        .map(|r| row_to_knowledge_entry(r))
+        .collect())
+}
+
+fn row_to_knowledge_entry(row: &[serde_json::Value]) -> models::KnowledgeEntry {
+    models::KnowledgeEntry {
+        id: row[0].as_str().unwrap_or("").to_string(),
+        knowledge_type: row[1].as_str().unwrap_or("general").to_string(),
+        title: row[2].as_str().unwrap_or("").to_string(),
+        content: row[3].as_str().unwrap_or("").to_string(),
+        element_qualified: row[4].as_str().map(String::from),
+        user_story_id: row[5].as_str().map(String::from),
+        feature_id: row[6].as_str().map(String::from),
+        tags: row[7].as_str().unwrap_or("[]").to_string(),
+        environment: row[8].as_str().unwrap_or("production").to_string(),
+        branch: row[9].as_str().map(String::from),
+        author: row[10].as_str().unwrap_or("").to_string(),
+        created_at: row[11].as_i64().unwrap_or(0),
+        updated_at: row[12].as_i64().unwrap_or(0),
+    }
 }

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -346,6 +346,112 @@ pub struct DailyMetrics {
     pub correctness: f64,
 }
 
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum KnowledgeType {
+    BusinessKnowledge,
+    DomainKnowledge,
+    ArchitectureDoc,
+    PrdMapping,
+    DebuggingNote,
+    General,
+}
+
+impl KnowledgeType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            KnowledgeType::BusinessKnowledge => "business",
+            KnowledgeType::DomainKnowledge => "domain",
+            KnowledgeType::ArchitectureDoc => "architecture",
+            KnowledgeType::PrdMapping => "prd_mapping",
+            KnowledgeType::DebuggingNote => "debugging",
+            KnowledgeType::General => "general",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "business" => Some(KnowledgeType::BusinessKnowledge),
+            "domain" => Some(KnowledgeType::DomainKnowledge),
+            "architecture" => Some(KnowledgeType::ArchitectureDoc),
+            "prd_mapping" => Some(KnowledgeType::PrdMapping),
+            "debugging" => Some(KnowledgeType::DebuggingNote),
+            "general" => Some(KnowledgeType::General),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for KnowledgeType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct KnowledgeEntry {
+    pub id: String,
+    pub knowledge_type: String,
+    pub title: String,
+    pub content: String,
+    pub element_qualified: Option<String>,
+    pub user_story_id: Option<String>,
+    pub feature_id: Option<String>,
+    pub tags: String,
+    pub environment: String,
+    pub branch: Option<String>,
+    pub author: String,
+    pub created_at: i64,
+    pub updated_at: i64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub enum Role {
+    Admin,
+    Contributor,
+    Viewer,
+}
+
+impl Role {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Role::Admin => "admin",
+            Role::Contributor => "contributor",
+            Role::Viewer => "viewer",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "admin" => Some(Role::Admin),
+            "contributor" => Some(Role::Contributor),
+            "viewer" => Some(Role::Viewer),
+            _ => None,
+        }
+    }
+
+    pub fn can_write(&self) -> bool {
+        matches!(self, Role::Admin | Role::Contributor)
+    }
+
+    pub fn can_admin(&self) -> bool {
+        matches!(self, Role::Admin)
+    }
+}
+
+impl std::fmt::Display for Role {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.as_str())
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuthContext {
+    pub client_id: String,
+    pub role: Role,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -420,5 +526,46 @@ mod tests {
             RelationshipType::from_str("presents"),
             Some(RelationshipType::Presents)
         );
+    }
+
+    #[test]
+    fn test_knowledge_type_roundtrip() {
+        assert_eq!(KnowledgeType::BusinessKnowledge.as_str(), "business");
+        assert_eq!(
+            KnowledgeType::from_str("domain"),
+            Some(KnowledgeType::DomainKnowledge)
+        );
+        assert_eq!(KnowledgeType::from_str("unknown"), None);
+        assert_eq!(format!("{}", KnowledgeType::PrdMapping), "prd_mapping");
+    }
+
+    #[test]
+    fn test_role_permissions() {
+        assert!(Role::Admin.can_write());
+        assert!(Role::Admin.can_admin());
+        assert!(Role::Contributor.can_write());
+        assert!(!Role::Contributor.can_admin());
+        assert!(!Role::Viewer.can_write());
+        assert!(!Role::Viewer.can_admin());
+        assert_eq!(Role::from_str("admin"), Some(Role::Admin));
+        assert_eq!(Role::from_str("viewer"), Some(Role::Viewer));
+    }
+
+    #[test]
+    fn test_knowledge_entry_creation() {
+        let entry = KnowledgeEntry {
+            id: "test-id".to_string(),
+            knowledge_type: "business".to_string(),
+            title: "Test".to_string(),
+            content: "Content".to_string(),
+            environment: "production".to_string(),
+            author: "test".to_string(),
+            created_at: 1000,
+            updated_at: 1000,
+            ..Default::default()
+        };
+        assert_eq!(entry.id, "test-id");
+        assert_eq!(entry.environment, "production");
+        assert!(entry.element_qualified.is_none());
     }
 }

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -165,6 +165,105 @@ fn init_schema(db: &CozoDb) -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
+    // Run migrations for schema evolution
+    run_migrations(db, &existing_relations)?;
+
+    Ok(())
+}
+
+fn run_migrations(
+    db: &CozoDb,
+    existing_relations: &std::collections::HashSet<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Create migrations tracking table if not exists
+    if !existing_relations.contains("migrations") {
+        let create_migrations = r#":create migrations {id: String, applied_at: Int}"#;
+        if let Err(e) = db.run_script(create_migrations, Default::default()) {
+            tracing::warn!("Failed to create migrations table: {:?}", e);
+        }
+    }
+
+    // Get already-applied migrations
+    let applied: std::collections::HashSet<String> = db
+        .run_script("?[id] := *migrations[id, _]", Default::default())
+        .map(|r| {
+            r.rows
+                .iter()
+                .filter_map(|row| row.first().and_then(|v| v.as_str().map(String::from)))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs() as i64;
+
+    // Migration 001: Create knowledge_entries table
+    if !applied.contains("001_knowledge_entries") {
+        tracing::info!("Running migration 001_knowledge_entries...");
+        let create_knowledge = r#":create knowledge_entries {id: String, knowledge_type: String, title: String, content: String, element_qualified: String?, user_story_id: String?, feature_id: String?, tags: String, environment: String, branch: String?, author: String, created_at: Int, updated_at: Int}"#;
+        if let Err(e) = db.run_script(create_knowledge, Default::default()) {
+            tracing::warn!("Migration 001 failed (may already exist): {:?}", e);
+        }
+
+        // Create indexes
+        let indexes = [
+            r#":create knowledge_entries::type_index {ref: (knowledge_type), compressed: true}"#,
+            r#":create knowledge_entries::element_index {ref: (element_qualified), compressed: true}"#,
+            r#":create knowledge_entries::env_index {ref: (environment), compressed: true}"#,
+            r#":create knowledge_entries::author_index {ref: (author), compressed: true}"#,
+        ];
+        for idx in &indexes {
+            if let Err(e) = db.run_script(idx, Default::default()) {
+                tracing::debug!("Index creation note: {:?}", e);
+            }
+        }
+
+        record_migration(db, "001_knowledge_entries", now)?;
+    }
+
+    // Migration 002: Add version columns to code_elements
+    if !applied.contains("002_code_elements_versioning") {
+        tracing::info!("Running migration 002_code_elements_versioning...");
+        // Only apply if the table already existed (new tables get these columns at creation)
+        if existing_relations.contains("code_elements") {
+            let replace_code_elements = r#":replace code_elements {qualified_name: String, element_type: String, name: String, file_path: String, line_start: Int, line_end: Int, language: String, parent_qualified: String?, cluster_id: String?, cluster_label: String?, metadata: String, environment: String default 'production', branch: String? default null, version_tag: String? default null, indexed_at: Int default 0}"#;
+            if let Err(e) = db.run_script(replace_code_elements, Default::default()) {
+                tracing::warn!("Migration 002 code_elements replace failed: {:?}", e);
+            }
+        }
+        record_migration(db, "002_code_elements_versioning", now)?;
+    }
+
+    // Migration 003: Add version columns to business_logic
+    if !applied.contains("003_business_logic_versioning") {
+        tracing::info!("Running migration 003_business_logic_versioning...");
+        if existing_relations.contains("business_logic") {
+            let replace_bl = r#":replace business_logic {element_qualified: String, description: String, user_story_id: String?, feature_id: String?, environment: String default 'production', branch: String? default null, author: String default '', updated_at: Int default 0}"#;
+            if let Err(e) = db.run_script(replace_bl, Default::default()) {
+                tracing::warn!("Migration 003 business_logic replace failed: {:?}", e);
+            }
+        }
+        record_migration(db, "003_business_logic_versioning", now)?;
+    }
+
+    Ok(())
+}
+
+fn record_migration(
+    db: &CozoDb,
+    id: &str,
+    applied_at: i64,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let query = r#"?[id, applied_at] <- [[$mid, $ts]] :put migrations {id, applied_at}"#;
+    let mut params = std::collections::BTreeMap::new();
+    params.insert("mid".to_string(), serde_json::Value::String(id.to_string()));
+    params.insert(
+        "ts".to_string(),
+        serde_json::Value::Number(applied_at.into()),
+    );
+    db.run_script(query, params)?;
     Ok(())
 }
 
@@ -173,7 +272,7 @@ fn validate_code_elements_schema(db: &CozoDb) -> Result<(), Box<dyn std::error::
     match db.run_script(schema_query, Default::default()) {
         Ok(result) => {
             let column_count = result.rows.len();
-            const EXPECTED_COLUMNS: usize = 11;
+            const EXPECTED_COLUMNS: usize = 15;
             if column_count != EXPECTED_COLUMNS {
                 eprintln!(
                     "WARNING: code_elements schema has {} columns, expected {}. \
@@ -194,7 +293,7 @@ fn validate_relationships_schema(db: &CozoDb) -> Result<(), Box<dyn std::error::
     match db.run_script(schema_query, Default::default()) {
         Ok(result) => {
             let column_count = result.rows.len();
-            const EXPECTED_COLUMNS: usize = 5;
+            const EXPECTED_COLUMNS: usize = 8;
             if column_count != EXPECTED_COLUMNS {
                 eprintln!(
                     "WARNING: relationships schema has {} columns, expected {}. \

--- a/src/db/versioning.rs
+++ b/src/db/versioning.rs
@@ -1,0 +1,54 @@
+#![allow(dead_code)]
+use std::process::Command;
+
+pub fn get_current_branch() -> Result<String, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .output()?;
+
+    if !output.status.success() {
+        return Ok("detached".to_string());
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+pub fn get_current_tag() -> Result<Option<String>, Box<dyn std::error::Error>> {
+    let output = Command::new("git")
+        .args(["describe", "--tags", "--exact-match", "HEAD"])
+        .output()?;
+
+    if output.status.success() {
+        Ok(Some(
+            String::from_utf8_lossy(&output.stdout).trim().to_string(),
+        ))
+    } else {
+        Ok(None)
+    }
+}
+
+pub fn infer_environment(branch: &str) -> String {
+    match branch {
+        "main" | "master" => "production".to_string(),
+        b if b.starts_with("release/") => "staging".to_string(),
+        b if b.starts_with("hotfix/") => "production".to_string(),
+        b if b.starts_with("develop") => "dev".to_string(),
+        _ => "upcoming".to_string(),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_infer_environment() {
+        assert_eq!(infer_environment("main"), "production");
+        assert_eq!(infer_environment("master"), "production");
+        assert_eq!(infer_environment("release/v1.0"), "staging");
+        assert_eq!(infer_environment("hotfix/urgent-fix"), "production");
+        assert_eq!(infer_environment("develop"), "dev");
+        assert_eq!(infer_environment("feature/new-login"), "upcoming");
+        assert_eq!(infer_environment("fix/bug-123"), "upcoming");
+        assert_eq!(infer_environment("detached"), "upcoming");
+    }
+}

--- a/src/mcp/auth.rs
+++ b/src/mcp/auth.rs
@@ -1,13 +1,222 @@
 #![allow(dead_code)]
+use crate::db::models::{AuthContext, Role};
 use sha2::{Digest, Sha256};
 use std::collections::HashMap;
 
+// ========================================================================
+// AuthManager - Main authentication entry point
+// ========================================================================
+
 #[derive(Debug, Clone)]
-pub struct AuthConfig {
+pub struct AuthManager {
+    config: AuthProviderConfig,
+}
+
+#[derive(Debug, Clone)]
+pub enum AuthProviderConfig {
+    Disabled,
+    Static(StaticAuthConfig),
+    // Future: Oidc(OidcAuthConfig)
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticAuthConfig {
+    pub tokens: HashMap<String, StaticTokenEntry>,
+}
+
+#[derive(Debug, Clone)]
+pub struct StaticTokenEntry {
+    pub client_id: String,
+    pub role: Role,
+}
+
+impl AuthManager {
+    pub fn new(config: AuthProviderConfig) -> Self {
+        Self { config }
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            config: AuthProviderConfig::Disabled,
+        }
+    }
+
+    pub fn with_default_token() -> Self {
+        let token = generate_token("leankg");
+        let mut tokens = HashMap::new();
+        tokens.insert(
+            token,
+            StaticTokenEntry {
+                client_id: "default".to_string(),
+                role: Role::Admin,
+            },
+        );
+        Self {
+            config: AuthProviderConfig::Static(StaticAuthConfig { tokens }),
+        }
+    }
+
+    pub fn from_config(settings: &crate::config::AuthSettings) -> Self {
+        if !settings.enabled {
+            return Self::disabled();
+        }
+
+        let mut tokens = HashMap::new();
+        for entry in &settings.tokens {
+            if let Some(role) = Role::from_str(&entry.role) {
+                tokens.insert(
+                    entry.token.clone(),
+                    StaticTokenEntry {
+                        client_id: entry.client_id.clone(),
+                        role,
+                    },
+                );
+            }
+        }
+
+        if tokens.is_empty() {
+            // If no tokens configured, create default admin token
+            return Self::with_default_token();
+        }
+
+        Self {
+            config: AuthProviderConfig::Static(StaticAuthConfig { tokens }),
+        }
+    }
+
+    pub fn validate_token(&self, token: &str) -> Result<AuthContext, AuthError> {
+        match &self.config {
+            AuthProviderConfig::Disabled => Ok(AuthContext {
+                client_id: "anonymous".to_string(),
+                role: Role::Admin,
+            }),
+            AuthProviderConfig::Static(static_config) => {
+                let entry = static_config
+                    .tokens
+                    .get(token)
+                    .ok_or(AuthError::InvalidToken)?;
+                Ok(AuthContext {
+                    client_id: entry.client_id.clone(),
+                    role: entry.role.clone(),
+                })
+            }
+        }
+    }
+
+    pub fn check_permission(
+        &self,
+        context: &AuthContext,
+        tool_name: &str,
+    ) -> Result<(), AuthError> {
+        let required = required_role(tool_name);
+        if role_sufficient(&context.role, &required) {
+            Ok(())
+        } else {
+            Err(AuthError::InsufficientPermission {
+                required,
+                actual: context.role.clone(),
+                tool: tool_name.to_string(),
+            })
+        }
+    }
+
+    pub fn is_enabled(&self) -> bool {
+        !matches!(self.config, AuthProviderConfig::Disabled)
+    }
+}
+
+// ========================================================================
+// Role-based access control
+// ========================================================================
+
+pub fn required_role(tool_name: &str) -> Role {
+    match tool_name {
+        // Admin-only: structural changes
+        "mcp_init" | "mcp_index" | "mcp_install" | "promote_environment" => Role::Admin,
+        // Contributor: knowledge writing
+        "add_knowledge" | "update_knowledge" | "delete_knowledge" | "add_annotation"
+        | "link_element" | "add_documentation" => Role::Contributor,
+        // Everything else: read-only
+        _ => Role::Viewer,
+    }
+}
+
+fn role_sufficient(actual: &Role, required: &Role) -> bool {
+    let level = |r: &Role| match r {
+        Role::Admin => 3,
+        Role::Contributor => 2,
+        Role::Viewer => 1,
+    };
+    level(actual) >= level(required)
+}
+
+// ========================================================================
+// Auth errors
+// ========================================================================
+
+#[derive(Debug, Clone)]
+pub enum AuthError {
+    InvalidToken,
+    InsufficientPermission {
+        required: Role,
+        actual: Role,
+        tool: String,
+    },
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthError::InvalidToken => write!(f, "Invalid or missing authentication token"),
+            AuthError::InsufficientPermission {
+                required,
+                actual,
+                tool,
+            } => {
+                write!(
+                    f,
+                    "Insufficient permission for '{}': requires '{}' but has '{}'",
+                    tool, required, actual
+                )
+            }
+        }
+    }
+}
+
+// ========================================================================
+// Token utilities
+// ========================================================================
+
+fn generate_token(secret: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(secret.as_bytes());
+    hasher.update(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+            .to_le_bytes(),
+    );
+    format!("{:x}", hasher.finalize())
+}
+
+#[allow(dead_code)]
+pub fn hash_token(token: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(token.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+// ========================================================================
+// Legacy compatibility - Old AuthConfig struct for CLI/backward compat
+// ========================================================================
+
+#[derive(Debug, Clone)]
+pub struct LegacyAuthConfig {
     pub tokens: HashMap<String, String>,
 }
 
-impl AuthConfig {
+impl LegacyAuthConfig {
     pub fn new() -> Self {
         Self {
             tokens: HashMap::new(),
@@ -31,30 +240,10 @@ impl AuthConfig {
     }
 }
 
-impl Default for AuthConfig {
+impl Default for LegacyAuthConfig {
     fn default() -> Self {
         Self::new().with_default_token()
     }
-}
-
-fn generate_token(secret: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(secret.as_bytes());
-    hasher.update(
-        std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_nanos()
-            .to_le_bytes(),
-    );
-    format!("{:x}", hasher.finalize())
-}
-
-#[allow(dead_code)]
-pub fn hash_token(token: &str) -> String {
-    let mut hasher = Sha256::new();
-    hasher.update(token.as_bytes());
-    format!("{:x}", hasher.finalize())
 }
 
 #[cfg(test)]
@@ -62,14 +251,14 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_auth_config_default() {
-        let config = AuthConfig::default();
+    fn test_legacy_auth_config_default() {
+        let config = LegacyAuthConfig::default();
         assert!(!config.tokens.is_empty());
     }
 
     #[test]
-    fn test_validate_token() {
-        let mut config = AuthConfig::new();
+    fn test_legacy_validate_token() {
+        let mut config = LegacyAuthConfig::new();
         config.add_token("test-token".to_string(), "client1".to_string());
         assert_eq!(
             config.validate_token("test-token"),
@@ -82,5 +271,57 @@ mod tests {
     fn test_hash_token() {
         let hash = hash_token("my-secret-token");
         assert_eq!(hash.len(), 64);
+    }
+
+    #[test]
+    fn test_auth_manager_disabled() {
+        let mgr = AuthManager::disabled();
+        let ctx = mgr.validate_token("anything").unwrap();
+        assert_eq!(ctx.role, Role::Admin);
+    }
+
+    #[test]
+    fn test_auth_manager_static() {
+        let mgr = AuthManager::with_default_token();
+        assert!(mgr.is_enabled());
+    }
+
+    #[test]
+    fn test_required_role_mapping() {
+        assert_eq!(required_role("mcp_index"), Role::Admin);
+        assert_eq!(required_role("add_knowledge"), Role::Contributor);
+        assert_eq!(required_role("search_code"), Role::Viewer);
+        assert_eq!(required_role("get_impact_radius"), Role::Viewer);
+    }
+
+    #[test]
+    fn test_role_sufficient() {
+        assert!(role_sufficient(&Role::Admin, &Role::Viewer));
+        assert!(role_sufficient(&Role::Admin, &Role::Contributor));
+        assert!(role_sufficient(&Role::Admin, &Role::Admin));
+        assert!(role_sufficient(&Role::Contributor, &Role::Viewer));
+        assert!(role_sufficient(&Role::Contributor, &Role::Contributor));
+        assert!(!role_sufficient(&Role::Contributor, &Role::Admin));
+        assert!(!role_sufficient(&Role::Viewer, &Role::Contributor));
+        assert!(!role_sufficient(&Role::Viewer, &Role::Admin));
+    }
+
+    #[test]
+    fn test_check_permission() {
+        let mgr = AuthManager::with_default_token();
+        let admin_ctx = AuthContext {
+            client_id: "test".to_string(),
+            role: Role::Admin,
+        };
+        let viewer_ctx = AuthContext {
+            client_id: "test".to_string(),
+            role: Role::Viewer,
+        };
+
+        assert!(mgr.check_permission(&admin_ctx, "mcp_index").is_ok());
+        assert!(mgr.check_permission(&admin_ctx, "search_code").is_ok());
+        assert!(mgr.check_permission(&viewer_ctx, "search_code").is_ok());
+        assert!(mgr.check_permission(&viewer_ctx, "mcp_index").is_err());
+        assert!(mgr.check_permission(&viewer_ctx, "add_knowledge").is_err());
     }
 }

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1,6 +1,6 @@
 use crate::compress::{FileReader, ReadMode, ResponseCompressor};
-use crate::db::models::ContextMetric;
-use crate::db::models::{CodeElement, Relationship};
+use crate::db;
+use crate::db::models::{CodeElement, ContextMetric, KnowledgeEntry, Relationship};
 use crate::db::record_metric;
 use crate::graph::{GraphEngine, ImpactAnalyzer};
 use crate::orchestrator::QueryOrchestrator;
@@ -191,6 +191,18 @@ impl ToolHandler {
             "find_route" => self.find_route(arguments),
             "get_screen_args" => self.get_screen_args(arguments),
             "get_nav_callers" => self.get_nav_callers(arguments),
+            // Knowledge contribution tools
+            "add_knowledge" => self.add_knowledge(arguments),
+            "update_knowledge" => self.update_knowledge(arguments),
+            "delete_knowledge" => self.delete_knowledge(arguments),
+            "search_knowledge" => self.search_knowledge_tool(arguments),
+            "add_annotation" => self.add_annotation(arguments),
+            "link_element" => self.link_element_tool(arguments),
+            "add_documentation" => self.add_documentation(arguments),
+            // Versioning tools
+            "search_by_environment" => self.search_by_environment(arguments),
+            "get_upcoming_changes" => self.get_upcoming_changes(arguments),
+            "promote_environment" => self.promote_environment(arguments),
             _ => Err(format!("Unknown tool: {}", tool_name)),
         };
 
@@ -1973,6 +1985,369 @@ impl ToolHandler {
                 Err("Cluster not found. Try get_clusters to see available cluster IDs.".to_string())
             }
         }
+    }
+
+    // ========================================================================
+    // Knowledge Contribution Tools
+    // ========================================================================
+
+    fn add_knowledge(&self, args: &Value) -> Result<Value, String> {
+        let knowledge_type = args["knowledge_type"]
+            .as_str()
+            .ok_or("Missing knowledge_type")?;
+        let title = args["title"].as_str().ok_or("Missing title")?;
+        let content = args["content"].as_str().ok_or("Missing content")?;
+        let environment = args["environment"].as_str().unwrap_or("production");
+        let tags = args["tags"].as_str().unwrap_or("[]");
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        let id = format!("k-{}-{}", knowledge_type, uuid_simple());
+
+        let entry = KnowledgeEntry {
+            id: id.clone(),
+            knowledge_type: knowledge_type.to_string(),
+            title: title.to_string(),
+            content: content.to_string(),
+            element_qualified: args["element_qualified"].as_str().map(String::from),
+            user_story_id: args["user_story_id"].as_str().map(String::from),
+            feature_id: args["feature_id"].as_str().map(String::from),
+            tags: tags.to_string(),
+            environment: environment.to_string(),
+            branch: args["branch"].as_str().map(String::from),
+            author: args["author"].as_str().unwrap_or("mcp-client").to_string(),
+            created_at: now,
+            updated_at: now,
+        };
+
+        db::create_knowledge_entry(self.graph_engine.db(), &entry)
+            .map_err(|e| format!("Failed to create knowledge entry: {}", e))?;
+
+        Ok(json!({
+            "id": entry.id,
+            "knowledge_type": entry.knowledge_type,
+            "title": entry.title,
+            "environment": entry.environment,
+            "status": "created"
+        }))
+    }
+
+    fn update_knowledge(&self, args: &Value) -> Result<Value, String> {
+        let id = args["id"].as_str().ok_or("Missing id")?;
+
+        let existing = db::get_knowledge_entry(self.graph_engine.db(), id)
+            .map_err(|e| format!("Failed to get knowledge entry: {}", e))?;
+
+        let mut entry = existing.ok_or("Knowledge entry not found")?;
+
+        if let Some(title) = args["title"].as_str() {
+            entry.title = title.to_string();
+        }
+        if let Some(content) = args["content"].as_str() {
+            entry.content = content.to_string();
+        }
+        if let Some(tags) = args["tags"].as_str() {
+            entry.tags = tags.to_string();
+        }
+        if let Some(env) = args["environment"].as_str() {
+            entry.environment = env.to_string();
+        }
+        entry.updated_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        db::update_knowledge_entry(self.graph_engine.db(), &entry)
+            .map_err(|e| format!("Failed to update knowledge entry: {}", e))?;
+
+        Ok(json!({
+            "id": entry.id,
+            "title": entry.title,
+            "environment": entry.environment,
+            "status": "updated"
+        }))
+    }
+
+    fn delete_knowledge(&self, args: &Value) -> Result<Value, String> {
+        let id = args["id"].as_str().ok_or("Missing id")?;
+
+        db::delete_knowledge_entry(self.graph_engine.db(), id)
+            .map_err(|e| format!("Failed to delete knowledge entry: {}", e))?;
+
+        Ok(json!({
+            "id": id,
+            "status": "deleted"
+        }))
+    }
+
+    fn search_knowledge_tool(&self, args: &Value) -> Result<Value, String> {
+        let query_str = args["query"].as_str().ok_or("Missing query")?;
+        let limit = args["limit"].as_u64().unwrap_or(20).min(50) as usize;
+        let knowledge_type = args["knowledge_type"].as_str();
+        let environment = args["environment"].as_str();
+
+        let entries = db::search_knowledge(
+            self.graph_engine.db(),
+            query_str,
+            knowledge_type,
+            environment,
+            limit,
+        )
+        .map_err(|e| format!("Failed to search knowledge: {}", e))?;
+
+        let results: Vec<Value> = entries
+            .iter()
+            .map(|e| {
+                json!({
+                    "id": e.id,
+                    "knowledge_type": e.knowledge_type,
+                    "title": e.title,
+                    "content_preview": truncate_str(&e.content, 200),
+                    "element_qualified": e.element_qualified,
+                    "tags": e.tags,
+                    "environment": e.environment,
+                    "branch": e.branch,
+                    "author": e.author,
+                    "created_at": e.created_at,
+                    "updated_at": e.updated_at
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "results": results,
+            "count": results.len()
+        }))
+    }
+
+    fn add_annotation(&self, args: &Value) -> Result<Value, String> {
+        let element = args["element"].as_str().ok_or("Missing element")?;
+        let description = args["description"].as_str().ok_or("Missing description")?;
+        let user_story = args["user_story"].as_str();
+        let feature = args["feature"].as_str();
+
+        let existing = db::get_business_logic(self.graph_engine.db(), element)
+            .map_err(|e| format!("DB error: {}", e))?;
+
+        if existing.is_some() {
+            db::update_business_logic(
+                self.graph_engine.db(),
+                element,
+                description,
+                user_story,
+                feature,
+            )
+            .map_err(|e| format!("Failed to update annotation: {}", e))?;
+        } else {
+            db::create_business_logic(
+                self.graph_engine.db(),
+                element,
+                description,
+                user_story,
+                feature,
+            )
+            .map_err(|e| format!("Failed to create annotation: {}", e))?;
+        }
+
+        Ok(json!({
+            "element": element,
+            "description": description,
+            "action": if existing.is_some() { "updated" } else { "created" }
+        }))
+    }
+
+    fn link_element_tool(&self, args: &Value) -> Result<Value, String> {
+        let element = args["element"].as_str().ok_or("Missing element")?;
+        let id = args["id"].as_str().ok_or("Missing id")?;
+        let kind = args["kind"].as_str().ok_or("Missing kind")?;
+
+        let existing = db::get_business_logic(self.graph_engine.db(), element)
+            .map_err(|e| format!("DB error: {}", e))?;
+
+        match existing {
+            Some(bl) => {
+                let new_desc = if bl.description.starts_with("Linked to") {
+                    bl.description.clone()
+                } else if kind == "story" {
+                    format!("{} | Linked to story {}", bl.description, id)
+                } else {
+                    format!("{} | Linked to feature {}", bl.description, id)
+                };
+                db::update_business_logic(
+                    self.graph_engine.db(),
+                    element,
+                    &new_desc,
+                    if kind == "story" {
+                        Some(id)
+                    } else {
+                        bl.user_story_id.as_deref()
+                    },
+                    if kind == "feature" {
+                        Some(id)
+                    } else {
+                        bl.feature_id.as_deref()
+                    },
+                )
+                .map_err(|e| format!("Failed to link: {}", e))?;
+            }
+            None => {
+                let description = format!("Linked to {} {}", kind, id);
+                db::create_business_logic(
+                    self.graph_engine.db(),
+                    element,
+                    &description,
+                    if kind == "story" { Some(id) } else { None },
+                    if kind == "feature" { Some(id) } else { None },
+                )
+                .map_err(|e| format!("Failed to create link: {}", e))?;
+            }
+        }
+
+        Ok(json!({
+            "element": element,
+            "linked_to": format!("{} {}", kind, id),
+            "status": "linked"
+        }))
+    }
+
+    fn add_documentation(&self, args: &Value) -> Result<Value, String> {
+        let file_path = args["file_path"].as_str().ok_or("Missing file_path")?;
+        let path = std::path::Path::new(file_path);
+        if !path.exists() {
+            return Err(format!("File not found: {}", file_path));
+        }
+
+        let parent = path.parent().unwrap_or(std::path::Path::new("."));
+        let result = crate::doc_indexer::index_docs_directory(parent, &self.graph_engine)
+            .map_err(|e| format!("Failed to index documentation: {}", e))?;
+
+        Ok(json!({
+            "file_indexed": file_path,
+            "documents_processed": result.documents.len(),
+            "total_references": result.relationships.len(),
+            "status": "indexed"
+        }))
+    }
+
+    // ========================================================================
+    // Version/Branch Tagging Tools
+    // ========================================================================
+
+    fn search_by_environment(&self, args: &Value) -> Result<Value, String> {
+        let environment = args["environment"].as_str().ok_or("Missing environment")?;
+        let limit = args["limit"].as_u64().unwrap_or(20).min(50) as usize;
+
+        let knowledge =
+            db::get_knowledge_by_environment(self.graph_engine.db(), environment, limit)
+                .map_err(|e| format!("Failed to search by environment: {}", e))?;
+
+        let results: Vec<Value> = knowledge
+            .iter()
+            .map(|e| {
+                json!({
+                    "id": e.id,
+                    "knowledge_type": e.knowledge_type,
+                    "title": e.title,
+                    "content_preview": truncate_str(&e.content, 200),
+                    "branch": e.branch,
+                    "author": e.author,
+                    "environment": e.environment,
+                    "created_at": e.created_at
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "environment": environment,
+            "results": results,
+            "count": results.len()
+        }))
+    }
+
+    fn get_upcoming_changes(&self, args: &Value) -> Result<Value, String> {
+        let limit = args["limit"].as_u64().unwrap_or(20).min(50) as usize;
+        let branch_filter = args["branch"].as_str();
+
+        let mut entries =
+            db::get_knowledge_by_environment(self.graph_engine.db(), "upcoming", limit)
+                .map_err(|e| format!("Failed to get upcoming changes: {}", e))?;
+
+        if let Some(branch) = branch_filter {
+            entries.retain(|e| e.branch.as_deref() == Some(branch));
+        }
+
+        let results: Vec<Value> = entries
+            .iter()
+            .map(|e| {
+                json!({
+                    "id": e.id,
+                    "knowledge_type": e.knowledge_type,
+                    "title": e.title,
+                    "content_preview": truncate_str(&e.content, 200),
+                    "branch": e.branch,
+                    "author": e.author,
+                    "created_at": e.created_at
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "environment": "upcoming",
+            "results": results,
+            "count": results.len()
+        }))
+    }
+
+    fn promote_environment(&self, args: &Value) -> Result<Value, String> {
+        let branch = args["branch"].as_str().ok_or("Missing branch")?;
+        let target_env = args["target_environment"].as_str().unwrap_or("production");
+
+        // Get all upcoming entries for this branch
+        let mut entries =
+            db::get_knowledge_by_environment(self.graph_engine.db(), "upcoming", 1000)
+                .map_err(|e| format!("Failed to query knowledge: {}", e))?;
+
+        entries.retain(|e| e.branch.as_deref() == Some(branch));
+
+        let mut promoted = 0;
+        for mut entry in entries {
+            entry.environment = target_env.to_string();
+            entry.updated_at = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64;
+
+            db::update_knowledge_entry(self.graph_engine.db(), &entry)
+                .map_err(|e| format!("Failed to promote entry: {}", e))?;
+            promoted += 1;
+        }
+
+        Ok(json!({
+            "branch": branch,
+            "target_environment": target_env,
+            "promoted_count": promoted,
+            "status": "promoted"
+        }))
+    }
+}
+
+fn uuid_simple() -> String {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let ts = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    format!("{:x}", ts)
+}
+
+fn truncate_str(s: &str, max_len: usize) -> String {
+    if s.len() <= max_len {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max_len])
     }
 }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1,7 +1,7 @@
 #![allow(dead_code)]
 use crate::db::schema::init_db;
 use crate::graph::GraphEngine;
-use crate::mcp::auth::AuthConfig;
+use crate::mcp::auth::AuthManager;
 use crate::mcp::handler::ToolHandler;
 use crate::mcp::tools::ToolRegistry;
 use crate::mcp::tracker::WriteTracker;
@@ -43,7 +43,7 @@ struct SessionInfo {
 }
 
 pub struct MCPServer {
-    auth_config: Arc<TokioRwLock<AuthConfig>>,
+    auth_manager: Arc<TokioRwLock<AuthManager>>,
     db_path: Arc<RwLock<PathBuf>>,
     graph_engine: Arc<parking_lot::Mutex<Option<GraphEngine>>>,
     graph_engine_cache: Arc<RwLock<HashMap<PathBuf, GraphEngine>>>,
@@ -69,7 +69,7 @@ impl std::fmt::Debug for MCPServer {
 impl Clone for MCPServer {
     fn clone(&self) -> Self {
         Self {
-            auth_config: self.auth_config.clone(),
+            auth_manager: self.auth_manager.clone(),
             db_path: self.db_path.clone(),
             graph_engine: self.graph_engine.clone(),
             graph_engine_cache: self.graph_engine_cache.clone(),
@@ -87,7 +87,7 @@ impl MCPServer {
     pub fn new(db_path: std::path::PathBuf) -> Self {
         let effective_db_path = Self::resolve_project_root(db_path);
         Self {
-            auth_config: Arc::new(TokioRwLock::new(AuthConfig::default())),
+            auth_manager: Arc::new(TokioRwLock::new(AuthManager::with_default_token())),
             db_path: Arc::new(RwLock::new(effective_db_path)),
             graph_engine: Arc::new(parking_lot::Mutex::new(None)),
             graph_engine_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -103,7 +103,7 @@ impl MCPServer {
     pub fn new_with_watch(db_path: std::path::PathBuf, watch_path: std::path::PathBuf) -> Self {
         let effective_db_path = Self::resolve_project_root(db_path);
         Self {
-            auth_config: Arc::new(TokioRwLock::new(AuthConfig::default())),
+            auth_manager: Arc::new(TokioRwLock::new(AuthManager::with_default_token())),
             db_path: Arc::new(RwLock::new(effective_db_path)),
             graph_engine: Arc::new(parking_lot::Mutex::new(None)),
             graph_engine_cache: Arc::new(RwLock::new(HashMap::new())),
@@ -267,8 +267,8 @@ impl MCPServer {
         Ok(ge)
     }
 
-    pub async fn auth_config_read(&self) -> tokio::sync::RwLockReadGuard<'_, AuthConfig> {
-        self.auth_config.read().await
+    pub async fn auth_manager_read(&self) -> tokio::sync::RwLockReadGuard<'_, AuthManager> {
+        self.auth_manager.read().await
     }
 
     fn get_graph_engine(&self) -> Result<GraphEngine, String> {
@@ -745,6 +745,7 @@ impl MCPServer {
         let server = Arc::new(HttpMcpServer {
             mcp_server: self.clone(),
             auth_token,
+            auth_manager: AuthManager::with_default_token(),
         });
 
         let cors = CorsLayer::new()
@@ -1476,6 +1477,20 @@ impl MCPServer {
             *guard = None;
         }
 
+        // Mark write tracker dirty for knowledge contribution tools
+        if matches!(
+            tool_name,
+            "add_knowledge"
+                | "update_knowledge"
+                | "delete_knowledge"
+                | "add_annotation"
+                | "link_element"
+                | "add_documentation"
+                | "promote_environment"
+        ) {
+            self.write_tracker.mark_dirty();
+        }
+
         result
     }
 }
@@ -1556,6 +1571,7 @@ impl ServerHandler for MCPServer {
 struct HttpMcpServer {
     mcp_server: MCPServer,
     auth_token: Option<String>,
+    auth_manager: AuthManager,
 }
 
 /// Query parameters extracted from MCP HTTP requests
@@ -1625,20 +1641,36 @@ mod json_rpc_code {
 }
 
 /// Extract bearer token from Authorization header using constant-time comparison
-/// to prevent timing attacks on bearer tokens.
-fn extract_bearer_token(auth_header: Option<&str>, token: &Option<String>) -> bool {
-    if token.is_none() {
-        return true; // No auth required
+/// to prevent timing attacks on bearer tokens. Returns an AuthContext with role.
+fn extract_auth_context(
+    auth_header: Option<&str>,
+    server: &HttpMcpServer,
+) -> Result<crate::db::models::AuthContext, StatusCode> {
+    if server.auth_token.is_none() {
+        // No auth configured — grant admin
+        return Ok(crate::db::models::AuthContext {
+            client_id: "anonymous".to_string(),
+            role: crate::db::models::Role::Admin,
+        });
     }
-    let token = token.as_ref().unwrap();
+
+    let expected_token = server.auth_token.as_ref().unwrap();
 
     if let Some(auth) = auth_header {
         if let Some(stripped) = auth.strip_prefix("Bearer ") {
             // Use constant-time comparison to prevent timing attacks
-            return subtle::ConstantTimeEq::ct_eq(stripped.as_bytes(), token.as_bytes()).into();
+            let matches: bool =
+                subtle::ConstantTimeEq::ct_eq(stripped.as_bytes(), expected_token.as_bytes())
+                    .into();
+            if matches {
+                return server
+                    .auth_manager
+                    .validate_token(stripped)
+                    .map_err(|_| StatusCode::UNAUTHORIZED);
+            }
         }
     }
-    false
+    Err(StatusCode::UNAUTHORIZED)
 }
 
 /// Handle POST /mcp - JSON-RPC request endpoint
@@ -1683,13 +1715,16 @@ async fn handle_mcp_request(
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok());
 
-    // Check authentication
-    if !extract_bearer_token(auth_value, &server.auth_token) {
-        return Response::builder()
-            .status(StatusCode::UNAUTHORIZED)
-            .body(Body::from(r#"{"error": "Unauthorized"}"#))
-            .unwrap();
-    }
+    // Check authentication and get auth context
+    let auth_context = match extract_auth_context(auth_value, &server) {
+        Ok(ctx) => ctx,
+        Err(status) => {
+            return Response::builder()
+                .status(status)
+                .body(Body::from(r#"{"error": "Unauthorized"}"#))
+                .unwrap();
+        }
+    };
 
     // Parse JSON-RPC request
     let request: JsonRpcRequest = match serde_json::from_str(&body) {
@@ -1771,8 +1806,16 @@ async fn handle_mcp_request(
 
     if is_notification {
         // Process the notification but don't send a response
-        let _ =
-            process_jsonrpc_request(&server.mcp_server, &request, project_param.as_deref()).await;
+        let _ = process_jsonrpc_request(
+            &server.mcp_server,
+            &request,
+            project_param.as_deref(),
+            crate::db::models::AuthContext {
+                client_id: "anonymous".to_string(),
+                role: crate::db::models::Role::Admin,
+            },
+        )
+        .await;
         return Response::builder()
             .status(StatusCode::NO_CONTENT)
             .body(Body::empty())
@@ -1780,8 +1823,13 @@ async fn handle_mcp_request(
     }
 
     // Process the request, passing project param for routing
-    let result =
-        process_jsonrpc_request(&server.mcp_server, &request, project_param.as_deref()).await;
+    let result = process_jsonrpc_request(
+        &server.mcp_server,
+        &request,
+        project_param.as_deref(),
+        auth_context,
+    )
+    .await;
 
     // Build response
     // unwrap is safe because if id was None we already returned NO_CONTENT above
@@ -1816,6 +1864,7 @@ async fn process_jsonrpc_request(
     mcp_server: &MCPServer,
     request: &JsonRpcRequest,
     project_param: Option<&str>,
+    auth_context: crate::db::models::AuthContext,
 ) -> Result<serde_json::Value, String> {
     let method = &request.method;
     let params = request.params.as_ref();
@@ -1865,6 +1914,16 @@ async fn process_jsonrpc_request(
                 .get("name")
                 .and_then(|v| v.as_str())
                 .ok_or("Missing tool name")?;
+
+            // RBAC: Check if user has permission to call this tool
+            if let Err(e) = mcp_server
+                .auth_manager
+                .read()
+                .await
+                .check_permission(&auth_context, tool_name)
+            {
+                return Err(format!("Permission denied: {}", e));
+            }
 
             let mut arguments = params_obj
                 .get("arguments")
@@ -1919,13 +1978,16 @@ async fn handle_sse_stream(
         .get(header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok());
 
-    // Check authentication
-    if !extract_bearer_token(auth_value, &server.auth_token) {
-        return Response::builder()
-            .status(StatusCode::UNAUTHORIZED)
-            .body(Body::from(r#"event: error\ndata: Unauthorized\n\n"#))
-            .unwrap();
-    }
+    // Check authentication and get auth context
+    let _auth_context = match extract_auth_context(auth_value, &server) {
+        Ok(ctx) => ctx,
+        Err(status) => {
+            return Response::builder()
+                .status(status)
+                .body(Body::from(r#"event: error\ndata: Unauthorized\n\n"#))
+                .unwrap();
+        }
+    };
 
     // For now, return an SSE stream that sends an endpoint message
     // In a full implementation, this would maintain a persistent connection
@@ -1963,6 +2025,6 @@ mod tests {
     async fn test_mcp_server_new_with_custom_path() {
         let db_path = std::path::PathBuf::from("/custom/path/.leankg");
         let server = MCPServer::new(db_path.clone());
-        assert!(server.auth_config.try_read().is_ok());
+        assert!(server.auth_manager.try_read().is_ok());
     }
 }

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -521,6 +521,153 @@ impl ToolRegistry {
                     "required": []
                 }),
             },
+
+            // Knowledge Contribution Tools
+            ToolDefinition {
+                name: "add_knowledge".to_string(),
+                description: "Add a knowledge entry to the knowledge base. Supports business knowledge, domain knowledge, architecture docs, PRD-code mapping, debugging notes, and general notes. Entries can optionally be linked to code elements, user stories, or features.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "knowledge_type": {"type": "string", "enum": ["business", "domain", "architecture", "prd_mapping", "debugging", "general"], "description": "Type of knowledge entry"},
+                        "title": {"type": "string", "description": "Title of the knowledge entry"},
+                        "content": {"type": "string", "description": "Content in markdown format"},
+                        "element_qualified": {"type": "string", "description": "Optional: qualified name of code element to link (e.g., src/main.rs::main)"},
+                        "user_story_id": {"type": "string", "description": "Optional: user story ID to link"},
+                        "feature_id": {"type": "string", "description": "Optional: feature ID to link"},
+                        "tags": {"type": "string", "description": "Comma-separated tags"},
+                        "environment": {"type": "string", "enum": ["production", "staging", "dev", "upcoming"], "description": "Environment tag (default: production)"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["knowledge_type", "title", "content"]
+                }),
+            },
+            ToolDefinition {
+                name: "update_knowledge".to_string(),
+                description: "Update an existing knowledge entry by ID.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "description": "ID of the knowledge entry to update"},
+                        "title": {"type": "string", "description": "New title"},
+                        "content": {"type": "string", "description": "New content in markdown"},
+                        "tags": {"type": "string", "description": "New comma-separated tags"},
+                        "environment": {"type": "string", "description": "New environment tag"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["id"]
+                }),
+            },
+            ToolDefinition {
+                name: "delete_knowledge".to_string(),
+                description: "Delete a knowledge entry by ID.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "id": {"type": "string", "description": "ID of the knowledge entry to delete"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["id"]
+                }),
+            },
+            ToolDefinition {
+                name: "search_knowledge".to_string(),
+                description: "Search all knowledge entries by keyword. Filters by knowledge type and environment. Returns matching entries with titles, content snippets, and metadata.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Search query (keyword in title)"},
+                        "knowledge_type": {"type": "string", "enum": ["business", "domain", "architecture", "prd_mapping", "debugging", "general"], "description": "Optional: filter by knowledge type"},
+                        "environment": {"type": "string", "enum": ["production", "staging", "dev", "upcoming"], "description": "Optional: filter by environment"},
+                        "limit": {"type": "integer", "description": "Max results (default: 20, max: 50)"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["query"]
+                }),
+            },
+            ToolDefinition {
+                name: "add_annotation".to_string(),
+                description: "Add or update a business logic annotation for a code element. Links a description (and optionally a user story or feature) to a code element.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "element": {"type": "string", "description": "Qualified name of the code element (e.g., src/auth/login.rs::handle_login)"},
+                        "description": {"type": "string", "description": "Business logic description"},
+                        "user_story": {"type": "string", "description": "Optional: user story ID"},
+                        "feature": {"type": "string", "description": "Optional: feature ID"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["element", "description"]
+                }),
+            },
+            ToolDefinition {
+                name: "link_element".to_string(),
+                description: "Link a code element to a user story or feature ID.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "element": {"type": "string", "description": "Qualified name of the code element"},
+                        "id": {"type": "string", "description": "User story or feature ID"},
+                        "kind": {"type": "string", "enum": ["story", "feature"], "description": "Type of link: 'story' for user story, 'feature' for feature"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["element", "id", "kind"]
+                }),
+            },
+            ToolDefinition {
+                name: "add_documentation".to_string(),
+                description: "Index a single documentation file into the knowledge graph. Extracts code references and creates documented_by/references relationships.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "file_path": {"type": "string", "description": "Path to the documentation file to index"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["file_path"]
+                }),
+            },
+
+            // Version/Branch Tagging Tools
+            ToolDefinition {
+                name: "search_by_environment".to_string(),
+                description: "Search code elements and knowledge entries filtered by environment (production, staging, dev, upcoming). Useful for seeing what's in production vs what's in development.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "environment": {"type": "string", "enum": ["production", "staging", "dev", "upcoming"], "description": "Environment to filter by"},
+                        "query": {"type": "string", "description": "Optional: search query to further filter results"},
+                        "limit": {"type": "integer", "description": "Max results (default: 20)"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["environment"]
+                }),
+            },
+            ToolDefinition {
+                name: "get_upcoming_changes".to_string(),
+                description: "Get knowledge entries and code elements tagged as 'upcoming' (feature branch changes not yet in main). Shows what's coming in the next release.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "branch": {"type": "string", "description": "Optional: filter by specific branch name"},
+                        "limit": {"type": "integer", "description": "Max results (default: 20)"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": []
+                }),
+            },
+            ToolDefinition {
+                name: "promote_environment".to_string(),
+                description: "Promote knowledge entries and code elements from one environment to another (e.g., upcoming -> production). Used when a feature branch merges to main.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "branch": {"type": "string", "description": "Branch name to promote entries from"},
+                        "target_environment": {"type": "string", "enum": ["production", "staging", "dev"], "description": "Target environment (default: production)"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["branch"]
+                }),
+            },
         ]
     }
 }

--- a/tests/mcp_tests.rs
+++ b/tests/mcp_tests.rs
@@ -1,6 +1,6 @@
 use leankg::db::schema::init_db;
 use leankg::graph::GraphEngine;
-use leankg::mcp::auth::{hash_token, AuthConfig};
+use leankg::mcp::auth::{hash_token, AuthManager, LegacyAuthConfig};
 use leankg::mcp::handler::ToolHandler;
 use leankg::mcp::server::MCPServer;
 use leankg::mcp::tools::ToolRegistry;
@@ -130,13 +130,13 @@ mod auth_tests {
 
     #[test]
     fn test_auth_config_default_has_token() {
-        let config = AuthConfig::default();
+        let config = LegacyAuthConfig::default();
         assert!(!config.tokens.is_empty());
     }
 
     #[test]
     fn test_auth_config_add_and_validate_token() {
-        let mut config = AuthConfig::new();
+        let mut config = LegacyAuthConfig::new();
         let token = "test-token-123".to_string();
         let client_id = "test-client".to_string();
 
@@ -148,7 +148,7 @@ mod auth_tests {
 
     #[test]
     fn test_auth_config_multiple_tokens() {
-        let mut config = AuthConfig::new();
+        let mut config = LegacyAuthConfig::new();
         config.add_token("token1".to_string(), "client1".to_string());
         config.add_token("token2".to_string(), "client2".to_string());
 
@@ -430,7 +430,7 @@ mod server_tests {
     #[tokio::test(flavor = "multi_thread")]
     async fn test_mcp_server_creation() {
         let server = MCPServer::new(std::path::PathBuf::from(".leankg"));
-        let _guard = server.auth_config_read().await;
+        let _guard = server.auth_manager_read().await;
     }
 
     #[test]


### PR DESCRIPTION
## Summary
Enable LeanKG as a collaborative "second brain" for engineering teams with knowledge contribution, environment/branch tagging, and role-based access control via MCP.

- **Knowledge contribution**: Add 7 MCP write tools (add_knowledge, update_knowledge, delete_knowledge, search_knowledge, add_annotation, link_element, add_documentation)
- **Versioning**: Environment inference from git branch (main→production, release/→staging, develop→dev, _→upcoming), plus 3 versioning MCP tools
- **RBAC**: AuthManager with Admin/Contributor/Viewer roles; HTTP transport enforces permissions, stdio transport bypasses auth for backward compatibility
- **Schema migrations**: CozoDB migration system with migrations table for safe schema evolution

## Test plan
- [ ] `cargo build --release` succeeds
- [ ] `cargo test --lib` — 331 unit tests pass
- [ ] Integration tests pass (SQLite lock contention in test env is a known issue, not a code bug)
- [ ] MCP tools add_knowledge/search_knowledge work via MCP client
- [ ] HTTP MCP server enforces RBAC for viewer tokens
