### PR TITLE
feat: ontology semantic search layer for agentic queries

### DIFF
--- a/ontology/concepts/concepts.example.yaml
+++ b/ontology/concepts/concepts.example.yaml
@@ -1,0 +1,47 @@
+# Concept Ontology - Domain Entities
+# Format: concept nodes that describe product/business concepts
+
+concepts:
+  - id: refund
+    type: domain_entity
+    name: Refund
+    env: local
+    aliases:
+      - reversal
+      - chargeback
+      - money back
+    description: Money returned to a customer after payment capture.
+    owned_by:
+      - checkout-service
+      - payment-service
+    code_refs:
+      - src/refund/handler.rs
+    docs:
+      - docs/refund.md
+
+  - id: checkout
+    type: workflow
+    name: Checkout
+    env: local
+    aliases:
+      - place order
+      - purchase flow
+    description: End-to-end customer checkout workflow
+    entry_points:
+      - src/checkout/handler.rs::create_order
+    steps:
+      - id: create_order
+        name: Create Order
+        code_refs:
+          - src/order/service.rs::create
+      - id: authorize_payment
+        name: Authorize Payment
+        code_refs:
+          - src/payment/client.rs::authorize
+        failure_modes:
+          - payment_timeout
+          - insufficient_funds
+      - id: confirm_order
+        name: Confirm Order
+        code_refs:
+          - src/order/service.rs::confirm

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -338,6 +338,52 @@ pub enum CLICommand {
         #[arg(long, default_value = "production")]
         env: String,
     },
+    /// Ontology management commands (semantic search layer)
+    Ontology {
+        #[command(subcommand)]
+        command: OntologyCommand,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum OntologyCommand {
+    /// Validate ontology YAML files
+    Validate,
+    /// Sync ontology from YAML files into the graph
+    Sync {
+        /// Path to ontology directory (default: ./ontology)
+        #[arg(long)]
+        path: Option<String>,
+    },
+    /// Show ontology status and coverage
+    Status,
+    /// Get ontology context for a semantic query
+    Context {
+        /// Query string
+        query: String,
+        /// Environment
+        #[arg(long, default_value = "local")]
+        env: String,
+        /// Expansion depth
+        #[arg(long, default_value = "2")]
+        depth: u32,
+    },
+    /// Get concept map for a domain or service
+    ConceptMap {
+        /// Concept or service name
+        query: String,
+        /// Environment
+        #[arg(long, default_value = "local")]
+        env: String,
+    },
+    /// Trace a workflow's ordered steps
+    TraceWorkflow {
+        /// Workflow name or ID
+        workflow_id_or_query: String,
+        /// Environment
+        #[arg(long, default_value = "local")]
+        env: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hooks;
 pub mod indexer;
 pub mod mcp;
 pub mod obsidian;
+pub mod ontology;
 pub mod orchestrator;
 pub mod registry;
 pub mod runtime;

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,7 @@ mod graph;
 mod indexer;
 mod mcp;
 mod obsidian;
+mod ontology;
 mod orchestrator;
 mod registry;
 mod runtime;
@@ -472,6 +473,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         cli::CLICommand::Pull { remote, token, env } => {
             pull_from_remote(&remote, &token, &env)?;
+        }
+        cli::CLICommand::Ontology { command } => {
+            handle_ontology_command(command)?;
         }
     }
 
@@ -3298,6 +3302,251 @@ fn show_env_conflicts(service: &str) -> Result<(), Box<dyn std::error::Error>> {
 
     if !found {
         println!("No environment conflicts found for service '{}'", service);
+    }
+
+    Ok(())
+}
+
+fn handle_ontology_command(
+    command: cli::OntologyCommand,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let project_path = find_project_root()?;
+    let db_path = project_path.join(".leankg");
+    let db = db::schema::init_db(&db_path)?;
+    let graph = graph::GraphEngine::new(db.clone());
+    let query_engine = crate::ontology::OntologyQueryEngine::new(db);
+
+    match command {
+        cli::OntologyCommand::Validate => {
+            println!("Validating ontology YAML files...");
+            let ontology_path = project_path.join("ontology");
+            if !ontology_path.exists() {
+                println!("No ontology directory found at {}. Run 'ontology sync' to create from example files.", ontology_path.display());
+                return Ok(());
+            }
+
+            let concepts_file = ontology_path.join("concepts");
+            let workflows_file = ontology_path.join("workflows");
+
+            if concepts_file.exists() {
+                println!("  concepts/ found");
+            }
+            if workflows_file.exists() {
+                println!("  workflows/ found");
+            }
+
+            println!("Validation complete.");
+        }
+
+        cli::OntologyCommand::Sync { path } => {
+            println!("Syncing ontology from YAML files...");
+            let ontology_path = match path {
+                Some(p) => std::path::PathBuf::from(p),
+                None => project_path.join("ontology"),
+            };
+
+            if !ontology_path.exists() {
+                println!(
+                    "Creating example ontology directory at {}",
+                    ontology_path.display()
+                );
+                std::fs::create_dir_all(&ontology_path)?;
+                std::fs::create_dir_all(ontology_path.join("concepts"))?;
+                std::fs::create_dir_all(ontology_path.join("workflows"))?;
+                std::fs::create_dir_all(ontology_path.join("playbooks"))?;
+                println!(
+                    "Created ontology structure. Add YAML files to define concepts and workflows."
+                );
+                return Ok(());
+            }
+
+            let mut total_nodes = 0;
+            let mut total_relationships = 0;
+
+            // Load concepts
+            let concepts_file = ontology_path.join("concepts.yaml");
+            if concepts_file.exists() {
+                match crate::ontology::load_concepts_yaml(&concepts_file) {
+                    Ok(nodes) => {
+                        let elements = crate::ontology::concept_nodes_to_elements(&nodes);
+                        for elem in &elements {
+                            if let Err(e) = graph.insert_element(elem) {
+                                tracing::warn!("Failed to insert concept element: {}", e);
+                            }
+                        }
+                        println!("  Loaded {} concept nodes", nodes.len());
+                        total_nodes += nodes.len();
+                    }
+                    Err(e) => println!("  Warning: Failed to load concepts.yaml: {}", e),
+                }
+            }
+
+            // Load workflows
+            let workflows_file = ontology_path.join("workflows.yaml");
+            if workflows_file.exists() {
+                match crate::ontology::load_workflows_yaml(&workflows_file) {
+                    Ok((workflows, steps, failures, relationships)) => {
+                        let workflow_elements =
+                            crate::ontology::workflow_nodes_to_elements(&workflows);
+                        let step_elements =
+                            crate::ontology::workflow_step_nodes_to_elements(&steps);
+                        let failure_elements =
+                            crate::ontology::failure_mode_nodes_to_elements(&failures);
+
+                        for elem in workflow_elements
+                            .iter()
+                            .chain(step_elements.iter())
+                            .chain(failure_elements.iter())
+                        {
+                            if let Err(e) = graph.insert_element(elem) {
+                                tracing::warn!("Failed to insert workflow element: {}", e);
+                            }
+                        }
+
+                        for rel in &relationships {
+                            if let Err(e) = graph.insert_relationship(rel) {
+                                tracing::warn!("Failed to insert relationship: {}", e);
+                            }
+                        }
+
+                        println!("  Loaded {} workflow nodes", workflows.len());
+                        println!("  Loaded {} workflow steps", steps.len());
+                        println!("  Loaded {} failure modes", failures.len());
+                        total_nodes += workflows.len() + steps.len() + failures.len();
+                        total_relationships += relationships.len();
+                    }
+                    Err(e) => println!("  Warning: Failed to load workflows.yaml: {}", e),
+                }
+            }
+
+            println!("\nOntology sync complete");
+            println!("  Total nodes: {}", total_nodes);
+            println!("  Total relationships: {}", total_relationships);
+        }
+
+        cli::OntologyCommand::Status => {
+            println!("Ontology Status\n===============");
+
+            let status = query_engine.get_ontology_status()?;
+
+            println!("\nConcept Nodes:");
+            for (t, count) in &status.concept_counts {
+                println!("  {}: {}", t, count);
+            }
+
+            println!("\nProcedural Nodes:");
+            for (t, count) in &status.procedural_counts {
+                println!("  {}: {}", t, count);
+            }
+
+            println!("\nTotal aliases: {}", status.total_aliases);
+            println!("Nodes missing aliases: {}", status.nodes_missing_aliases);
+            println!(
+                "Workflows without failure modes: {}",
+                status.workflows_without_failure_modes
+            );
+        }
+
+        cli::OntologyCommand::Context { query, env, depth } => {
+            let context = query_engine.get_ontology_context(&query, &env, depth)?;
+
+            if context.matched_ontology_nodes.is_empty() {
+                println!("No ontology nodes matched query '{}'", query);
+                return Ok(());
+            }
+
+            println!("Matched Ontology Nodes:");
+            for node in &context.matched_ontology_nodes {
+                println!(
+                    "  [{}] {} ({}) - score: {:.2}",
+                    node.gid, node.name, node.element_type, node.match_score
+                );
+                println!("    Match reason: {}", node.match_reason);
+            }
+
+            if !context.workflows.is_empty() {
+                println!("\nWorkflows:");
+                for w in &context.workflows {
+                    println!("  - {} ({})", w.name, w.gid);
+                }
+            }
+
+            if !context.workflow_steps.is_empty() {
+                println!("\nWorkflow Steps:");
+                for s in &context.workflow_steps {
+                    println!("  {}. {} ({})", s.order, s.name, s.gid);
+                }
+            }
+
+            if !context.expanded_code_context.is_empty() {
+                println!(
+                    "\nRelated Code Elements ({}):",
+                    context.expanded_code_context.len()
+                );
+                for elem in context.expanded_code_context.iter().take(10) {
+                    println!("  - {} ({})", elem.qualified_name, elem.element_type);
+                }
+                if context.expanded_code_context.len() > 10 {
+                    println!(
+                        "  ... and {} more",
+                        context.expanded_code_context.len() - 10
+                    );
+                }
+            }
+
+            println!("\nConfidence: {:.2}", context.confidence);
+        }
+
+        cli::OntologyCommand::ConceptMap { query, env } => {
+            let nodes = query_engine.search_ontology_nodes(&query, &env, 2)?;
+
+            if nodes.is_empty() {
+                println!("No concept nodes matched query '{}'", query);
+                return Ok(());
+            }
+
+            println!("Concept Map for '{}':", query);
+            for node in &nodes {
+                println!("  [{}] {} ({})", node.gid, node.name, node.element_type);
+                if !node.aliases.is_empty() {
+                    println!("    Aliases: {}", node.aliases.join(", "));
+                }
+                println!("    Description: {}", node.description);
+            }
+
+            println!("\nFound {} matching nodes", nodes.len());
+        }
+
+        cli::OntologyCommand::TraceWorkflow {
+            workflow_id_or_query,
+            env,
+        } => {
+            let steps = query_engine.trace_workflow(&workflow_id_or_query, &env)?;
+
+            if steps.is_empty() {
+                println!("No workflow found matching '{}'", workflow_id_or_query);
+                return Ok(());
+            }
+
+            println!(
+                "Workflow Trace: {} ({} steps)",
+                workflow_id_or_query,
+                steps.len()
+            );
+            for step in &steps {
+                println!("\n  Step {}: {}", step.order, step.name);
+                println!("    GID: {}", step.gid);
+                if !step.metadata.code_refs.is_empty() {
+                    println!("    Code refs: {}", step.metadata.code_refs.join(", "));
+                }
+                if !step.metadata.failure_modes.is_empty() {
+                    println!(
+                        "    Failure modes: {}",
+                        step.metadata.failure_modes.join(", ")
+                    );
+                }
+            }
+        }
     }
 
     Ok(())

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -210,6 +210,11 @@ impl ToolHandler {
             "query_incidents" => self.query_incidents(arguments),
             "find_env_conflicts" => self.find_env_conflicts(arguments),
             "get_service_context" => self.get_service_context(arguments),
+            // Ontology semantic search tools
+            "kg_context" => self.kg_context(arguments),
+            "kg_concept_map" => self.kg_concept_map(arguments),
+            "kg_trace_workflow" => self.kg_trace_workflow(arguments),
+            "kg_ontology_status" => self.kg_ontology_status(arguments),
             _ => Err(format!("Unknown tool: {}", tool_name)),
         };
 
@@ -2540,6 +2545,112 @@ impl ToolHandler {
             "recent_incidents": context.recent_incidents,
             "last_incident": context.last_incident,
             "known_risks": context.known_risks,
+        }))
+    }
+
+    fn kg_context(&self, args: &Value) -> Result<Value, String> {
+        let query = args["query"].as_str().ok_or("Missing 'query' parameter")?;
+        let env = args["env"].as_str().unwrap_or("local");
+        let depth = args["depth"].as_u64().unwrap_or(2) as u32;
+
+        let query_engine =
+            crate::ontology::OntologyQueryEngine::new(self.graph_engine.db().clone());
+
+        let context = query_engine
+            .get_ontology_context(query, env, depth)
+            .map_err(|e| format!("Failed to get ontology context: {}", e))?;
+
+        Ok(json!({
+            "matched_ontology_nodes": context.matched_ontology_nodes,
+            "expanded_code_context": context.expanded_code_context,
+            "expanded_relationships": context.expanded_relationships,
+            "workflows": context.workflows,
+            "workflow_steps": context.workflow_steps,
+            "failure_modes": context.failure_modes,
+            "confidence": context.confidence,
+            "match_reasons": context.match_reasons,
+        }))
+    }
+
+    fn kg_concept_map(&self, args: &Value) -> Result<Value, String> {
+        let query = args["query"].as_str().ok_or("Missing 'query' parameter")?;
+        let env = args["env"].as_str().unwrap_or("local");
+
+        let query_engine =
+            crate::ontology::OntologyQueryEngine::new(self.graph_engine.db().clone());
+
+        // Search for matching ontology nodes
+        let nodes = query_engine
+            .search_ontology_nodes(query, env, 2)
+            .map_err(|e| format!("Failed to search ontology: {}", e))?;
+
+        // Expand context for each node
+        let mut all_elements = Vec::new();
+        let mut all_relationships = Vec::new();
+
+        for node in &nodes {
+            let (elements, relationships) = query_engine
+                .expand_ontology_context(&node.gid, 2)
+                .unwrap_or_else(|_| (vec![], vec![]));
+            all_elements.extend(elements);
+            all_relationships.extend(relationships);
+        }
+
+        Ok(json!({
+            "concept_nodes": nodes,
+            "related_code": all_elements,
+            "relationships": all_relationships,
+        }))
+    }
+
+    fn kg_trace_workflow(&self, args: &Value) -> Result<Value, String> {
+        let workflow_query = args["workflow_id_or_query"]
+            .as_str()
+            .ok_or("Missing 'workflow_id_or_query' parameter")?;
+        let env = args["env"].as_str().unwrap_or("local");
+
+        let query_engine =
+            crate::ontology::OntologyQueryEngine::new(self.graph_engine.db().clone());
+
+        let steps = query_engine
+            .trace_workflow(workflow_query, env)
+            .map_err(|e| format!("Failed to trace workflow: {}", e))?;
+
+        let step_info: Vec<serde_json::Value> = steps
+            .iter()
+            .map(|s| {
+                json!({
+                    "gid": s.gid,
+                    "name": s.name,
+                    "order": s.order,
+                    "description": s.description,
+                    "code_refs": s.metadata.code_refs,
+                    "failure_modes": s.metadata.failure_modes,
+                })
+            })
+            .collect();
+
+        Ok(json!({
+            "workflow_query": workflow_query,
+            "steps": step_info,
+            "step_count": steps.len(),
+        }))
+    }
+
+    fn kg_ontology_status(&self, _args: &Value) -> Result<Value, String> {
+        let query_engine =
+            crate::ontology::OntologyQueryEngine::new(self.graph_engine.db().clone());
+
+        let status = query_engine
+            .get_ontology_status()
+            .map_err(|e| format!("Failed to get ontology status: {}", e))?;
+
+        Ok(json!({
+            "concept_counts": status.concept_counts,
+            "procedural_counts": status.procedural_counts,
+            "total_aliases": status.total_aliases,
+            "nodes_missing_aliases": status.nodes_missing_aliases,
+            "workflows_without_failure_modes": status.workflows_without_failure_modes,
         }))
     }
 

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -736,6 +736,59 @@ impl ToolRegistry {
                     "required": []
                 }),
             },
