### PR TITLE
fix: stabilize HTTP MCP indexing

### DIFF
--- a/docs/implementation/mcp-index-fetch-failed-root-cause-2026-05-19.md
+++ b/docs/implementation/mcp-index-fetch-failed-root-cause-2026-05-19.md
@@ -1,0 +1,188 @@
+# MCP Index Fetch Failed Root Cause Report
+
+Date: 2026-05-19
+Status: Fix implemented and validated in `fix/mcp-index-fetch-failed`
+Owner: LeanKG local MCP integration
+
+## Summary
+
+Cursor reports `{"error":"fetch failed"}` when calling LeanKG MCP index over HTTP. The error is not a normal JSON-RPC tool error from LeanKG. It is a client-side fetch failure caused by the HTTP request timing out, the connection being closed, or the server process becoming unhealthy while the request is in flight.
+
+The immediate failure pattern is tied to long-running synchronous index work inside the MCP HTTP request path, stale/conflicting MCP server processes on port `9699`, SQLite/CozoDB write contention during index and call-edge resolution, and a legacy 11-column Cozo schema in `/Users/linh.doan/work/be/.leankg` that made core search tools fail with `Arity mismatch for rule application code_elements`.
+
+## Evidence
+
+- Cursor project MCP config points to `http://localhost:9699/mcp?project=/Users/linh.doan/work/harvey/freepeak/leankg`.
+- Port `9699` was actually served by a debug binary started for another project:
+  - `/Users/linh.doan/work/harvey/freepeak/leankg/target/debug/leankg mcp-http --port 9699 --project /Users/linh.doan/work/be`
+- Stale session metadata under `.leankg/.leankg_sessions/` pointed to a different release server PID.
+- Manual HTTP JSON-RPC calls to `mcp_status` succeeded but took several seconds.
+- Manual HTTP JSON-RPC call to `mcp_index` for one file took `8.385s` and reported `142325` call edges resolved.
+- Logs contained:
+  - `Cannot start a runtime from within a runtime` at `src/mcp/server.rs:512`
+  - `database is locked` from Cozo SQLite storage
+  - `PoisonError`
+  - `Address already in use (os error 48)`
+- Cursor validation report from `/Users/linh.doan/work/be/platform-core/be-diagram/food/performance/leankg-mcp-validation-report.md` showed:
+  - `mcp_index`: `fetch failed`
+  - `search_code`: `MCP error -32603: Arity mismatch for rule application code_elements`
+  - `find_function`: `MCP error -32603: Arity mismatch for rule application code_elements`
+- Reproduction against `/Users/linh.doan/work/be` with the fixed binary before schema repair confirmed:
+  - `leankg query main --kind name` failed with `Required arity: 11, number of arguments given: 12`.
+  - The DB had legacy `code_elements` and `relationships` arities despite the migration ledger recording the canonical repair.
+
+## Root Causes
+
+1. `mcp_index` performs blocking index work in the MCP request path.
+   - File: `src/mcp/handler.rs`
+   - Function: `mcp_index`
+   - It scans files, indexes them synchronously, then always runs full call-edge resolution.
+
+2. `resolve_call_edges()` is global and expensive.
+   - File: `src/graph/query.rs`
+   - Function: `resolve_call_edges`
+   - It loads all unresolved call relationships and all functions, then deletes and reinserts relationship batches.
+   - Even a one-file index can trigger a large full-database resolution pass.
+
+3. Full-repo indexing can include nested worktrees and build/cache directories.
+   - File: `src/indexer/mod.rs`
+   - Function: `find_files_sync`
+   - This duplicates graph data and makes explicit MCP indexing much slower than the active checkout requires.
+
+4. HTTP `tools/call` performs auto-index checks before every tool execution when URL `project` is present.
+   - File: `src/mcp/server.rs`
+   - Function: `process_jsonrpc_request`
+   - This can make unrelated tools inherit index latency and write contention.
+
+5. Server session and port-lock handling has unsafe async/runtime behavior.
+   - File: `src/mcp/server.rs`
+   - Function: `try_acquire_port_lock`
+   - It creates a Tokio runtime and calls `block_on` from code that can run inside an existing runtime, causing panics.
+
+6. Multiple MCP server instances can point at different projects while sharing port/session state.
+   - This caused Cursor to hit a server launched for `/Users/linh.doan/work/be` while URL-level routing attempted to use `/Users/linh.doan/work/harvey/freepeak/leankg`.
+
+7. `--project` and URL `?project=` were not consistently applied.
+   - File: `src/mcp/server.rs`
+   - Functions: `find_project_root`, `handle_mcp_request`, `find_leankg_for_path`
+   - Server startup used process cwd for project discovery, and relative tool paths were not always resolved against the URL project.
+
+8. Database write concurrency is not guarded for HTTP index and watcher activity.
+   - Concurrent index/write operations can trigger SQLite lock errors and poison Cozo internals.
+
+9. Canonical schema migration could be marked applied while the database stayed legacy.
+   - File: `src/db/schema.rs`
+   - Migration `006_safe_canonical_schema_repair` only ran when absent from the migration table.
+   - The old repair used bare `:replace`, which Cozo rejects with `Program has no entry` because `:replace` cannot omit a query.
+   - Result: current graph queries used 12-column `code_elements[..., env]`, while `/Users/linh.doan/work/be/.leankg` still had 11 columns.
+
+10. `mcp_status` performed full counts by default.
+   - File: `src/mcp/handler.rs`
+   - On large databases, readiness checks could spend too long counting files/functions/classes and look like a stalled MCP call.
+
+## Implementation Plan
+
+Work will be done in a new git worktree:
+
+```text
+./worktrees/fix-mcp-index-fetch-failed
+```
+
+Planned branch:
+
+```text
+fix/mcp-index-fetch-failed
+```
+
+### Phase 1: Stop Per-Request Index Surprises
+
+- [x] Remove `ensure_project_indexed()` from generic HTTP `tools/call`.
+- [x] Only run auto-index on server startup or explicit index requests.
+- [x] Preserve project routing for query tools without triggering writes before every call.
+- [x] Always resolve relative HTTP tool path arguments against URL `?project=`.
+- [x] Use configured `db_path` parent as MCP server project root when `--project` is provided.
+
+### Phase 2: Make Index Safer for HTTP MCP
+
+- [x] Honor `incremental` in `mcp_index`.
+- [x] Add `resolve_calls` with default `false` so MCP index calls do not always perform global call-edge resolution.
+- [x] Report whether call resolution ran or was skipped in the tool result.
+- [x] Exclude nested worktrees and common generated/cache directories during default file discovery.
+- [ ] Improve per-file error reporting for skipped files instead of only counting skipped files.
+
+### Phase 3: Fix Session/Lock Runtime Panic
+
+- [x] Replace `block_on` inside `try_acquire_port_lock` with a blocking health check that does not create a nested Tokio runtime.
+- [ ] Make stale lock cleanup more deterministic across multiple project-specific session directories.
+
+### Phase 4: Serialize DB Writes
+
+- [x] Add an MCP-server-level mutex for write-heavy MCP tools and dirty-write-triggered reindex.
+- [ ] Extend the same serialization boundary to watcher reindex paths if watcher and HTTP run in the same process.
+
+### Phase 5: Verification
+
+- [x] `cargo check`
+- [x] `cargo build`
+- [x] `cargo test test_mcp_index -- --nocapture`
+- [x] `cargo test mcp_server -- --nocapture`
+- [x] `cargo test test_find_files -- --nocapture`
+- [x] `cargo test test_init_db_repairs_legacy_code_elements_after_recorded_migration -- --nocapture`
+- [x] `cargo test test_mcp_status -- --nocapture`
+- [x] `git diff --check`
+- [x] Manual HTTP smoke test against a clean single-server setup on port `9802`.
+  - `GET /health` returned ok.
+  - HTTP JSON-RPC `mcp_index {"path":"src"}` returned a normal tool result with `resolve_calls: false`.
+  - HTTP JSON-RPC `mcp_status` returned the temp project database path and populated counts.
+  - HTTP JSON-RPC `search_code {"query":"main"}` returned the indexed function.
+  - Concurrent HTTP JSON-RPC `mcp_index` calls returned normal tool results with no `database is locked` or `fetch failed`.
+- [x] Manual HTTP validation against `/Users/linh.doan/work/be` on port `9807`.
+  - First fixed CLI startup repaired `code_elements` from 11 to 12 columns and `relationships` from 5 to 6 columns, preserving rows and setting `env = "local"`.
+  - HTTP JSON-RPC `mcp_status {}` returned `initialized: true`, `index_populated: true`, and `database_exists: true` without full counts.
+  - HTTP JSON-RPC `search_code {"query":"main","limit":3}` returned normal results.
+  - HTTP JSON-RPC `find_function {"name":"main"}` returned normal results.
+  - HTTP JSON-RPC `mcp_index {"path":"platform-core/be-activity-history/cmd/client","resolve_calls":false}` returned `success: true` and indexed one file.
+- [x] Replaced the stale Cursor-facing process on port `9699`.
+  - Old PID `99390` was `/Users/linh.doan/work/harvey/freepeak/leankg/target/debug/leankg`.
+  - New process is running from `./worktrees/fix-mcp-index-fetch-failed/target/debug/leankg` in tmux session `leankg-mcp-9699-fixed`.
+  - Revalidated `mcp_status`, `search_code`, and `mcp_index` over `http://127.0.0.1:9699/mcp?project=/Users/linh.doan/work/be`.
+
+## Implemented File Map
+
+- `src/mcp/server.rs`
+  - Removed per-request project auto-index from HTTP `tools/call`.
+  - Added `write_lock` to serialize write-heavy MCP tools.
+  - Replaced nested-runtime health check in `try_acquire_port_lock`.
+  - Fixed `--project` project-root detection and URL `?project=` relative path routing.
+- `src/mcp/handler.rs`
+  - Made `mcp_index.incremental` active.
+  - Added `resolve_calls` behavior with default false.
+  - Made `mcp_status` a lightweight readiness check by default; full counts require `include_counts: true`.
+- `src/mcp/tools.rs`
+  - Added `resolve_calls` to the `mcp_index` tool schema.
+  - Added `include_counts` to the `mcp_status` tool schema.
+- `src/db/schema.rs`
+  - Added arity probes for `code_elements` and `relationships`.
+  - Runs canonical repair even if the migration ledger says migration 006 already applied.
+  - Replaced invalid bare `:replace` with data-preserving `:replace` queries that add `env = "local"` to legacy rows.
+- `src/graph/query.rs`
+  - Added a fast `has_elements` readiness query.
+  - Fixed malformed `get_top_level_directories` and service schema discovery queries.
+- `src/indexer/mod.rs`
+  - Excluded nested worktrees, `.leankg`, VCS, build, and dependency cache directories relative to the requested index root.
+- `tests/cli_tests.rs`
+  - Updated `CLICommand::Index` patterns with `..` so newer fields do not break test compilation.
+- `tests/integration.rs`
+  - Added regression coverage for a legacy DB that already recorded migration 006 but still has 11-column `code_elements`.
+
+## Immediate Operational Workaround
+
+Until the fixed binary is the one Cursor launches:
+
+1. Kill duplicate `leankg mcp-http` processes.
+2. Remove stale `.leankg/.leankg_sessions/*`.
+3. Start exactly one server for the active project.
+4. Set `mcp.auto_index_on_start: false` in `.leankg/leankg.yaml` if Cursor must stay responsive.
+5. Run full indexing from CLI outside Cursor MCP requests.
+
+For the BE workspace, the database schema has already been repaired by the fixed binary during validation on 2026-05-19. The old process on port `9699` was replaced with the fixed worktree binary and revalidated over HTTP.

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -168,6 +168,12 @@ fn init_schema(db: &CozoDb) -> Result<(), Box<dyn std::error::Error>> {
     // Run migrations for schema evolution
     run_migrations(db, &existing_relations)?;
 
+    // Do not rely solely on the migration ledger for canonical graph arity.
+    // Some older databases recorded migration 006 while retaining the
+    // pre-env 11-column code_elements relation, which breaks all current
+    // graph queries at runtime.
+    repair_canonical_schema(db, &existing_relations)?;
+
     // Create service_metadata table if not exists (idempotent via migration)
     if !existing_relations.contains("service_metadata") {
         let create_svc = r#":create service_metadata {service_name: String, env: String default 'local', team: String?, on_call: String?, repo_url: String?, language: String?, health_endpoint: String?, slo_p99_ms: Int?, incident_count: Int, last_incident: Int?, tags: String, version: String?, deploy_envs: String, created_at: Int, updated_at: Int}"#;
@@ -285,22 +291,60 @@ fn repair_canonical_schema(
     db: &CozoDb,
     existing_relations: &std::collections::HashSet<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if let Err(e) = ensure_canonical_code_elements(db, existing_relations) {
-        tracing::warn!("code_elements canonical repair failed: {:?}", e);
-    }
-    if let Err(e) = ensure_canonical_relationships(db, existing_relations) {
-        tracing::warn!("relationships canonical repair failed: {:?}", e);
-    }
+    ensure_canonical_code_elements(db, existing_relations)?;
+    ensure_canonical_relationships(db, existing_relations)?;
     if let Err(e) = ensure_incidents_table(db) {
         tracing::warn!("incidents table creation failed: {:?}", e);
     }
     Ok(())
 }
 
-const CANONICAL_CODE_ELEMENTS: &str = ":replace code_elements {qualified_name: String, element_type: String, name: String, file_path: String, line_start: Int, line_end: Int, language: String, parent_qualified: String?, cluster_id: String?, cluster_label: String?, metadata: String, env: String default 'local'}";
-const CANONICAL_RELATIONSHIPS: &str = ":replace relationships {source_qualified: String, target_qualified: String, rel_type: String, confidence: Float, metadata: String, env: String default 'local'}";
+const REPAIR_LEGACY_CODE_ELEMENTS_11_TO_12: &str = r#"
+?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env] :=
+    *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata],
+    env = "local"
+:replace code_elements {qualified_name: String, element_type: String, name: String, file_path: String, line_start: Int, line_end: Int, language: String, parent_qualified: String?, cluster_id: String?, cluster_label: String?, metadata: String, env: String default 'local'}
+"#;
+const REPAIR_LEGACY_RELATIONSHIPS_5_TO_6: &str = r#"
+?[source_qualified, target_qualified, rel_type, confidence, metadata, env] :=
+    *relationships[source_qualified, target_qualified, rel_type, confidence, metadata],
+    env = "local"
+:replace relationships {source_qualified: String, target_qualified: String, rel_type: String, confidence: Float, metadata: String, env: String default 'local'}
+"#;
 
 fn get_column_count(db: &CozoDb, relation: &str) -> usize {
+    let arity_probe = match relation {
+        "code_elements" => Some([
+            (
+                12,
+                "?[qualified_name] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env] :limit 0",
+            ),
+            (
+                11,
+                "?[qualified_name] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata] :limit 0",
+            ),
+        ]),
+        "relationships" => Some([
+            (
+                6,
+                "?[source_qualified] := *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env] :limit 0",
+            ),
+            (
+                5,
+                "?[source_qualified] := *relationships[source_qualified, target_qualified, rel_type, confidence, metadata] :limit 0",
+            ),
+        ]),
+        _ => None,
+    };
+
+    if let Some(probes) = arity_probe {
+        for (arity, query) in probes {
+            if db.run_script(query, Default::default()).is_ok() {
+                return arity;
+            }
+        }
+    }
+
     let query = format!(":schema {}", relation);
     db.run_script(&query, Default::default())
         .map(|r| r.rows.len())
@@ -328,7 +372,14 @@ fn ensure_canonical_code_elements(
         current,
         EXPECTED
     );
-    db.run_script(CANONICAL_CODE_ELEMENTS, Default::default())?;
+    if current != 11 {
+        tracing::warn!(
+            "code_elements schema has unsupported arity {}; canonical repair only supports legacy 11-column schema",
+            current
+        );
+        return Ok(());
+    }
+    db.run_script(REPAIR_LEGACY_CODE_ELEMENTS_11_TO_12, Default::default())?;
     tracing::info!("code_elements :replace successful");
     Ok(())
 }
