### PR TITLE
fix: avoid nested tokio runtime panic in --reuse flag

### DIFF
--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -505,11 +505,8 @@ impl MCPServer {
                     // (PID recycling can cause false positives with kill -0 alone)
                     if Self::is_process_alive(pid) {
                         // Verify the server is actually running by checking health endpoint
-                        let rt = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
-                        let alive = rt.block_on(Self::check_health_sync(port));
+                        // Use run_blocking() — never create a new Runtime inside an existing one
+                        let alive = crate::runtime::run_blocking(Self::check_health_sync(port));
                         if alive {
                             return Ok(Some(pid));
                         }
@@ -901,7 +898,7 @@ impl MCPServer {
         if pid_file.exists() {
             if let Ok(contents) = fs::read_to_string(&pid_file) {
                 if let Ok(pid) = contents.trim().parse::<u32>() {
-                    if pid == std::process::id() as u32 {
+                    if pid == std::process::id() {
                         let _ = fs::remove_file(&pid_file);
                         tracing::info!("Removed PID file");
                     }


### PR DESCRIPTION
## Problem

The `--reuse` flag in `mcp-http` panics with a tokio async runtime error:

> cannot start a runtime from within a runtime

This happens because `try_acquire_port_lock` creates a new `tokio::runtime::Builder::new_current_thread()` while already running inside the main tokio runtime (the `serve_http` async function).

## Fix

Replaced the manual runtime creation with `crate::runtime::run_blocking()`, which safely handles both contexts:

- Uses `block_in_place` when already inside a tokio runtime
- Falls back to the static `OnceLock` runtime when not

This is the same pattern already used throughout the codebase (orchestrator cache, graph query, web handlers, etc.).

## Verification

- `cargo build --release` — clean
- `cargo clippy` — no warnings on `src/mcp/server.rs`
- Manual test: `mcp-http --reuse` detects existing server and exits cleanly (code 0), no panic