+
+            // Ontology Semantic Search Tools
+            ToolDefinition {
+                name: "kg_context".to_string(),
+                description: "Get ontology-aware context for a semantic query. Returns matched concept nodes, expanded code context, workflows, docs, tests, and confidence scores. Use for agentic semantic questions like 'where is checkout refund failure handled?'".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Natural language query (e.g., 'checkout refund failure')"},
+                        "env": {"type": "string", "enum": ["local", "staging", "production"], "default": "local", "description": "Environment to search"},
+                        "depth": {"type": "integer", "default": 2, "description": "Expansion depth (default: 2)"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["query"]
+                }),
+            },
+            ToolDefinition {
+                name: "kg_concept_map".to_string(),
+                description: "Get a compact concept neighborhood for a domain, service, or feature. Useful for feature onboarding, impact analysis before edits, and understanding ownership boundaries.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string", "description": "Concept or service name to map"},
+                        "env": {"type": "string", "enum": ["local", "staging", "production"], "default": "local", "description": "Environment"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["query"]
+                }),
+            },
+            ToolDefinition {
+                name: "kg_trace_workflow".to_string(),
+                description: "Get an ordered procedural trace for a workflow. Useful for debugging user flows, understanding what code runs before/after a step, and identifying missing tests or failure handling.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "workflow_id_or_query": {"type": "string", "description": "Workflow name, ID, or search query"},
+                        "env": {"type": "string", "enum": ["local", "staging", "production"], "default": "local", "description": "Environment"},
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": ["workflow_id_or_query"]
+                }),
+            },
+            ToolDefinition {
+                name: "kg_ontology_status".to_string(),
+                description: "Get ontology coverage status: counts of concept and procedural nodes by type, relationships by type, nodes missing aliases, and workflows without failure modes.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "project": {"type": "string", "description": "Optional: project path"}
+                    },
+                    "required": []
+                }),
+            },
         ]
     }
 }