@@ -354,7 +405,14 @@ fn ensure_canonical_relationships(
         current,
         EXPECTED
     );
-    db.run_script(CANONICAL_RELATIONSHIPS, Default::default())?;
+    if current != 5 {
+        tracing::warn!(
+            "relationships schema has unsupported arity {}; canonical repair only supports legacy 5-column schema",
+            current
+        );
+        return Ok(());
+    }
+    db.run_script(REPAIR_LEGACY_RELATIONSHIPS_5_TO_6, Default::default())?;
     tracing::info!("relationships :replace successful");
     Ok(())
 }

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -1295,7 +1295,7 @@ impl GraphEngine {
         } else {
             format!("{}\x7f", prefix_with_slash)
         };
-        let query = r#"?[fp] := *code_elements[fp, _, _, _, _, _, _, _, _, _, _, _], file_path >= $lo and file_path < $hi"#;
+        let query = r#"?[fp] := *code_elements[qualified_name, element_type, name, fp, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env], fp >= $lo and fp < $hi"#;
         let mut params = std::collections::BTreeMap::new();
         params.insert("lo".to_string(), serde_json::Value::String(lo));
         params.insert("hi".to_string(), serde_json::Value::String(hi));
@@ -2618,6 +2618,14 @@ impl GraphEngine {
         Ok(result.rows.first().and_then(|r| r[0].as_i64()).unwrap_or(0) as usize)
     }
 