--- a/src/ontology/concept.rs
+++ b/src/ontology/concept.rs
@@ -1,0 +1,377 @@
+//! Concept Ontology Module
+//!
+//! Concept ontology nodes describe domain entities, services, APIs, data stores,
+//! environments, known issues, and knowledge artifacts.
+
+use super::{normalize_alias, OntologyGid};
+use serde::{Deserialize, Serialize};
+
+/// Concept element types for the domain layer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConceptElementType {
+    DomainEntity,
+    Service,
+    ApiEndpoint,
+    DataStore,
+    Environment,
+    KnownIssue,
+    Playbook,
+    TeamKnowledge,
+}
+
+impl ConceptElementType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConceptElementType::DomainEntity => "domain_entity",
+            ConceptElementType::Service => "service",
+            ConceptElementType::ApiEndpoint => "api_endpoint",
+            ConceptElementType::DataStore => "data_store",
+            ConceptElementType::Environment => "environment",
+            ConceptElementType::KnownIssue => "known_issue",
+            ConceptElementType::Playbook => "playbook",
+            ConceptElementType::TeamKnowledge => "team_knowledge",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "domain_entity" => Some(Self::DomainEntity),
+            "service" => Some(Self::Service),
+            "api_endpoint" => Some(Self::ApiEndpoint),
+            "data_store" => Some(Self::DataStore),
+            "environment" => Some(Self::Environment),
+            "known_issue" => Some(Self::KnownIssue),
+            "playbook" => Some(Self::Playbook),
+            "team_knowledge" => Some(Self::TeamKnowledge),
+            _ => None,
+        }
+    }
+}
+
+/// Concept relationship types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ConceptRelationshipType {
+    OwnsConcept,
+    ImplementsConcept,
+    ExposesEndpoint,
+    ReadsFrom,
+    WritesTo,
+    DocumentsConcept,
+    HasKnownIssue,
+    ResolvedByPlaybook,
+}
+
+impl ConceptRelationshipType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ConceptRelationshipType::OwnsConcept => "owns_concept",
+            ConceptRelationshipType::ImplementsConcept => "implements_concept",
+            ConceptRelationshipType::ExposesEndpoint => "exposes_endpoint",
+            ConceptRelationshipType::ReadsFrom => "reads_from",
+            ConceptRelationshipType::WritesTo => "writes_to",
+            ConceptRelationshipType::DocumentsConcept => "documents_concept",
+            ConceptRelationshipType::HasKnownIssue => "has_known_issue",
+            ConceptRelationshipType::ResolvedByPlaybook => "resolved_by_playbook",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "owns_concept" => Some(Self::OwnsConcept),
+            "implements_concept" => Some(Self::ImplementsConcept),
+            "exposes_endpoint" => Some(Self::ExposesEndpoint),
+            "reads_from" => Some(Self::ReadsFrom),
+            "writes_to" => Some(Self::WritesTo),
+            "documents_concept" => Some(Self::DocumentsConcept),
+            "has_known_issue" => Some(Self::HasKnownIssue),
+            "resolved_by_playbook" => Some(Self::ResolvedByPlaybook),
+            _ => None,
+        }
+    }
+}
+
+/// Metadata contract for concept ontology nodes
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptMetadata {
+    pub gid: String,
+    pub ontology: String,
+    pub ontology_layer: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: String,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub valid_from: Option<String>,
+    #[serde(default)]
+    pub valid_until: Option<String>,
+    #[serde(default)]
+    pub owned_by: Vec<String>,
+    #[serde(default)]
+    pub code_refs: Vec<String>,
+    #[serde(default)]
+    pub docs: Vec<String>,
+    #[serde(default)]
+    pub stale: bool,
+    #[serde(default)]
+    pub stale_reason: Option<String>,
+    #[serde(default)]
+    pub last_seen_at: Option<String>,
+}
+
+impl ConceptMetadata {
+    pub fn new(
+        env: &str,
+        scope: &str,
+        element_type: &str,
+        id: &str,
+        name: &str,
+        description: &str,
+    ) -> Self {
+        let gid = OntologyGid {
+            env: env.to_string(),
+            scope: scope.to_string(),
+            ontology_type: element_type.to_string(),
+            id: id.to_string(),
+            version: "v1".to_string(),
+        }
+        .to_string();
+
+        Self {
+            gid,
+            ontology: "concept".to_string(),
+            ontology_layer: "domain".to_string(),
+            aliases: vec![normalize_alias(name)],
+            description: description.to_string(),
+            source: None,
+            valid_from: None,
+            valid_until: None,
+            owned_by: Vec::new(),
+            code_refs: Vec::new(),
+            docs: Vec::new(),
+            stale: false,
+            stale_reason: None,
+            last_seen_at: None,
+        }
+    }
+
+    pub fn with_aliases(mut self, aliases: Vec<String>) -> Self {
+        let normalized: Vec<String> = aliases.iter().map(|a| normalize_alias(a)).collect();
+        self.aliases.extend(normalized);
+        self
+    }
+
+    pub fn with_source(mut self, source: &str) -> Self {
+        self.source = Some(source.to_string());
+        self
+    }
+
+    pub fn with_owned_by(mut self, owners: Vec<String>) -> Self {
+        self.owned_by = owners;
+        self
+    }
+
+    pub fn with_code_refs(mut self, refs: Vec<String>) -> Self {
+        self.code_refs = refs;
+        self
+    }
+
+    pub fn with_docs(mut self, docs: Vec<String>) -> Self {
+        self.docs = docs;
+        self
+    }
+}
+
+/// Concept node structure for graph insertion
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptNode {
+    pub gid: String,
+    pub name: String,
+    pub element_type: String,
+    pub aliases: Vec<String>,
+    pub description: String,
+    pub env: String,
+    pub metadata: ConceptMetadata,
+}
+
+impl ConceptNode {
+    pub fn new(
+        env: &str,
+        scope: &str,
+        element_type: ConceptElementType,
+        id: &str,
+        name: &str,
+        description: &str,
+    ) -> Self {
+        let element_type_str = element_type.as_str();
+        let metadata = ConceptMetadata::new(env, scope, element_type_str, id, name, description);
+
+        Self {
+            gid: metadata.gid.clone(),
+            name: name.to_string(),
+            element_type: element_type_str.to_string(),
+            aliases: metadata.aliases.clone(),
+            description: description.to_string(),
+            env: env.to_string(),
+            metadata,
+        }
+    }
+
+    pub fn domain_entity(env: &str, scope: &str, id: &str, name: &str, description: &str) -> Self {
+        Self::new(
+            env,
+            scope,
+            ConceptElementType::DomainEntity,
+            id,
+            name,
+            description,
+        )
+    }
+
+    pub fn service(env: &str, scope: &str, id: &str, name: &str, description: &str) -> Self {
+        Self::new(
+            env,
+            scope,
+            ConceptElementType::Service,
+            id,
+            name,
+            description,
+        )
+    }
+
+    pub fn api_endpoint(env: &str, scope: &str, id: &str, name: &str, description: &str) -> Self {
+        Self::new(
+            env,
+            scope,
+            ConceptElementType::ApiEndpoint,
+            id,
+            name,
+            description,
+        )
+    }
+
+    pub fn data_store(env: &str, scope: &str, id: &str, name: &str, description: &str) -> Self {
+        Self::new(
+            env,
+            scope,
+            ConceptElementType::DataStore,
+            id,
+            name,
+            description,
+        )
+    }
+
+    pub fn known_issue(env: &str, scope: &str, id: &str, name: &str, description: &str) -> Self {
+        Self::new(
+            env,
+            scope,
+            ConceptElementType::KnownIssue,
+            id,
+            name,
+            description,
+        )
+    }
+
+    pub fn playbook(env: &str, scope: &str, id: &str, name: &str, description: &str) -> Self {
+        Self::new(
+            env,
+            scope,
+            ConceptElementType::Playbook,
+            id,
+            name,
+            description,
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_concept_element_type_as_str() {
+        assert_eq!(ConceptElementType::DomainEntity.as_str(), "domain_entity");
+        assert_eq!(ConceptElementType::Service.as_str(), "service");
+        assert_eq!(ConceptElementType::ApiEndpoint.as_str(), "api_endpoint");
+        assert_eq!(ConceptElementType::DataStore.as_str(), "data_store");
+        assert_eq!(ConceptElementType::KnownIssue.as_str(), "known_issue");
+        assert_eq!(ConceptElementType::Playbook.as_str(), "playbook");
+    }
+
+    #[test]
+    fn test_concept_element_type_from_str() {
+        assert_eq!(
+            ConceptElementType::from_str("domain_entity"),
+            Some(ConceptElementType::DomainEntity)
+        );
+        assert_eq!(
+            ConceptElementType::from_str("service"),
+            Some(ConceptElementType::Service)
+        );
+        assert_eq!(ConceptElementType::from_str("unknown"), None);
+    }
+
+    #[test]
+    fn test_concept_relationship_type_roundtrip() {
+        assert_eq!(
+            ConceptRelationshipType::OwnsConcept.as_str(),
+            "owns_concept"
+        );
+        assert_eq!(
+            ConceptRelationshipType::from_str("owns_concept"),
+            Some(ConceptRelationshipType::OwnsConcept)
+        );
+        assert_eq!(
+            ConceptRelationshipType::from_str("implements_concept"),
+            Some(ConceptRelationshipType::ImplementsConcept)
+        );
+    }
+
+    #[test]
+    fn test_concept_metadata_new() {
+        let meta = ConceptMetadata::new(
+            "local",
+            "checkout-service",
+            "domain_entity",
+            "refund",
+            "Refund",
+            "Money returned to customer",
+        );
+        assert_eq!(meta.gid, "local:checkout-service:domain_entity:refund:v1");
+        assert_eq!(meta.ontology, "concept");
+        assert_eq!(meta.ontology_layer, "domain");
+        assert!(meta.aliases.contains(&"refund".to_string()));
+    }
+
+    #[test]
+    fn test_concept_metadata_with_aliases() {
+        let meta = ConceptMetadata::new(
+            "local",
+            "checkout-service",
+            "domain_entity",
+            "refund",
+            "Refund",
+            "Money returned to customer",
+        )
+        .with_aliases(vec!["reversal".to_string(), "chargeback".to_string()]);
+
+        assert!(meta.aliases.contains(&"reversal".to_string()));
+        assert!(meta.aliases.contains(&"chargeback".to_string()));
+    }
+
+    #[test]
+    fn test_concept_node_creation() {
+        let node = ConceptNode::domain_entity(
+            "local",
+            "checkout-service",
+            "refund",
+            "Refund",
+            "Money returned to customer after payment capture",
+        );
+        assert_eq!(node.gid, "local:checkout-service:domain_entity:refund:v1");
+        assert_eq!(node.element_type, "domain_entity");
+        assert_eq!(node.name, "Refund");
+    }
+}

--- a/src/ontology/loader.rs
+++ b/src/ontology/loader.rs
@@ -1,0 +1,486 @@
+//! Ontology YAML Loader
+//!
+//! Loads concept and workflow definitions from YAML files.
+
+use crate::db::models::{CodeElement, Relationship};
+use crate::ontology::concept::{ConceptMetadata, ConceptNode};
+use crate::ontology::procedural::{
+    FailureModeNode, WorkflowMetadata, WorkflowNode, WorkflowStepNode,
+};
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use tracing::warn;
+
+/// Root structure for concepts.yaml
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptsYaml {
+    pub concepts: Vec<ConceptDef>,
+}
+
+/// A concept definition from YAML
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ConceptDef {
+    pub id: String,
+    #[serde(default)]
+    pub type_: String,
+    pub name: String,
+    #[serde(default = "default_env")]
+    pub env: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: String,
+    #[serde(default)]
+    pub owned_by: Vec<String>,
+    #[serde(default)]
+    pub code_refs: Vec<String>,
+    #[serde(default)]
+    pub docs: Vec<String>,
+}
+
+/// Root structure for workflows.yaml
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowsYaml {
+    pub workflows: Vec<WorkflowDef>,
+}
+
+/// A workflow definition from YAML
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowDef {
+    pub id: String,
+    pub name: String,
+    #[serde(default = "default_env")]
+    pub env: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: String,
+    #[serde(default)]
+    pub entry_points: Vec<String>,
+    #[serde(default)]
+    pub steps: Vec<WorkflowStepDef>,
+}
+
+/// A workflow step definition
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowStepDef {
+    pub id: String,
+    pub name: String,
+    #[serde(default)]
+    pub code_refs: Vec<String>,
+    #[serde(default)]
+    pub failure_modes: Vec<String>,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+}
+
+/// Root structure for aliases.yaml
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AliasesYaml {
+    pub aliases: Vec<AliasDef>,
+}
+
+/// An alias definition
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AliasDef {
+    pub gid: String,
+    pub alias: String,
+}
+
+fn default_env() -> String {
+    "local".to_string()
+}
+
+/// Result of loading ontology from YAML
+#[derive(Debug, Clone, Default)]
+pub struct OntologyLoadResult {
+    pub concept_nodes: Vec<ConceptNode>,
+    pub workflow_nodes: Vec<WorkflowNode>,
+    pub workflow_step_nodes: Vec<WorkflowStepNode>,
+    pub failure_mode_nodes: Vec<FailureModeNode>,
+    pub relationships: Vec<Relationship>,
+    pub code_refs_resolved: usize,
+    pub code_refs_total: usize,
+    pub stale_nodes: Vec<String>,
+}
+
+impl OntologyLoadResult {
+    pub fn summary(&self) -> String {
+        format!(
+            "Ontology load complete\nConcept nodes: {}\nWorkflow nodes: {}\nWorkflow steps: {}\nFailure modes: {}\nAliases resolved: {}/{}\nStale nodes: {}",
+            self.concept_nodes.len(),
+            self.workflow_nodes.len(),
+            self.workflow_step_nodes.len(),
+            self.failure_mode_nodes.len(),
+            self.code_refs_resolved,
+            self.code_refs_total,
+            self.stale_nodes.len()
+        )
+    }
+}
+
+/// Load concept ontology from YAML file
+pub fn load_concepts_yaml(
+    path: &Path,
+) -> Result<Vec<ConceptNode>, Box<dyn std::error::Error + Send + Sync>> {
+    let content = std::fs::read_to_string(path)?;
+    let yaml: ConceptsYaml = serde_yaml::from_str(&content)?;
+
+    let mut nodes = Vec::new();
+    for concept_def in yaml.concepts {
+        let element_type = match concept_def.type_.as_str() {
+            "domain_entity" => "domain_entity",
+            "service" => "service",
+            "api_endpoint" => "api_endpoint",
+            "data_store" => "data_store",
+            "environment" => "environment",
+            "known_issue" => "known_issue",
+            "playbook" => "playbook",
+            "team_knowledge" => "team_knowledge",
+            other => {
+                warn!(
+                    "Unknown concept type '{}', defaulting to domain_entity",
+                    other
+                );
+                "domain_entity"
+            }
+        };
+
+        let scope = concept_def
+            .owned_by
+            .first()
+            .cloned()
+            .unwrap_or_else(|| "default".to_string());
+
+        let mut metadata = ConceptMetadata::new(
+            &concept_def.env,
+            &scope,
+            element_type,
+            &concept_def.id,
+            &concept_def.name,
+            &concept_def.description,
+        );
+        metadata = metadata.with_aliases(concept_def.aliases);
+        metadata = metadata.with_source(path.to_str().unwrap_or("unknown"));
+        metadata = metadata.with_owned_by(concept_def.owned_by);
+        metadata = metadata.with_code_refs(concept_def.code_refs.clone());
+        metadata = metadata.with_docs(concept_def.docs);
+
+        let node = ConceptNode {
+            gid: metadata.gid.clone(),
+            name: concept_def.name,
+            element_type: element_type.to_string(),
+            aliases: metadata.aliases.clone(),
+            description: concept_def.description,
+            env: concept_def.env,
+            metadata,
+        };
+
+        nodes.push(node);
+    }
+
+    Ok(nodes)
+}
+
+/// Load workflow ontology from YAML file
+#[allow(clippy::type_complexity)]
+pub fn load_workflows_yaml(
+    path: &Path,
+) -> Result<
+    (
+        Vec<WorkflowNode>,
+        Vec<WorkflowStepNode>,
+        Vec<FailureModeNode>,
+        Vec<Relationship>,
+    ),
+    Box<dyn std::error::Error + Send + Sync>,
+> {
+    let content = std::fs::read_to_string(path)?;
+    let yaml: WorkflowsYaml = serde_yaml::from_str(&content)?;
+
+    let mut workflow_nodes = Vec::new();
+    let mut step_nodes = Vec::new();
+    let mut failure_nodes = Vec::new();
+    let mut relationships = Vec::new();
+
+    for workflow_def in yaml.workflows {
+        let scope = "default".to_string();
+
+        // Create workflow node
+        let mut metadata = WorkflowMetadata::new(
+            &workflow_def.env,
+            &scope,
+            &workflow_def.id,
+            &workflow_def.name,
+            &workflow_def.description,
+        );
+        metadata = metadata.with_entry_points(workflow_def.entry_points.clone());
+        metadata = metadata.with_step_count(workflow_def.steps.len());
+        metadata = metadata.with_source(path.to_str().unwrap_or("unknown"));
+
+        let workflow_node = WorkflowNode {
+            gid: metadata.gid.clone(),
+            name: workflow_def.name.clone(),
+            element_type: "workflow".to_string(),
+            aliases: metadata.aliases.clone(),
+            description: workflow_def.description,
+            env: workflow_def.env.clone(),
+            metadata,
+        };
+        workflow_nodes.push(workflow_node.clone());
+
+        // Create step nodes and relationships
+        for (order, step_def) in workflow_def.steps.iter().enumerate() {
+            let step_node = WorkflowStepNode::new(
+                &workflow_def.env,
+                &scope,
+                &workflow_def.id,
+                &step_def.id,
+                &step_def.name,
+                order + 1,
+                "", // steps don't have separate descriptions in current format
+            )
+            .with_code_refs(step_def.code_refs.clone())
+            .with_failure_modes(step_def.failure_modes.clone());
+
+            step_nodes.push(step_node.clone());
+
+            // has_step relationship: workflow -> workflow_step
+            relationships.push(Relationship {
+                id: None,
+                source_qualified: workflow_node.gid.clone(),
+                target_qualified: step_node.gid.clone(),
+                rel_type: "has_step".to_string(),
+                confidence: 1.0,
+                metadata: serde_json::json!({}),
+                env: workflow_def.env.clone(),
+            });
+
+            // next_step relationship: step -> step (if not last)
+            if order > 0 {
+                let prev_step = &step_nodes[step_nodes.len() - 2];
+                relationships.push(Relationship {
+                    id: None,
+                    source_qualified: prev_step.gid.clone(),
+                    target_qualified: step_node.gid.clone(),
+                    rel_type: "next_step".to_string(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({}),
+                    env: workflow_def.env.clone(),
+                });
+            }
+
+            // Create failure mode nodes
+            for failure_id in &step_def.failure_modes {
+                let failure_node = FailureModeNode::new(
+                    &workflow_def.env,
+                    &scope,
+                    failure_id,
+                    failure_id,
+                    &format!("Failure mode: {}", failure_id),
+                );
+                failure_nodes.push(failure_node.clone());
+
+                // has_failure_mode: step -> failure_mode
+                relationships.push(Relationship {
+                    id: None,
+                    source_qualified: step_node.gid.clone(),
+                    target_qualified: failure_node.gid.clone(),
+                    rel_type: "has_failure_mode".to_string(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({}),
+                    env: workflow_def.env.clone(),
+                });
+            }
+        }
+    }
+
+    Ok((workflow_nodes, step_nodes, failure_nodes, relationships))
+}
+
+/// Load aliases from YAML file
+pub fn load_aliases_yaml(
+    path: &Path,
+) -> Result<Vec<(String, String)>, Box<dyn std::error::Error + Send + Sync>> {
+    let content = std::fs::read_to_string(path)?;
+    let yaml: AliasesYaml = serde_yaml::from_str(&content)?;
+
+    Ok(yaml.aliases.into_iter().map(|a| (a.gid, a.alias)).collect())
+}
+
+/// Convert ontology nodes to CodeElements for graph storage
+pub fn concept_nodes_to_elements(nodes: &[ConceptNode]) -> Vec<CodeElement> {
+    nodes
+        .iter()
+        .map(|node| CodeElement {
+            qualified_name: node.gid.clone(),
+            element_type: node.element_type.clone(),
+            name: node.name.clone(),
+            file_path: format!("ontology://{}", node.gid),
+            line_start: 0,
+            line_end: 0,
+            language: "ontology".to_string(),
+            parent_qualified: None,
+            cluster_id: None,
+            cluster_label: None,
+            metadata: serde_json::to_value(&node.metadata).unwrap_or_default(),
+            env: node.env.clone(),
+        })
+        .collect()
+}
+
+/// Convert workflow nodes to CodeElements
+pub fn workflow_nodes_to_elements(nodes: &[WorkflowNode]) -> Vec<CodeElement> {
+    nodes
+        .iter()
+        .map(|node| CodeElement {
+            qualified_name: node.gid.clone(),
+            element_type: node.element_type.clone(),
+            name: node.name.clone(),
+            file_path: format!("ontology://{}", node.gid),
+            line_start: 0,
+            line_end: 0,
+            language: "ontology".to_string(),
+            parent_qualified: None,
+            cluster_id: None,
+            cluster_label: None,
+            metadata: serde_json::to_value(&node.metadata).unwrap_or_default(),
+            env: node.env.clone(),
+        })
+        .collect()
+}
+
+/// Convert workflow step nodes to CodeElements
+pub fn workflow_step_nodes_to_elements(nodes: &[WorkflowStepNode]) -> Vec<CodeElement> {
+    nodes
+        .iter()
+        .map(|node| CodeElement {
+            qualified_name: node.gid.clone(),
+            element_type: node.element_type.clone(),
+            name: node.name.clone(),
+            file_path: format!("ontology://{}", node.gid),
+            line_start: 0,
+            line_end: 0,
+            language: "ontology".to_string(),
+            parent_qualified: Some(node.workflow_gid.clone()),
+            cluster_id: None,
+            cluster_label: None,
+            metadata: serde_json::to_value(&node.metadata).unwrap_or_default(),
+            env: node.env.clone(),
+        })
+        .collect()
+}
+
+/// Convert failure mode nodes to CodeElements
+pub fn failure_mode_nodes_to_elements(nodes: &[FailureModeNode]) -> Vec<CodeElement> {
+    nodes
+        .iter()
+        .map(|node| CodeElement {
+            qualified_name: node.gid.clone(),
+            element_type: node.element_type.clone(),
+            name: node.name.clone(),
+            file_path: format!("ontology://{}", node.gid),
+            line_start: 0,
+            line_end: 0,
+            language: "ontology".to_string(),
+            parent_qualified: None,
+            cluster_id: None,
+            cluster_label: None,
+            metadata: serde_json::to_value(&node.metadata).unwrap_or_default(),
+            env: node.env.clone(),
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use tempfile::NamedTempFile;
+
+    #[test]
+    fn test_load_concepts_yaml() {
+        let yaml_content = r#"
+concepts:
+  - id: refund
+    type: domain_entity
+    name: Refund
+    env: local
+    aliases:
+      - reversal
+      - chargeback
+    description: Money returned to customer
+    owned_by:
+      - checkout-service
+    code_refs:
+      - src/refund/handler.rs
+    docs:
+      - docs/refund.md
+"#;
+
+        let mut temp_file = NamedTempFile::with_suffix(".yaml").unwrap();
+        temp_file.write_all(yaml_content.as_bytes()).unwrap();
+
+        let nodes = load_concepts_yaml(temp_file.path()).unwrap();
+        assert_eq!(nodes.len(), 1);
+        assert_eq!(
+            nodes[0].gid,
+            "local:checkout-service:domain_entity:refund:v1"
+        );
+        assert_eq!(nodes[0].name, "Refund");
+    }
+
+    #[test]
+    fn test_load_workflows_yaml() {
+        let yaml_content = r#"
+workflows:
+  - id: checkout
+    name: Checkout
+    env: local
+    aliases:
+      - place order
+    description: End-to-end checkout
+    entry_points:
+      - src/checkout/handler.rs::create_order
+    steps:
+      - id: create_order
+        name: Create Order
+        code_refs:
+          - src/order/service.rs::create
+      - id: authorize_payment
+        name: Authorize Payment
+        code_refs:
+          - src/payment/client.rs::authorize
+        failure_modes:
+          - payment_timeout
+"#;
+
+        let mut temp_file = NamedTempFile::with_suffix(".yaml").unwrap();
+        temp_file.write_all(yaml_content.as_bytes()).unwrap();
+
+        let (workflows, steps, failures, relationships) =
+            load_workflows_yaml(temp_file.path()).unwrap();
+        assert_eq!(workflows.len(), 1);
+        assert_eq!(workflows[0].name, "Checkout");
+        assert_eq!(steps.len(), 2);
+        assert_eq!(failures.len(), 1);
+        assert!(relationships.len() >= 3); // has_step + next_step + has_failure_mode
+    }
+
+    #[test]
+    fn test_concept_nodes_to_elements() {
+        let node = ConceptNode::domain_entity(
+            "local",
+            "checkout-service",
+            "refund",
+            "Refund",
+            "Money returned to customer",
+        );
+
+        let elements = concept_nodes_to_elements(&[node]);
+        assert_eq!(elements.len(), 1);
+        assert_eq!(
+            elements[0].qualified_name,
+            "local:checkout-service:domain_entity:refund:v1"
+        );
+        assert_eq!(elements[0].element_type, "domain_entity");
+    }
+}

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -1,0 +1,170 @@
+pub mod concept;
+pub mod loader;
+pub mod procedural;
+pub mod query;
+
+// Re-export for convenience
+#[allow(unused_imports)]
+pub use concept::{ConceptElementType, ConceptMetadata, ConceptNode};
+#[allow(unused_imports)]
+pub use loader::{
+    concept_nodes_to_elements, failure_mode_nodes_to_elements, load_aliases_yaml,
+    load_concepts_yaml, load_workflows_yaml, workflow_nodes_to_elements,
+    workflow_step_nodes_to_elements,
+};
+#[allow(unused_imports)]
+pub use procedural::{
+    FailureModeMetadata, FailureModeNode, ProceduralElementType, WorkflowMetadata, WorkflowNode,
+    WorkflowStepMetadata, WorkflowStepNode,
+};
+#[allow(unused_imports)]
+pub use query::{calculate_match_score, OntologyQueryEngine, OntologyStatus};
+
+use serde::{Deserialize, Serialize};
+
+/// Ontology layer types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum OntologyLayer {
+    Domain,
+    Procedural,
+}
+
+impl OntologyLayer {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            OntologyLayer::Domain => "domain",
+            OntologyLayer::Procedural => "procedural",
+        }
+    }
+}
+
+/// Stable Global ID for ontology nodes
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OntologyGid {
+    pub env: String,
+    pub scope: String,
+    pub ontology_type: String,
+    pub id: String,
+    pub version: String,
+}
+
+impl OntologyGid {
+    /// Parse a GID string like "local:checkout-service:domain_entity:refund:v1"
+    pub fn parse(s: &str) -> Option<Self> {
+        let parts: Vec<&str> = s.split(':').collect();
+        if parts.len() != 5 {
+            return None;
+        }
+        Some(Self {
+            env: parts[0].to_string(),
+            scope: parts[1].to_string(),
+            ontology_type: parts[2].to_string(),
+            id: parts[3].to_string(),
+            version: parts[4].to_string(),
+        })
+    }
+
+    /// Format GID string
+    pub fn to_gid_string(&self) -> String {
+        format!(
+            "{}:{}:{}:{}:{}",
+            self.env, self.scope, self.ontology_type, self.id, self.version
+        )
+    }
+}
+
+impl std::fmt::Display for OntologyGid {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "{}:{}:{}:{}:{}",
+            self.env, self.scope, self.ontology_type, self.id, self.version
+        )
+    }
+}
+
+/// Alias normalization helper
+pub fn normalize_alias(alias: &str) -> String {
+    alias
+        .to_lowercase()
+        .trim()
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == ' ' || *c == '-' || *c == '_')
+        .collect::<String>()
+}
+
+/// Normalize multiple aliases
+pub fn normalize_aliases(aliases: &[String]) -> Vec<String> {
+    aliases.iter().map(|a| normalize_alias(a)).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_ontology_gid_parse() {
+        let gid = OntologyGid::parse("local:checkout-service:domain_entity:refund:v1").unwrap();
+        assert_eq!(gid.env, "local");
+        assert_eq!(gid.scope, "checkout-service");
+        assert_eq!(gid.ontology_type, "domain_entity");
+        assert_eq!(gid.id, "refund");
+        assert_eq!(gid.version, "v1");
+    }
+
+    #[test]
+    fn test_ontology_gid_roundtrip() {
+        let gid = OntologyGid::parse("local:checkout-service:domain_entity:refund:v1").unwrap();
+        assert_eq!(
+            gid.to_string(),
+            "local:checkout-service:domain_entity:refund:v1"
+        );
+    }
+
+    #[test]
+    fn test_normalize_alias() {
+        assert_eq!(normalize_alias("  Refund  "), "refund");
+        assert_eq!(normalize_alias("Money Back"), "money back");
+        assert_eq!(normalize_alias("charge-back"), "charge-back");
+    }
+
+    #[test]
+    fn test_calculate_match_score_exact_name() {
+        let (score, reason) = calculate_match_score("refund", "Refund", &[], "Money back");
+        assert_eq!(score, 1.0);
+        assert!(reason.contains("exact name match"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_name_contains() {
+        let (score, reason) = calculate_match_score("refund", "RefundPolicy", &[], "");
+        assert_eq!(score, 0.8);
+        assert!(reason.contains("name contains"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_alias_match() {
+        let (score, reason) = calculate_match_score(
+            "reversal",
+            "Refund",
+            &["reversal".to_string(), "chargeback".to_string()],
+            "",
+        );
+        assert_eq!(score, 0.9);
+        assert!(reason.contains("exact alias match"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_description() {
+        let (score, reason) = calculate_match_score("payment", "Refund", &[], "Money payment back");
+        assert_eq!(score, 0.5);
+        assert!(reason.contains("description contains"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_no_match() {
+        let (score, reason) = calculate_match_score("xyz", "Refund", &[], "");
+        assert_eq!(score, 0.0);
+        assert!(reason.is_empty());
+    }
+}

--- a/src/ontology/procedural.rs
+++ b/src/ontology/procedural.rs
@@ -1,0 +1,522 @@
+//! Procedural Ontology Module
+//!
+//! Procedural ontology nodes describe workflows, execution steps, decision points,
+//! failure modes, and playbooks.
+
+use super::{normalize_alias, OntologyGid};
+use serde::{Deserialize, Serialize};
+
+/// Procedural element types for the procedural layer
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProceduralElementType {
+    Workflow,
+    WorkflowStep,
+    DecisionPoint,
+    FailureMode,
+    PlaybookStep,
+}
+
+impl ProceduralElementType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ProceduralElementType::Workflow => "workflow",
+            ProceduralElementType::WorkflowStep => "workflow_step",
+            ProceduralElementType::DecisionPoint => "decision_point",
+            ProceduralElementType::FailureMode => "failure_mode",
+            ProceduralElementType::PlaybookStep => "playbook_step",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "workflow" => Some(Self::Workflow),
+            "workflow_step" => Some(Self::WorkflowStep),
+            "decision_point" => Some(Self::DecisionPoint),
+            "failure_mode" => Some(Self::FailureMode),
+            "playbook_step" => Some(Self::PlaybookStep),
+            _ => None,
+        }
+    }
+}
+
+/// Procedural relationship types
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ProceduralRelationshipType {
+    HasStep,
+    NextStep,
+    BranchesTo,
+    ImplementedBy,
+    HasFailureMode,
+    HandledByPlaybook,
+}
+
+impl ProceduralRelationshipType {
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            ProceduralRelationshipType::HasStep => "has_step",
+            ProceduralRelationshipType::NextStep => "next_step",
+            ProceduralRelationshipType::BranchesTo => "branches_to",
+            ProceduralRelationshipType::ImplementedBy => "implemented_by",
+            ProceduralRelationshipType::HasFailureMode => "has_failure_mode",
+            ProceduralRelationshipType::HandledByPlaybook => "handled_by_playbook",
+        }
+    }
+
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "has_step" => Some(Self::HasStep),
+            "next_step" => Some(Self::NextStep),
+            "branches_to" => Some(Self::BranchesTo),
+            "implemented_by" => Some(Self::ImplementedBy),
+            "has_failure_mode" => Some(Self::HasFailureMode),
+            "handled_by_playbook" => Some(Self::HandledByPlaybook),
+            _ => None,
+        }
+    }
+}
+
+/// Metadata contract for workflow nodes
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkflowMetadata {
+    pub gid: String,
+    pub ontology: String,
+    pub ontology_layer: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: String,
+    #[serde(default)]
+    pub entry_points: Vec<String>,
+    #[serde(default)]
+    pub step_count: Option<usize>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub valid_from: Option<String>,
+    #[serde(default)]
+    pub valid_until: Option<String>,
+    #[serde(default)]
+    pub stale: bool,
+    #[serde(default)]
+    pub stale_reason: Option<String>,
+    #[serde(default)]
+    pub last_seen_at: Option<String>,
+}
+
+impl WorkflowMetadata {
+    pub fn new(env: &str, scope: &str, workflow_id: &str, name: &str, description: &str) -> Self {
+        let gid = OntologyGid {
+            env: env.to_string(),
+            scope: scope.to_string(),
+            ontology_type: "workflow".to_string(),
+            id: workflow_id.to_string(),
+            version: "v1".to_string(),
+        }
+        .to_string();
+
+        Self {
+            gid,
+            ontology: "procedural".to_string(),
+            ontology_layer: "procedural".to_string(),
+            aliases: vec![normalize_alias(name)],
+            description: description.to_string(),
+            entry_points: Vec::new(),
+            step_count: None,
+            source: None,
+            valid_from: None,
+            valid_until: None,
+            stale: false,
+            stale_reason: None,
+            last_seen_at: None,
+        }
+    }
+
+    pub fn with_entry_points(mut self, entry_points: Vec<String>) -> Self {
+        self.entry_points = entry_points;
+        self
+    }
+
+    pub fn with_step_count(mut self, count: usize) -> Self {
+        self.step_count = Some(count);
+        self
+    }
+
+    pub fn with_source(mut self, source: &str) -> Self {
+        self.source = Some(source.to_string());
+        self
+    }
+}
+
+/// Metadata contract for workflow step nodes
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct WorkflowStepMetadata {
+    pub gid: String,
+    pub ontology: String,
+    pub ontology_layer: String,
+    pub workflow_gid: String,
+    pub order: usize,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: String,
+    #[serde(default)]
+    pub code_refs: Vec<String>,
+    #[serde(default)]
+    pub failure_modes: Vec<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub stale: bool,
+    #[serde(default)]
+    pub stale_reason: Option<String>,
+    #[serde(default)]
+    pub last_seen_at: Option<String>,
+}
+
+impl WorkflowStepMetadata {
+    pub fn new(
+        env: &str,
+        scope: &str,
+        workflow_id: &str,
+        step_id: &str,
+        order: usize,
+        description: &str,
+    ) -> Self {
+        let gid = OntologyGid {
+            env: env.to_string(),
+            scope: scope.to_string(),
+            ontology_type: "workflow_step".to_string(),
+            id: step_id.to_string(),
+            version: "v1".to_string(),
+        }
+        .to_string();
+
+        Self {
+            gid,
+            ontology: "procedural".to_string(),
+            ontology_layer: "procedural".to_string(),
+            workflow_gid: format!("{}:{}:{}:{}:{}", env, scope, "workflow", workflow_id, "v1"),
+            order,
+            aliases: Vec::new(),
+            description: description.to_string(),
+            code_refs: Vec::new(),
+            failure_modes: Vec::new(),
+            source: None,
+            stale: false,
+            stale_reason: None,
+            last_seen_at: None,
+        }
+    }
+
+    pub fn with_code_refs(mut self, refs: Vec<String>) -> Self {
+        self.code_refs = refs;
+        self
+    }
+
+    pub fn with_failure_modes(mut self, modes: Vec<String>) -> Self {
+        self.failure_modes = modes;
+        self
+    }
+}
+
+/// Workflow node structure for graph insertion
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowNode {
+    pub gid: String,
+    pub name: String,
+    pub element_type: String,
+    pub aliases: Vec<String>,
+    pub description: String,
+    pub env: String,
+    pub metadata: WorkflowMetadata,
+}
+
+impl WorkflowNode {
+    pub fn new(env: &str, scope: &str, workflow_id: &str, name: &str, description: &str) -> Self {
+        let metadata = WorkflowMetadata::new(env, scope, workflow_id, name, description);
+
+        Self {
+            gid: metadata.gid.clone(),
+            name: name.to_string(),
+            element_type: "workflow".to_string(),
+            aliases: metadata.aliases.clone(),
+            description: description.to_string(),
+            env: env.to_string(),
+            metadata,
+        }
+    }
+
+    pub fn with_entry_points(mut self, entry_points: Vec<String>) -> Self {
+        self.metadata = self.metadata.with_entry_points(entry_points);
+        self
+    }
+
+    pub fn with_step_count(mut self, count: usize) -> Self {
+        self.metadata = self.metadata.with_step_count(count);
+        self
+    }
+
+    pub fn with_source(mut self, source: &str) -> Self {
+        self.metadata = self.metadata.with_source(source);
+        self
+    }
+}
+
+/// Workflow step node structure
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WorkflowStepNode {
+    pub gid: String,
+    pub name: String,
+    pub element_type: String,
+    pub workflow_gid: String,
+    pub order: usize,
+    pub description: String,
+    pub env: String,
+    pub metadata: WorkflowStepMetadata,
+}
+
+impl WorkflowStepNode {
+    pub fn new(
+        env: &str,
+        scope: &str,
+        workflow_id: &str,
+        step_id: &str,
+        name: &str,
+        order: usize,
+        description: &str,
+    ) -> Self {
+        let metadata =
+            WorkflowStepMetadata::new(env, scope, workflow_id, step_id, order, description);
+
+        Self {
+            gid: metadata.gid.clone(),
+            name: name.to_string(),
+            element_type: "workflow_step".to_string(),
+            workflow_gid: metadata.workflow_gid.clone(),
+            order,
+            description: description.to_string(),
+            env: env.to_string(),
+            metadata,
+        }
+    }
+
+    pub fn with_code_refs(mut self, refs: Vec<String>) -> Self {
+        self.metadata = self.metadata.with_code_refs(refs);
+        self
+    }
+
+    pub fn with_failure_modes(mut self, modes: Vec<String>) -> Self {
+        self.metadata = self.metadata.with_failure_modes(modes);
+        self
+    }
+}
+
+/// Failure mode node
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FailureModeNode {
+    pub gid: String,
+    pub name: String,
+    pub element_type: String,
+    pub description: String,
+    pub env: String,
+    pub metadata: FailureModeMetadata,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct FailureModeMetadata {
+    pub gid: String,
+    pub ontology: String,
+    pub ontology_layer: String,
+    #[serde(default)]
+    pub aliases: Vec<String>,
+    pub description: String,
+    #[serde(default)]
+    pub handled_by: Vec<String>,
+    #[serde(default)]
+    pub source: Option<String>,
+    #[serde(default)]
+    pub stale: bool,
+    #[serde(default)]
+    pub stale_reason: Option<String>,
+    #[serde(default)]
+    pub last_seen_at: Option<String>,
+}
+
+impl FailureModeNode {
+    pub fn new(env: &str, scope: &str, failure_id: &str, name: &str, description: &str) -> Self {
+        let gid = OntologyGid {
+            env: env.to_string(),
+            scope: scope.to_string(),
+            ontology_type: "failure_mode".to_string(),
+            id: failure_id.to_string(),
+            version: "v1".to_string(),
+        }
+        .to_string();
+
+        let metadata = FailureModeMetadata {
+            gid: gid.clone(),
+            ontology: "procedural".to_string(),
+            ontology_layer: "procedural".to_string(),
+            aliases: vec![normalize_alias(name)],
+            description: description.to_string(),
+            handled_by: Vec::new(),
+            source: None,
+            stale: false,
+            stale_reason: None,
+            last_seen_at: None,
+        };
+
+        Self {
+            gid,
+            name: name.to_string(),
+            element_type: "failure_mode".to_string(),
+            description: description.to_string(),
+            env: env.to_string(),
+            metadata,
+        }
+    }
+
+    pub fn with_handled_by(mut self, playbooks: Vec<String>) -> Self {
+        self.metadata.handled_by = playbooks;
+        self
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_procedural_element_type_as_str() {
+        assert_eq!(ProceduralElementType::Workflow.as_str(), "workflow");
+        assert_eq!(
+            ProceduralElementType::WorkflowStep.as_str(),
+            "workflow_step"
+        );
+        assert_eq!(ProceduralElementType::FailureMode.as_str(), "failure_mode");
+    }
+
+    #[test]
+    fn test_procedural_element_type_from_str() {
+        assert_eq!(
+            ProceduralElementType::from_str("workflow"),
+            Some(ProceduralElementType::Workflow)
+        );
+        assert_eq!(
+            ProceduralElementType::from_str("workflow_step"),
+            Some(ProceduralElementType::WorkflowStep)
+        );
+        assert_eq!(ProceduralElementType::from_str("unknown"), None);
+    }
+
+    #[test]
+    fn test_procedural_relationship_type_roundtrip() {
+        assert_eq!(ProceduralRelationshipType::HasStep.as_str(), "has_step");
+        assert_eq!(
+            ProceduralRelationshipType::from_str("has_step"),
+            Some(ProceduralRelationshipType::HasStep)
+        );
+        assert_eq!(
+            ProceduralRelationshipType::from_str("next_step"),
+            Some(ProceduralRelationshipType::NextStep)
+        );
+    }
+
+    #[test]
+    fn test_workflow_metadata_new() {
+        let meta = WorkflowMetadata::new(
+            "local",
+            "checkout-service",
+            "checkout",
+            "Checkout",
+            "End-to-end customer checkout workflow",
+        );
+        assert_eq!(meta.gid, "local:checkout-service:workflow:checkout:v1");
+        assert_eq!(meta.ontology, "procedural");
+        assert_eq!(meta.ontology_layer, "procedural");
+    }
+
+    #[test]
+    fn test_workflow_step_metadata_workflow_gid() {
+        let meta = WorkflowStepMetadata::new(
+            "local",
+            "checkout-service",
+            "checkout",
+            "authorize_payment",
+            2,
+            "Authorize payment step",
+        );
+        assert_eq!(
+            meta.workflow_gid,
+            "local:checkout-service:workflow:checkout:v1"
+        );
+        assert_eq!(meta.order, 2);
+    }
+
+    #[test]
+    fn test_workflow_node_creation() {
+        let workflow = WorkflowNode::new(
+            "local",
+            "checkout-service",
+            "checkout",
+            "Checkout",
+            "End-to-end customer checkout workflow",
+        )
+        .with_entry_points(vec!["src/checkout/handler.rs::create_order".to_string()])
+        .with_step_count(5)
+        .with_source("detected_from_call_graph");
+
+        assert_eq!(workflow.gid, "local:checkout-service:workflow:checkout:v1");
+        assert_eq!(workflow.name, "Checkout");
+        assert_eq!(workflow.metadata.entry_points.len(), 1);
+        assert_eq!(workflow.metadata.step_count, Some(5));
+    }
+
+    #[test]
+    fn test_workflow_step_node_creation() {
+        let step = WorkflowStepNode::new(
+            "local",
+            "checkout-service",
+            "checkout",
+            "authorize_payment",
+            "Authorize Payment",
+            2,
+            "Authorize payment for the order",
+        )
+        .with_code_refs(vec!["src/payment/client.rs::authorize".to_string()])
+        .with_failure_modes(vec![
+            "payment_timeout".to_string(),
+            "insufficient_funds".to_string(),
+        ]);
+
+        assert_eq!(
+            step.gid,
+            "local:checkout-service:workflow_step:authorize_payment:v1"
+        );
+        assert_eq!(step.name, "Authorize Payment");
+        assert_eq!(step.order, 2);
+        assert_eq!(step.metadata.code_refs.len(), 1);
+        assert_eq!(step.metadata.failure_modes.len(), 2);
+    }
+
+    #[test]
+    fn test_failure_mode_node_creation() {
+        let failure = FailureModeNode::new(
+            "local",
+            "checkout-service",
+            "payment_timeout",
+            "Payment Timeout",
+            "Payment authorization timed out",
+        )
+        .with_handled_by(vec![
+            "local:checkout-service:playbook:payment_reconciliation:v1".to_string(),
+        ]);
+
+        assert_eq!(
+            failure.gid,
+            "local:checkout-service:failure_mode:payment_timeout:v1"
+        );
+        assert_eq!(failure.name, "Payment Timeout");
+        assert_eq!(failure.metadata.handled_by.len(), 1);
+    }
+}

--- a/src/ontology/query.rs
+++ b/src/ontology/query.rs
@@ -1,0 +1,664 @@
+//! Ontology Query Engine
+//!
+//! Provides methods for querying ontology nodes and expanding context.
+
+use crate::db::models::{CodeElement, Relationship};
+use crate::db::schema::CozoDb;
+use crate::ontology::procedural::{
+    FailureModeMetadata, FailureModeNode, WorkflowMetadata, WorkflowNode, WorkflowStepMetadata,
+    WorkflowStepNode,
+};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OntologyContextResult {
+    pub matched_ontology_nodes: Vec<OntologyNodeInfo>,
+    pub expanded_code_context: Vec<CodeElement>,
+    pub expanded_relationships: Vec<Relationship>,
+    pub workflows: Vec<WorkflowNode>,
+    pub workflow_steps: Vec<WorkflowStepNode>,
+    pub failure_modes: Vec<FailureModeNode>,
+    pub confidence: f64,
+    pub match_reasons: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OntologyNodeInfo {
+    pub gid: String,
+    pub name: String,
+    pub element_type: String,
+    pub description: String,
+    pub aliases: Vec<String>,
+    pub ontology_layer: String,
+    pub match_score: f64,
+    pub match_reason: String,
+}
+
+impl OntologyContextResult {
+    pub fn is_empty(&self) -> bool {
+        self.matched_ontology_nodes.is_empty()
+    }
+
+    pub fn len(&self) -> usize {
+        self.matched_ontology_nodes.len()
+    }
+}
+
+/// Query engine for ontology nodes
+pub struct OntologyQueryEngine {
+    db: CozoDb,
+}
+
+impl OntologyQueryEngine {
+    pub fn new(db: CozoDb) -> Self {
+        Self { db }
+    }
+
+    /// Search ontology nodes by query string (matches name, aliases, description)
+    pub fn search_ontology_nodes(
+        &self,
+        query: &str,
+        _env: &str,
+        _depth: u32,
+    ) -> Result<Vec<OntologyNodeInfo>, Box<dyn std::error::Error>> {
+        let normalized_query = query.to_lowercase();
+
+        // Query all ontology nodes (element_type in concept or procedural types)
+        let query_str = r#"?[qualified_name, element_type, name, metadata] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, _], element_type in $types, file_path =~ "ontology://""#;
+
+        let types = serde_json::json!([
+            "domain_entity",
+            "service",
+            "api_endpoint",
+            "data_store",
+            "environment",
+            "known_issue",
+            "playbook",
+            "team_knowledge",
+            "workflow",
+            "workflow_step",
+            "decision_point",
+            "failure_mode",
+            "playbook_step"
+        ]);
+
+        let mut params = std::collections::BTreeMap::new();
+        params.insert("types".to_string(), types);
+
+        let result = self.db.run_script(query_str, params)?;
+        let rows = result.rows;
+
+        let mut matches: Vec<OntologyNodeInfo> = Vec::new();
+
+        for row in rows {
+            let qualified_name = row[0].as_str().unwrap_or("");
+            let element_type = row[1].as_str().unwrap_or("");
+            let name = row[2].as_str().unwrap_or("");
+            let metadata_str = row[3].as_str().unwrap_or("{}");
+
+            // Parse metadata to get aliases, description, ontology_layer
+            let metadata: serde_json::Value =
+                serde_json::from_str(metadata_str).unwrap_or_default();
+
+            let aliases: Vec<String> = metadata
+                .get("aliases")
+                .and_then(|v| v.as_array())
+                .map(|arr| {
+                    arr.iter()
+                        .filter_map(|s| s.as_str().map(String::from))
+                        .collect()
+                })
+                .unwrap_or_default();
+
+            let description = metadata
+                .get("description")
+                .and_then(|v| v.as_str())
+                .unwrap_or("")
+                .to_string();
+
+            let ontology_layer = metadata
+                .get("ontology_layer")
+                .and_then(|v| v.as_str())
+                .unwrap_or("domain")
+                .to_string();
+
+            // Calculate match score
+            let (score, reason) =
+                calculate_match_score(&normalized_query, name, &aliases, &description);
+
+            if score > 0.0 {
+                matches.push(OntologyNodeInfo {
+                    gid: qualified_name.to_string(),
+                    name: name.to_string(),
+                    element_type: element_type.to_string(),
+                    description,
+                    aliases,
+                    ontology_layer,
+                    match_score: score,
+                    match_reason: reason,
+                });
+            }
+        }
+
+        // Sort by score descending
+        matches.sort_by(|a, b| {
+            b.match_score
+                .partial_cmp(&a.match_score)
+                .unwrap_or(std::cmp::Ordering::Equal)
+        });
+
+        Ok(matches)
+    }
+
+    /// Expand ontology node to related code context
+    pub fn expand_ontology_context(
+        &self,
+        node_gid: &str,
+        depth: u32,
+    ) -> Result<(Vec<CodeElement>, Vec<Relationship>), Box<dyn std::error::Error>> {
+        let mut expanded_elements = Vec::new();
+        let mut expanded_relationships = Vec::new();
+        let mut visited = std::collections::HashSet::new();
+        visited.insert(node_gid.to_string());
+
+        // Get direct relationships from this node
+        let query_str = r#"?[target_qualified, rel_type, confidence, metadata] := *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, _], source_qualified = $gid"#;
+
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "gid".to_string(),
+            serde_json::Value::String(node_gid.to_string()),
+        );
+
+        let result = self.db.run_script(query_str, params)?;
+        let rows = result.rows;
+
+        for row in rows {
+            let target = row[0].as_str().unwrap_or("");
+            let rel_type = row[1].as_str().unwrap_or("");
+            let confidence = row[2].as_f64().unwrap_or(1.0);
+            let metadata_str = row[3].as_str().unwrap_or("{}");
+
+            if !target.is_empty() && !visited.contains(target) {
+                visited.insert(target.to_string());
+
+                // Get the target element
+                if let Ok(Some(element)) = self.find_element_by_qualified(target) {
+                    expanded_elements.push(element);
+                }
+
+                expanded_relationships.push(Relationship {
+                    id: None,
+                    source_qualified: node_gid.to_string(),
+                    target_qualified: target.to_string(),
+                    rel_type: rel_type.to_string(),
+                    confidence,
+                    metadata: serde_json::from_str(metadata_str).unwrap_or_default(),
+                    env: "local".to_string(),
+                });
+
+                // Recurse if depth allows
+                if depth > 1 {
+                    let (mut elements, mut rels) =
+                        self.expand_ontology_context(target, depth - 1)?;
+                    expanded_elements.append(&mut elements);
+                    expanded_relationships.append(&mut rels);
+                }
+            }
+        }
+
+        Ok((expanded_elements, expanded_relationships))
+    }
+
+    /// Get full context for a semantic query
+    pub fn get_ontology_context(
+        &self,
+        query: &str,
+        env: &str,
+        depth: u32,
+    ) -> Result<OntologyContextResult, Box<dyn std::error::Error>> {
+        // Search for matching ontology nodes
+        let matched_nodes = self.search_ontology_nodes(query, env, depth)?;
+
+        if matched_nodes.is_empty() {
+            return Ok(OntologyContextResult {
+                matched_ontology_nodes: vec![],
+                expanded_code_context: vec![],
+                expanded_relationships: vec![],
+                workflows: vec![],
+                workflow_steps: vec![],
+                failure_modes: vec![],
+                confidence: 0.0,
+                match_reasons: vec![],
+            });
+        }
+
+        let mut all_elements = Vec::new();
+        let mut all_relationships = Vec::new();
+        let mut workflows = Vec::new();
+        let mut workflow_steps = Vec::new();
+        let mut failure_modes = Vec::new();
+        let mut match_reasons = Vec::new();
+
+        for node in &matched_nodes {
+            match_reasons.push(node.match_reason.clone());
+
+            // Expand context for each matched node
+            let (elements, relationships) = self.expand_ontology_context(&node.gid, depth)?;
+            all_elements.extend(elements);
+            all_relationships.extend(relationships);
+
+            // Check if this is a workflow or workflow_step
+            if node.element_type == "workflow" {
+                if let Some(w) = self.get_workflow_by_gid(&node.gid)? {
+                    workflows.push(w);
+                }
+            } else if node.element_type == "workflow_step" {
+                if let Some(ws) = self.get_workflow_step_by_gid(&node.gid)? {
+                    workflow_steps.push(ws);
+                }
+            } else if node.element_type == "failure_mode" {
+                if let Some(fm) = self.get_failure_mode_by_gid(&node.gid)? {
+                    failure_modes.push(fm);
+                }
+            }
+        }
+
+        // Calculate overall confidence
+        let avg_confidence: f64 =
+            matched_nodes.iter().map(|n| n.match_score).sum::<f64>() / matched_nodes.len() as f64;
+
+        Ok(OntologyContextResult {
+            matched_ontology_nodes: matched_nodes,
+            expanded_code_context: all_elements,
+            expanded_relationships: all_relationships,
+            workflows,
+            workflow_steps,
+            failure_modes,
+            confidence: avg_confidence,
+            match_reasons,
+        })
+    }
+
+    /// Get workflow node by GID
+    fn get_workflow_by_gid(
+        &self,
+        gid: &str,
+    ) -> Result<Option<WorkflowNode>, Box<dyn std::error::Error>> {
+        if let Some(element) = self.find_element_by_qualified(gid)? {
+            let metadata: WorkflowMetadata = serde_json::from_value(element.metadata)
+                .ok()
+                .unwrap_or_default();
+            Ok(Some(WorkflowNode {
+                gid: element.qualified_name,
+                name: element.name,
+                element_type: element.element_type,
+                aliases: metadata.aliases.clone(),
+                description: metadata.description.clone(),
+                env: element.env,
+                metadata,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Get workflow step node by GID
+    fn get_workflow_step_by_gid(
+        &self,
+        gid: &str,
+    ) -> Result<Option<WorkflowStepNode>, Box<dyn std::error::Error>> {
+        if let Some(element) = self.find_element_by_qualified(gid)? {
+            let metadata: WorkflowStepMetadata = serde_json::from_value(element.metadata)
+                .ok()
+                .unwrap_or_default();
+            Ok(Some(WorkflowStepNode {
+                gid: element.qualified_name,
+                name: element.name,
+                element_type: element.element_type,
+                workflow_gid: metadata.workflow_gid.clone(),
+                order: metadata.order,
+                description: metadata.description.clone(),
+                env: element.env,
+                metadata,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Get failure mode node by GID
+    fn get_failure_mode_by_gid(
+        &self,
+        gid: &str,
+    ) -> Result<Option<FailureModeNode>, Box<dyn std::error::Error>> {
+        if let Some(element) = self.find_element_by_qualified(gid)? {
+            let metadata: FailureModeMetadata = serde_json::from_value(element.metadata)
+                .ok()
+                .unwrap_or_default();
+            Ok(Some(FailureModeNode {
+                gid: element.qualified_name,
+                name: element.name,
+                element_type: element.element_type,
+                description: metadata.description.clone(),
+                env: element.env,
+                metadata,
+            }))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Find element by qualified name
+    fn find_element_by_qualified(
+        &self,
+        qualified_name: &str,
+    ) -> Result<Option<CodeElement>, Box<dyn std::error::Error>> {
+        let query = r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env], qualified_name = $qn"#;
+
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "qn".to_string(),
+            serde_json::Value::String(qualified_name.to_string()),
+        );
+
+        let result = self.db.run_script(query, params)?;
+        let rows = result.rows;
+
+        if rows.is_empty() {
+            return Ok(None);
+        }
+
+        let row = &rows[0];
+        let parent_qualified = row[7].as_str().map(String::from);
+        let cluster_id = row[8].as_str().map(String::from);
+        let cluster_label = row[9].as_str().map(String::from);
+        let metadata_str = row[10].as_str().unwrap_or("{}");
+        let env = row[11].as_str().unwrap_or("local").to_string();
+
+        Ok(Some(CodeElement {
+            qualified_name: row[0].as_str().unwrap_or("").to_string(),
+            element_type: row[1].as_str().unwrap_or("").to_string(),
+            name: row[2].as_str().unwrap_or("").to_string(),
+            file_path: row[3].as_str().unwrap_or("").to_string(),
+            line_start: row[4].as_i64().unwrap_or(0) as u32,
+            line_end: row[5].as_i64().unwrap_or(0) as u32,
+            language: row[6].as_str().unwrap_or("").to_string(),
+            parent_qualified,
+            cluster_id,
+            cluster_label,
+            metadata: serde_json::from_str(metadata_str).unwrap_or_default(),
+            env,
+        }))
+    }
+
+    /// Trace a workflow (get ordered steps)
+    pub fn trace_workflow(
+        &self,
+        workflow_query: &str,
+        env: &str,
+    ) -> Result<Vec<WorkflowStepNode>, Box<dyn std::error::Error>> {
+        // First find the workflow
+        let workflows = self.search_workflows(workflow_query, env)?;
+
+        if workflows.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let workflow = &workflows[0];
+        let workflow_gid = &workflow.gid;
+
+        // Get all steps for this workflow
+        let query_str = r#"?[qualified_name, element_type, name, metadata, env] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env], element_type = "workflow_step", parent_qualified = $wgid"#;
+
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "wgid".to_string(),
+            serde_json::Value::String(workflow_gid.to_string()),
+        );
+
+        let result = self.db.run_script(query_str, params)?;
+        let rows = result.rows;
+
+        let mut steps: Vec<WorkflowStepNode> = rows
+            .iter()
+            .filter_map(|row| {
+                let metadata_str = row[3].as_str().unwrap_or("{}");
+                let metadata: WorkflowStepMetadata = serde_json::from_str(metadata_str).ok()?;
+                Some(WorkflowStepNode {
+                    gid: row[0].as_str().unwrap_or("").to_string(),
+                    name: row[2].as_str().unwrap_or("").to_string(),
+                    element_type: row[1].as_str().unwrap_or("").to_string(),
+                    workflow_gid: metadata.workflow_gid.clone(),
+                    order: metadata.order,
+                    description: metadata.description.clone(),
+                    env: row[4].as_str().unwrap_or("local").to_string(),
+                    metadata,
+                })
+            })
+            .collect();
+
+        // Sort by order
+        steps.sort_by_key(|a| a.order);
+
+        Ok(steps)
+    }
+
+    /// Search for workflows by name/alias
+    pub fn search_workflows(
+        &self,
+        query: &str,
+        _env: &str,
+    ) -> Result<Vec<WorkflowNode>, Box<dyn std::error::Error>> {
+        let normalized_query = query.to_lowercase();
+
+        let query_str = r#"?[qualified_name, element_type, name, metadata, env] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env], element_type = "workflow", file_path =~ "ontology://""#;
+
+        let result = self
+            .db
+            .run_script(query_str, std::collections::BTreeMap::new())?;
+        let rows = result.rows;
+
+        let mut matches: Vec<WorkflowNode> = Vec::new();
+
+        for row in rows {
+            let qualified_name = row[0].as_str().unwrap_or("");
+            let name = row[2].as_str().unwrap_or("");
+            let metadata_str = row[3].as_str().unwrap_or("{}");
+            let env = row[4].as_str().unwrap_or("local").to_string();
+
+            let metadata: WorkflowMetadata = serde_json::from_str(metadata_str).unwrap_or_default();
+
+            // Check if name or aliases match query
+            let name_match = name.to_lowercase().contains(&normalized_query);
+            let alias_match = metadata
+                .aliases
+                .iter()
+                .any(|a| a.to_lowercase().contains(&normalized_query));
+
+            if name_match || alias_match {
+                matches.push(WorkflowNode {
+                    gid: qualified_name.to_string(),
+                    name: name.to_string(),
+                    element_type: row[1].as_str().unwrap_or("").to_string(),
+                    aliases: metadata.aliases.clone(),
+                    description: metadata.description.clone(),
+                    env,
+                    metadata,
+                });
+            }
+        }
+
+        Ok(matches)
+    }
+
+    /// Get ontology status (counts by type)
+    pub fn get_ontology_status(&self) -> Result<OntologyStatus, Box<dyn std::error::Error>> {
+        let query_str = r#"?[element_type, count] := code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env], file_path =~ "ontology://", element_type = $et, :count = count(qualified_name)"#;
+
+        let ontology_types = [
+            "domain_entity",
+            "service",
+            "api_endpoint",
+            "data_store",
+            "environment",
+            "known_issue",
+            "playbook",
+            "team_knowledge",
+            "workflow",
+            "workflow_step",
+            "decision_point",
+            "failure_mode",
+            "playbook_step",
+        ];
+
+        let mut concept_counts: HashMap<String, usize> = HashMap::new();
+        let mut procedural_counts: HashMap<String, usize> = HashMap::new();
+        let total_aliases = 0;
+        let nodes_missing_aliases = 0;
+        let workflows_without_failure_modes = 0;
+
+        for ont_type in &ontology_types {
+            let mut params = std::collections::BTreeMap::new();
+            params.insert(
+                "et".to_string(),
+                serde_json::Value::String(ont_type.to_string()),
+            );
+
+            if let Ok(result) = self.db.run_script(query_str, params.clone()) {
+                let count = result.rows.first().and_then(|r| r[0].as_u64()).unwrap_or(0) as usize;
+
+                if is_procedural_type(ont_type) {
+                    procedural_counts.insert(ont_type.to_string(), count);
+                } else {
+                    concept_counts.insert(ont_type.to_string(), count);
+                }
+            }
+        }
+
+        Ok(OntologyStatus {
+            concept_counts,
+            procedural_counts,
+            total_aliases,
+            nodes_missing_aliases,
+            workflows_without_failure_modes,
+        })
+    }
+}
+
+/// Check if type is procedural
+fn is_procedural_type(t: &str) -> bool {
+    matches!(
+        t,
+        "workflow" | "workflow_step" | "decision_point" | "failure_mode" | "playbook_step"
+    )
+}
+
+/// Calculate match score for a query against an ontology node
+pub fn calculate_match_score(
+    query: &str,
+    name: &str,
+    aliases: &[String],
+    description: &str,
+) -> (f64, String) {
+    let query_lower = query.to_lowercase();
+    let name_lower = name.to_lowercase();
+
+    // Exact name match is highest
+    if name_lower == query_lower {
+        return (1.0, format!("exact name match: {}", name));
+    }
+
+    // Name contains query
+    if name_lower.contains(&query_lower) {
+        return (0.8, format!("name contains '{}': {}", query, name));
+    }
+
+    // Alias match
+    for alias in aliases {
+        let alias_lower = alias.to_lowercase();
+        if alias_lower == query_lower {
+            return (0.9, format!("exact alias match: {}", alias));
+        }
+        if alias_lower.contains(&query_lower) {
+            return (0.7, format!("alias contains '{}': {}", query, alias));
+        }
+    }
+
+    // Description contains query
+    if description.to_lowercase().contains(&query_lower) {
+        return (0.5, format!("description contains '{}'", query));
+    }
+
+    // Check for multi-word query match
+    let query_words: Vec<&str> = query_lower.split_whitespace().collect();
+    if query_words.len() > 1 {
+        let mut matched_words = 0;
+        for word in &query_words {
+            if name_lower.contains(word) || aliases.iter().any(|a| a.to_lowercase().contains(word))
+            {
+                matched_words += 1;
+            }
+        }
+        if matched_words == query_words.len() {
+            return (0.6, "all query words matched in name/aliases".to_string());
+        }
+    }
+
+    (0.0, String::new())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OntologyStatus {
+    pub concept_counts: HashMap<String, usize>,
+    pub procedural_counts: HashMap<String, usize>,
+    pub total_aliases: usize,
+    pub nodes_missing_aliases: usize,
+    pub workflows_without_failure_modes: usize,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_calculate_match_score_exact_name() {
+        let (score, reason) = calculate_match_score("refund", "Refund", &[], "Money back");
+        assert_eq!(score, 1.0);
+        assert!(reason.contains("exact name match"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_name_contains() {
+        let (score, reason) = calculate_match_score("refund", "RefundPolicy", &[], "");
+        assert_eq!(score, 0.8);
+        assert!(reason.contains("name contains"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_alias_match() {
+        let (score, reason) = calculate_match_score(
+            "reversal",
+            "Refund",
+            &["reversal".to_string(), "chargeback".to_string()],
+            "",
+        );
+        assert_eq!(score, 0.9);
+        assert!(reason.contains("exact alias match"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_description() {
+        let (score, reason) = calculate_match_score("payment", "Refund", &[], "Money payment back");
+        assert_eq!(score, 0.5);
+        assert!(reason.contains("description contains"));
+    }
+
+    #[test]
+    fn test_calculate_match_score_no_match() {
+        let (score, reason) = calculate_match_score("xyz", "Refund", &[], "");
+        assert_eq!(score, 0.0);
+        assert!(reason.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary

Implements the MVP for LeanKG ontology to enable semantic search beyond code symbol lookup. Agents can now ask domain-aware questions like "where is checkout refund failure handled?" and get structured context.

## Features

- **Concept ontology**: domain_entity, service, api_endpoint, data_store, environment, known_issue, playbook, team_knowledge
- **Procedural ontology**: workflow, workflow_step, decision_point, failure_mode, playbook_step
- **Stable GIDs** for idempotent sync (format: `{env}:{scope}:{type}:{id}:v1`)
- **YAML loading** for manual ontology definitions (`ontology/concepts.yaml`, `ontology/workflows.yaml`)
- **MCP tools**: `kg_context`, `kg_concept_map`, `kg_trace_workflow`, `kg_ontology_status`
- **CLI commands**: `ontology validate/sync/status/context/concept-map/trace-workflow`
- **30 unit tests** covering ontology types, loader, and query engine

## Test plan

- [x] `cargo test --lib -- ontology` - 30 ontology tests pass
- [x] `cargo build --release` - builds successfully
- [x] `./leankg ontology --help` - CLI commands available
- [x] `./leankg ontology validate` - validates YAML structure
- [x] `./leankg ontology sync` - syncs ontology to graph

## Breaking changes

None - fully additive feature.