+    pub fn has_elements(&self) -> Result<bool, Box<dyn std::error::Error>> {
+        let query = r#"?[qualified_name] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env] :limit 1"#;
+        let result = self
+            .db
+            .run_script(query, std::collections::BTreeMap::new())?;
+        Ok(!result.rows.is_empty())
+    }
+
     pub fn count_relationships(&self) -> Result<usize, Box<dyn std::error::Error>> {
         let query = r#"?[count(n)] := *relationships[n, a, b, c, d, _]"#;
         let result = self
@@ -2783,7 +2791,7 @@ impl GraphEngine {
 
         let service_prefix = format!("./{}", service);
         let schemas_query = format!(
-            r#"?[name] := *code_elements[name, element_type, qualified_name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env], starts_with(file_path, "{}"), regex_matches(element_type, "(schema|protobuf|proto|openapi|json_schema|avro|sql_table|event|topic|config")"#,
+            r#"?[name] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env], starts_with(file_path, "{}"), regex_matches(element_type, "(schema|protobuf|proto|openapi|json_schema|avro|sql_table|event|topic|config)")"#,
             escape_datalog(&service_prefix)
         );
         let schemas: Vec<String> = self

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -66,7 +66,22 @@ use crate::graph::GraphEngine;
 use ignore::WalkBuilder;
 use rayon::prelude::*;
 use std::collections::HashSet;
+use std::path::Path;
 use std::sync::Arc;
+
+const DEFAULT_INDEX_IGNORED_DIRS: &[&str] = &[
+    ".git",
+    ".leankg",
+    ".worktrees",
+    "worktrees",
+    "target",
+    "node_modules",
+    "vendor",
+    "__pycache__",
+    ".gradle",
+    ".idea",
+    ".vscode",
+];
 
 pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let mut files = Vec::new();
@@ -87,7 +102,11 @@ pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Er
         "AndroidManifest.xml",
     ];
 
-    let walker = WalkBuilder::new(root).follow_links(true).build();
+    let root_path = Path::new(root).to_path_buf();
+    let walker = WalkBuilder::new(root)
+        .follow_links(true)
+        .filter_entry(move |entry| !is_default_ignored_entry(&root_path, entry.path()))
+        .build();
 
     for entry in walker.flatten() {
         let path = entry.path();
@@ -100,12 +119,24 @@ pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Er
             || extensions.contains(&ext)
             || is_cicd_yaml_file(path);
 
-        if path.is_file() && is_valid_file && !path.to_string_lossy().contains("/node_modules/") {
+        if path.is_file() && is_valid_file {
             files.push(path.to_string_lossy().to_string());
         }
     }
 
     Ok(files)
+}
+
+fn is_default_ignored_entry(root: &Path, path: &Path) -> bool {
+    if path == root {
+        return false;
+    }
+
+    let relative = path.strip_prefix(root).unwrap_or(path);
+    relative.components().any(|component| {
+        let segment = component.as_os_str().to_string_lossy();
+        DEFAULT_INDEX_IGNORED_DIRS.contains(&segment.as_ref())
+    })
 }
 
 /// Returns true if the path should be skipped during indexing.

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -424,7 +424,8 @@ impl ToolHandler {
 
     async fn mcp_index(&self, args: &Value) -> Result<Value, String> {
         let path = args["path"].as_str().unwrap_or(".");
-        let _incremental = args["incremental"].as_bool().unwrap_or(false);
+        let incremental = args["incremental"].as_bool().unwrap_or(false);
+        let resolve_calls = args["resolve_calls"].as_bool().unwrap_or(false);
         let lang = args["lang"].as_str();
         let exclude = args["exclude"].as_str();
         let env = args["env"].as_str().unwrap_or("local");
@@ -456,6 +457,49 @@ impl ToolHandler {
         parser_manager
             .init_parsers()
             .map_err(|e| format!("Parser init error: {}", e))?;
+
+        if incremental {
+            let result = crate::indexer::incremental_index_sync(
+                &self.graph_engine,
+                &mut parser_manager,
+                path,
+            )
+            .await
+            .map_err(|e| format!("Incremental index error: {}", e))?;
+            let resolved = if resolve_calls {
+                self.graph_engine.resolve_call_edges().unwrap_or(0)
+            } else {
+                0
+            };
+
+            return Ok(json!({
+                "success": true,
+                "message": if resolve_calls {
+                    format!(
+                        "Incrementally indexed {} files ({} elements), {} dependent files, {} call edges resolved",
+                        result.total_files_processed,
+                        result.elements_indexed,
+                        result.dependent_files.len(),
+                        resolved
+                    )
+                } else {
+                    format!(
+                        "Incrementally indexed {} files ({} elements), {} dependent files; call edge resolution skipped",
+                        result.total_files_processed,
+                        result.elements_indexed,
+                        result.dependent_files.len()
+                    )
+                },
+                "incremental": true,
+                "changed_files": result.changed_files,
+                "dependent_files": result.dependent_files,
+                "indexed": result.total_files_processed,
+                "elements_indexed": result.elements_indexed,
+                "resolved": resolved,
+                "resolve_calls": resolve_calls,
+                "path": path
+            }));
+        }
 
         let files = crate::indexer::find_files_sync(path)
             .map_err(|e| format!("Find files error: {}", e))?;
@@ -502,14 +546,24 @@ impl ToolHandler {
             }
         }
 
-        let resolved = self.graph_engine.resolve_call_edges().unwrap_or(0);
+        let resolved = if resolve_calls {
+            self.graph_engine.resolve_call_edges().unwrap_or(0)
+        } else {
+            0
+        };
 
         Ok(json!({
             "success": true,
-            "message": format!("Indexed {} files, {} skipped, {} call edges resolved", indexed, skipped, resolved),
+            "message": if resolve_calls {
+                format!("Indexed {} files, {} skipped, {} call edges resolved", indexed, skipped, resolved)
+            } else {
+                format!("Indexed {} files, {} skipped; call edge resolution skipped", indexed, skipped)
+            },
+            "incremental": false,
             "indexed": indexed,
             "skipped": skipped,
             "resolved": resolved,
+            "resolve_calls": resolve_calls,
             "path": path
         }))
     }
@@ -540,8 +594,9 @@ impl ToolHandler {
         }))
     }
 
-    fn mcp_status(&self, _args: &Value) -> Result<Value, String> {
+    fn mcp_status(&self, args: &Value) -> Result<Value, String> {
         let db_path = &self.db_path;
+        let include_counts = args["include_counts"].as_bool().unwrap_or(false);
 
         if !db_path.exists() {
             return Ok(json!({
@@ -551,51 +606,40 @@ impl ToolHandler {
         }
 
         // Verify database is actually initialized with proper tables
-        let count = self.graph_engine.count_elements().unwrap_or_default();
-        if count == 0 {
+        let has_elements = self.graph_engine.has_elements().unwrap_or(false);
+        if !has_elements {
             return Ok(json!({
                 "initialized": false,
                 "message": "LeanKG directory exists but database not initialized. Run mcp_index to populate index.",
-                "database_exists": false
+                "database_exists": false,
+                "counts_included": false
             }));
         }
 
-        let elements = count;
-        let relationships = self.graph_engine.count_relationships().unwrap_or(0);
-        let annotations = self.graph_engine.count_business_logic().unwrap_or(0);
-        let files = self.graph_engine.count_files().unwrap_or(0);
-        let functions = self
-            .graph_engine
-            .count_by_element_type("function")
-            .unwrap_or(0);
-        let classes = self
-            .graph_engine
-            .count_by_element_type("class")
-            .unwrap_or(0)
-            + self
-                .graph_engine
-                .count_by_element_type("struct")
-                .unwrap_or(0);
-
-        if elements == 0 && relationships == 0 {
+        if !include_counts {
             return Ok(json!({
                 "initialized": true,
-                "index_populated": false,
-                "message": "Database exists but is empty. Run mcp_index to index codebase.",
-                "database": db_path.to_string_lossy()
+                "index_populated": true,
+                "database_exists": true,
+                "database": db_path.to_string_lossy(),
+                "counts_included": false,
+                "message": "Database exists and contains indexed elements. Pass include_counts=true for full counts."
             }));
         }
 
         Ok(json!({
             "initialized": true,
             "index_populated": true,
+            "database_exists": true,
             "database": db_path.to_string_lossy(),
-            "elements": elements,
-            "relationships": relationships,
-            "files": files,
-            "functions": functions,
-            "classes": classes,
-            "annotations": annotations
+            "counts_included": true,
+            "elements": self.graph_engine.count_elements().unwrap_or(0),
+            "relationships": self.graph_engine.count_relationships().unwrap_or(0),
+            "files": self.graph_engine.count_files().unwrap_or(0),
+            "functions": self.graph_engine.count_by_element_type("function").unwrap_or(0),
+            "classes": self.graph_engine.count_by_element_type("class").unwrap_or(0)
+                + self.graph_engine.count_by_element_type("struct").unwrap_or(0),
+            "annotations": self.graph_engine.count_business_logic().unwrap_or(0)
         }))
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -30,7 +30,7 @@ use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, SystemTime};
 use tokio::signal;
-use tokio::sync::RwLock as TokioRwLock;
+use tokio::sync::{Mutex as TokioMutex, RwLock as TokioRwLock};
 use tower_http::cors::{Any, CorsLayer};
 
 /// Session information for coordination between multiple LeanKG instances
@@ -56,6 +56,8 @@ pub struct MCPServer {
     shutdown_flag: Arc<AtomicBool>,
     /// Port this server is bound to (for cleanup tracking)
     bound_port: Arc<AtomicU32>,
+    /// Serializes MCP write/index operations so Cozo SQLite is not written concurrently.
+    write_lock: Arc<TokioMutex<()>>,
 }
 
 impl std::fmt::Debug for MCPServer {
@@ -79,6 +81,7 @@ impl Clone for MCPServer {
             child_processes: self.child_processes.clone(),
             shutdown_flag: self.shutdown_flag.clone(),
             bound_port: self.bound_port.clone(),
+            write_lock: self.write_lock.clone(),
         }
     }
 }
@@ -97,6 +100,7 @@ impl MCPServer {
             child_processes: Arc::new(TokioRwLock::new(HashMap::new())),
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             bound_port: Arc::new(AtomicU32::new(0)),
+            write_lock: Arc::new(TokioMutex::new(())),
         }
     }
 
@@ -113,6 +117,7 @@ impl MCPServer {
             child_processes: Arc::new(TokioRwLock::new(HashMap::new())),
             shutdown_flag: Arc::new(AtomicBool::new(false)),
             bound_port: Arc::new(AtomicU32::new(0)),
+            write_lock: Arc::new(TokioMutex::new(())),
         }
     }
 
@@ -212,7 +217,7 @@ impl MCPServer {
             if leankg_path.is_dir() {
                 return Some(leankg_path);
             }
-            if ancestor.join("leankg.yaml").exists() {
+            if ancestor.join("leankg.yaml").exists() && leankg_path.exists() {
                 return Some(leankg_path);
             }
         }
@@ -504,12 +509,9 @@ impl MCPServer {
                     // Check if process is still alive AND actually responds as the MCP server
                     // (PID recycling can cause false positives with kill -0 alone)
                     if Self::is_process_alive(pid) {
-                        // Verify the server is actually running by checking health endpoint
-                        let rt = tokio::runtime::Builder::new_current_thread()
-                            .enable_all()
-                            .build()
-                            .map_err(|e| format!("Failed to create tokio runtime: {}", e))?;
-                        let alive = rt.block_on(Self::check_health_sync(port));
+                        // Verify without creating a nested Tokio runtime. This method is called
+                        // from async startup paths, so block_on here can panic.
+                        let alive = Self::check_health_blocking(port);
                         if alive {
                             return Ok(Some(pid));
                         }
@@ -541,6 +543,16 @@ impl MCPServer {
             .timeout(Duration::from_millis(500))
             .send()
             .await
+            .map(|r| r.status().is_success())
+            .unwrap_or(false)
+    }
+
+    fn check_health_blocking(port: u16) -> bool {
+        let url = format!("http://127.0.0.1:{}/health", port);
+        reqwest::blocking::Client::builder()
+            .timeout(Duration::from_millis(500))
+            .build()
+            .and_then(|client| client.get(url).send())
             .map(|r| r.status().is_success())
             .unwrap_or(false)
     }
@@ -919,20 +931,23 @@ impl MCPServer {
         let leankg_dir_exists = leankg_path.is_dir();
         let leankg_yaml_exists = project_root.join("leankg.yaml").exists();
 
-        if leankg_dir_exists || leankg_yaml_exists {
-            if leankg_dir_exists {
-                tracing::info!(
-                    "LeanKG project already initialized at {}",
-                    project_root.display()
-                );
-                return self.auto_index_if_needed().await;
-            } else {
-                tracing::warn!(
-                    ".leankg exists but is not a directory. Removing and re-initializing..."
-                );
-                std::fs::remove_file(&leankg_path)
-                    .map_err(|e| format!("Failed to remove invalid .leankg file: {}", e))?;
-            }
+        if leankg_path.exists() && !leankg_dir_exists {
+            tracing::warn!(
+                ".leankg exists but is not a directory. Removing and re-initializing..."
+            );
+            std::fs::remove_file(&leankg_path)
+                .map_err(|e| format!("Failed to remove invalid .leankg file: {}", e))?;
+        } else if leankg_dir_exists {
+            tracing::info!(
+                "LeanKG project already initialized at {}",
+                project_root.display()
+            );
+            return self.auto_index_if_needed().await;
+        } else if leankg_yaml_exists {
+            tracing::info!(
+                "LeanKG config exists at {}, creating missing .leankg directory",
+                project_root.display()
+            );
         }
 
         tracing::info!("LeanKG not found, searching for project root...");
@@ -1315,6 +1330,19 @@ impl MCPServer {
     }
 
     fn find_project_root(&self) -> Result<std::path::PathBuf, String> {
+        let configured_db_path = self.get_db_path();
+        if configured_db_path.ends_with(".leankg") {
+            if let Some(parent) = configured_db_path.parent() {
+                if !parent.as_os_str().is_empty() && parent.exists() {
+                    tracing::debug!(
+                        "Using configured db_path parent as project root: {}",
+                        parent.display()
+                    );
+                    return Ok(parent.to_path_buf());
+                }
+            }
+        }
+
         let current_dir =
             std::env::current_dir().map_err(|e| format!("Failed to get current dir: {}", e))?;
 
@@ -1391,6 +1419,13 @@ impl MCPServer {
         tool_name: &str,
         arguments: serde_json::Map<String, serde_json::Value>,
     ) -> Result<serde_json::Value, String> {
+        let _write_guard = if Self::requires_write_lock(tool_name) || self.write_tracker.is_dirty()
+        {
+            Some(self.write_lock.lock().await)
+        } else {
+            None
+        };
+
         let project_root = self.find_project_root()?;
         tracing::info!(
             "execute_tool called. project_root={}, db_path={}",
@@ -1492,6 +1527,22 @@ impl MCPServer {
         }
 
         result
+    }
+
+    fn requires_write_lock(tool_name: &str) -> bool {
+        matches!(
+            tool_name,
+            "mcp_init"
+                | "mcp_index"
+                | "mcp_index_docs"
+                | "add_knowledge"
+                | "update_knowledge"
+                | "delete_knowledge"
+                | "add_annotation"
+                | "link_element"
+                | "add_documentation"
+                | "promote_environment"
+        )
     }
 }
 
@@ -1757,38 +1808,31 @@ async fn handle_mcp_request(
     //    (without this, relative paths resolve against server CWD → wrong database)
     let request = if let Some(ref project) = project_param {
         let project_path = std::path::PathBuf::from(project);
-        let db_path = if project_path.ends_with(".leankg") {
-            project_path.clone()
-        } else {
-            project_path.join(".leankg")
-        };
-        if db_path != server.mcp_server.get_db_path() {
-            let mut req = request.clone();
-            if let Some(ref mut params) = req.params {
-                if let Some(obj) = params.as_object_mut() {
-                    // Inject project param for routing
-                    if let Some(ref mut args) = obj.get_mut("arguments") {
-                        if let Some(args_obj) = args.as_object_mut() {
-                            args_obj
-                                .entry("project".to_string())
-                                .or_insert(serde_json::Value::String(project.clone()));
-                            // Resolve relative paths against project root
-                            for key in &["file", "doc", "path"] {
-                                if let Some(serde_json::Value::String(v)) = args_obj.get_mut(*key) {
+        let mut req = request.clone();
+        if let Some(ref mut params) = req.params {
+            if let Some(obj) = params.as_object_mut() {
+                // Inject project param for routing
+                if let Some(ref mut args) = obj.get_mut("arguments") {
+                    if let Some(args_obj) = args.as_object_mut() {
+                        args_obj
+                            .entry("project".to_string())
+                            .or_insert(serde_json::Value::String(project.clone()));
+                        // Resolve relative paths against project root
+                        for key in &["file", "doc", "path"] {
+                            if let Some(serde_json::Value::String(v)) = args_obj.get_mut(*key) {
+                                if !v.starts_with('/') {
+                                    let resolved = project_path.join(&*v);
+                                    *v = resolved.to_string_lossy().to_string();
+                                }
+                            }
+                        }
+                        // Resolve files array elements too
+                        if let Some(serde_json::Value::Array(arr)) = args_obj.get_mut("files") {
+                            for item in arr.iter_mut() {
+                                if let serde_json::Value::String(v) = item {
                                     if !v.starts_with('/') {
                                         let resolved = project_path.join(&*v);
                                         *v = resolved.to_string_lossy().to_string();
-                                    }
-                                }
-                            }
-                            // Resolve files array elements too
-                            if let Some(serde_json::Value::Array(arr)) = args_obj.get_mut("files") {
-                                for item in arr.iter_mut() {
-                                    if let serde_json::Value::String(v) = item {
-                                        if !v.starts_with('/') {
-                                            let resolved = project_path.join(&*v);
-                                            *v = resolved.to_string_lossy().to_string();
-                                        }
                                     }
                                 }
                             }
@@ -1796,10 +1840,8 @@ async fn handle_mcp_request(
                     }
                 }
             }
-            req
-        } else {
-            request
         }
+        req
     } else {
         request
     };
@@ -1936,14 +1978,6 @@ async fn process_jsonrpc_request(
                 arguments
                     .entry("project".to_string())
                     .or_insert(serde_json::Value::String(project.to_string()));
-            }
-
-            // Auto-index the project if needed (this ensures the database is fresh before tool execution)
-            if let Some(ref project) = project_param {
-                if let Err(e) = mcp_server.ensure_project_indexed(project).await {
-                    tracing::warn!("Auto-index check failed for {}: {}", project, e);
-                    // Continue with tool execution even if auto-index fails
-                }
             }
 
             let result = mcp_server

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -26,6 +26,7 @@ impl ToolRegistry {
                     "properties": {
                         "path": {"type": "string", "description": "Path to index (default: current directory)"},
                         "incremental": {"type": "boolean", "description": "Only index changed files (git-based)"},
+                        "resolve_calls": {"type": "boolean", "default": false, "description": "Resolve unresolved call edges after indexing. Defaults to false for MCP responsiveness."},
                         "lang": {"type": "string", "description": "Filter by language (e.g., go,ts,py,rs,kt)"},
                         "exclude": {"type": "string", "description": "Exclude patterns (comma-separated)"},
                         "env": {"type": "string", "enum": ["local", "staging", "production"], "default": "local", "description": "Target environment for this index"},
@@ -341,6 +342,11 @@ impl ToolRegistry {
                 input_schema: json!({
                     "type": "object",
                     "properties": {
+                        "include_counts": {
+                            "type": "boolean",
+                            "description": "Optional: compute full element/file/function counts. Disabled by default because large databases can take a long time to count.",
+                            "default": false
+                        },
                         "project": {"type": "string", "description": "Optional: project path (resolves to nearest .leankg directory)"}
                     },
                     "required": []

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -35,6 +35,7 @@ fn test_cli_index_no_args() {
             lang,
             exclude,
             verbose,
+            ..
         } => {
             assert!(path.is_none());
             assert!(!incremental);
@@ -56,6 +57,7 @@ fn test_cli_index_with_path() {
             lang,
             exclude,
             verbose,
+            ..
         } => {
             assert_eq!(path.as_deref(), Some("./src"));
             assert!(!incremental);
@@ -77,6 +79,7 @@ fn test_cli_index_incremental() {
             lang,
             exclude,
             verbose,
+            ..
         } => {
             assert!(path.is_none());
             assert!(incremental);
@@ -98,6 +101,7 @@ fn test_cli_index_lang() {
             lang,
             exclude,
             verbose,
+            ..
         } => {
             assert!(path.is_none());
             assert!(!incremental);
@@ -119,6 +123,7 @@ fn test_cli_index_exclude() {
             lang,
             exclude,
             verbose,
+            ..
         } => {
             assert!(path.is_none());
             assert!(!incremental);
@@ -140,6 +145,7 @@ fn test_cli_index_verbose() {
             lang,
             exclude,
             verbose,
+            ..
         } => {
             assert!(path.is_none());
             assert!(!incremental);
@@ -172,6 +178,7 @@ fn test_cli_index_all_options() {
             lang,
             exclude,
             verbose,
+            ..
         } => {
             assert_eq!(path.as_deref(), Some("./src"));
             assert!(incremental);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -37,6 +37,39 @@ async fn test_find_files_excludes_node_modules() {
 }
 
 #[tokio::test(flavor = "multi_thread")]
+async fn test_find_files_excludes_nested_worktrees_from_project_root() {
+    let tmp = TempDir::new().unwrap();
+    std::fs::write(tmp.path().join("main.rs"), "fn main() {}").unwrap();
+    let worktree_src = tmp.path().join("worktrees").join("feature").join("src");
+    std::fs::create_dir_all(&worktree_src).unwrap();
+    std::fs::write(worktree_src.join("duplicate.rs"), "fn duplicate() {}").unwrap();
+
+    let files = find_files_sync(tmp.path().to_str().unwrap()).unwrap();
+    assert!(files.iter().any(|f| f.ends_with("main.rs")));
+    assert!(
+        !files.iter().any(|f| f.contains("duplicate.rs")),
+        "nested worktree files should not be indexed from the project root: {:?}",
+        files
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_find_files_allows_explicit_worktree_root() {
+    let tmp = TempDir::new().unwrap();
+    let worktree_src = tmp.path().join("worktrees").join("feature").join("src");
+    std::fs::create_dir_all(&worktree_src).unwrap();
+    std::fs::write(worktree_src.join("feature.rs"), "fn feature() {}").unwrap();
+
+    let worktree_root = tmp.path().join("worktrees").join("feature");
+    let files = find_files_sync(worktree_root.to_str().unwrap()).unwrap();
+    assert!(
+        files.iter().any(|f| f.ends_with("feature.rs")),
+        "explicit worktree roots should still be indexable: {:?}",
+        files
+    );
+}
+
+#[tokio::test(flavor = "multi_thread")]
 async fn test_find_files_in_nested_dirs() {
     let tmp = tempfile::TempDir::new().unwrap();
     let nested = tmp.path().join("a").join("b").join("c");
@@ -56,6 +89,61 @@ async fn test_init_db_creates_schema() {
     let db_path = tmp.path().join("leankg.db");
     let _db = init_db(db_path.as_path()).unwrap();
     assert!(db_path.exists() || std::path::Path::new(db_path.parent().unwrap()).exists());
+}
+
+#[tokio::test(flavor = "multi_thread")]
+async fn test_init_db_repairs_legacy_code_elements_after_recorded_migration() {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("legacy.db");
+    let db_path_str = db_path.to_string_lossy().to_string();
+    let legacy_db = cozo::new_cozo_sqlite(db_path_str).unwrap();
+
+    legacy_db.run_script(
+        r#":create code_elements {qualified_name: String, element_type: String, name: String, file_path: String, line_start: Int, line_end: Int, language: String, parent_qualified: String?, cluster_id: String?, cluster_label: String?, metadata: String}"#,
+        Default::default(),
+    ).unwrap();
+    legacy_db.run_script(
+        r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata] <- [["src/main.rs::main", "function", "main", "src/main.rs", 1, 3, "rust", null, null, null, "{}"]]
+        :put code_elements {qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata}"#,
+        Default::default(),
+    ).unwrap();
+    legacy_db
+        .run_script(
+            r#":create relationships {source_qualified: String, target_qualified: String, rel_type: String, confidence: Float, metadata: String}"#,
+            Default::default(),
+        )
+        .unwrap();
+    legacy_db
+        .run_script(
+            r#":create migrations {id: String, applied_at: Int}"#,
+            Default::default(),
+        )
+        .unwrap();
+    legacy_db
+        .run_script(
+            r#"?[id, applied_at] <- [["006_safe_canonical_schema_repair", 1]]
+        :put migrations {id, applied_at}"#,
+            Default::default(),
+        )
+        .unwrap();
+    drop(legacy_db);
+
+    let repaired_db = init_db(db_path.as_path()).unwrap();
+    let canonical_query = repaired_db
+        .run_script(
+            r#"?[qualified_name, env] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env]"#,
+            Default::default(),
+        )
+        .unwrap();
+    assert_eq!(canonical_query.rows.len(), 1);
+    assert_eq!(canonical_query.rows[0][1].as_str(), Some("local"));
+
+    let graph = GraphEngine::new(repaired_db);
+    let results = graph
+        .search_by_name_typed("main", Some("function"), 10)
+        .unwrap();
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].qualified_name, "src/main.rs::main");
 }
 
 #[tokio::test(flavor = "multi_thread")]


### PR DESCRIPTION
## Summary
- Stop HTTP MCP tool calls from doing surprise per-request auto-index work and serialize write-heavy tools.
- Make `mcp_index` skip expensive global call-edge resolution by default via `resolve_calls: false`.
- Repair legacy Cozo graph schemas where `code_elements`/`relationships` were missing the `env` column even after migration 006 was recorded.
- Make `mcp_status` lightweight by default and add `include_counts` for full counts.
- Fix project path routing, nested-runtime health checks, nested worktree indexing, and malformed graph queries found during the investigation.

## Validation
- `cargo fmt --check`
- `cargo check`
- `cargo build`
- `cargo test test_init_db_repairs_legacy_code_elements_after_recorded_migration -- --nocapture`
- `cargo test test_mcp_status -- --nocapture`
- `cargo test test_mcp_index -- --nocapture`
- `cargo test mcp_server -- --nocapture`
- `cargo test test_find_files -- --nocapture`
- `git diff --check`
- Manual HTTP MCP validation on `/Users/linh.doan/work/be` for `mcp_status`, `search_code`, `find_function`, and `mcp_index`.

## Notes
- The BE workspace DB schema was repaired during local validation.
- A fixed local server is currently running on port `9699` from tmux session `leankg-mcp-9699-fixed` for Cursor validation.