### PR TITLE
fix(docker): route LEANKG_MCP_PROJECT through env_file for multi-project compose

### DIFF
--- a/.dockerfile.example
+++ b/.dockerfile.example
@@ -1,12 +1,22 @@
 # Local-only docker compose overrides. Copy to `.dockerfile` and edit.
 # This file is .gitignored so user-specific host paths never leak.
 #
-# Usage:
+# Usage (single project):
 #   cp .dockerfile.example .dockerfile
-#   $EDITOR .dockerfile   # edit the paths
+#   $EDITOR .dockerfile
 #   docker compose -f docker-compose.rocksdb.yml --env-file .dockerfile up -d
 #
-# All variables are optional. Defaults are set in docker-compose.rocksdb.yml.
+# Usage (multi-project, with override file for side mounts):
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#   $EDITOR docker-compose.override.yml  # add bind mounts for side repos
+#   docker compose \
+#     -f docker-compose.rocksdb.yml \
+#     -f docker-compose.override.yml \
+#     --env-file .dockerfile up -d
+#
+# All variables below are optional. When unset, `entrypoint.sh` falls back to:
+#   LEANKG_MCP_PROJECT   -> /workspace
+#   LEANKG_PROJECT_DIRS  -> /workspace* glob (auto-discovery)
 
 # Absolute path to the LeanKG source tree on the host. Used as the primary
 # project mount and the container's working directory.
@@ -18,17 +28,24 @@ CONTAINER_PROJECT_PATH=/workspace
 
 # Path inside the container that the MCP server should serve by default.
 # LEANKG_MCP_PROJECT is read by `leankg mcp-http --project <path>`.
-# If LEANKG_PROJECT_DIRS is empty, the entrypoint falls back to CONTAINER_PROJECT_PATH.
 LEANKG_MCP_PROJECT=/workspace
+
+# Paths the entrypoint should scan and auto-index at startup.
+# IMPORTANT: this is a COMMA-SEPARATED list. `entrypoint.sh` does
+#   IFS=',' read -ra DIRS <<< "$LEANKG_PROJECT_DIRS"
+# so each entry must be separated by `,` (spaces are NOT separators).
+# Omit or leave blank to let the entrypoint fall back to a /workspace* glob.
 LEANKG_PROJECT_DIRS=/workspace
 
-# Multiple projects: list the host:container pairs (one per line). The MCP
-# server will scan and index every project listed in LEANKG_PROJECT_DIRS.
+# Multiple projects: list additional container paths after a comma. Each path
+# listed here MUST also be bind-mounted into the container. The simplest way
+# is via a local docker-compose override file (recommended); an example
+# template lives at `docker-compose.override.yml.example` (committed).
 #
 # Example — a second project on the side:
-#   LEANKG_PROJECT_DIRS=/workspace /workspace-other
-#   # Then add the matching bind mount via a docker compose override file
-#   # (see `.dockerfile.example` and `docker compose --env-file`).
-#
-# For additional mounts, prefer a docker-compose override file alongside
-# this .dockerfile rather than crowding the env list.
+#   LEANKG_PROJECT_DIRS=/workspace,/workspace-other
+#   # And in docker-compose.override.yml:
+#   #   services:
+#   #     leankg:
+#   #       volumes:
+#   #         - /Users/you/work/other-repo:/workspace-other

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -137,18 +137,18 @@ Environment variables for RocksDB (defaults are built into compose):
 - `LEANKG_DB_ENGINE=rocksdb` -- Switch from SQLite to RocksDB
 - `LEANKG_ROCKSDB_ROOT` -- Centralized storage root (default: `$HOME/.leankg-rocksdb`)
 
-The MCP server selects its project via `LEANKG_MCP_PROJECT`; the entrypoint scans and auto-indexes any directory listed in `LEANKG_PROJECT_DIRS` (comma-separated, e.g. `/workspace,/workspace-be`).
+The MCP server selects its project via `LEANKG_MCP_PROJECT`; the entrypoint scans and auto-indexes any directory listed in `LEANKG_PROJECT_DIRS` (comma-separated, e.g. `/workspace,/workspace-other`).
 
 ### Multi-project (side-by-side repos)
 
-To serve additional repos (e.g. a Go monorepo mounted at `/workspace-be` alongside the LeanKG source tree at `/workspace`):
+To serve additional repos (e.g. another project mounted at `/workspace-other` alongside the LeanKG source tree at `/workspace`):
 
 1. Create `.dockerfile` (local-only, gitignored) — copy from `.dockerfile.example`. Set:
    ```bash
    HOST_PROJECT_PATH=/path/to/leankg
    CONTAINER_PROJECT_PATH=/workspace
-   LEANKG_MCP_PROJECT=/workspace-be
-   LEANKG_PROJECT_DIRS=/workspace,/workspace-be
+   LEANKG_MCP_PROJECT=/workspace-other
+   LEANKG_PROJECT_DIRS=/workspace,/workspace-other
    ```
    Note the **comma-separated** `LEANKG_PROJECT_DIRS` -- `entrypoint.sh` uses `IFS=','`.
 
@@ -157,8 +157,9 @@ To serve additional repos (e.g. a Go monorepo mounted at `/workspace-be` alongsi
    services:
      leankg:
        volumes:
-         - /Users/you/work/be:/workspace-be
+         - /Users/you/work/other-repo:/workspace-other
    ```
+
 
 3. Start with the override file chained in:
    ```bash

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -118,11 +118,13 @@ Environment variables:
 
 ## RocksDB Docker Deployment
 
-The HTTP/SSE MCP server supports optional centralized RocksDB storage, useful when a single long-running server handles multiple projects:
+The HTTP/SSE MCP server supports optional centralized RocksDB storage, useful when a single long-running server handles multiple projects.
+
+### Single-project (default)
 
 ```bash
 # Start with RocksDB in Docker
-docker compose -f docker-compose.rocksdb.yml up --build
+docker compose -f docker-compose.rocksdb.yml --env-file .dockerfile up --build
 
 # Stop
 docker compose -f docker-compose.rocksdb.yml down
@@ -131,9 +133,43 @@ docker compose -f docker-compose.rocksdb.yml down
 docker volume rm leankg_leankg-rocksdb
 ```
 
-Environment variables for RocksDB:
+Environment variables for RocksDB (defaults are built into compose):
 - `LEANKG_DB_ENGINE=rocksdb` -- Switch from SQLite to RocksDB
 - `LEANKG_ROCKSDB_ROOT` -- Centralized storage root (default: `$HOME/.leankg-rocksdb`)
+
+The MCP server selects its project via `LEANKG_MCP_PROJECT`; the entrypoint scans and auto-indexes any directory listed in `LEANKG_PROJECT_DIRS` (comma-separated, e.g. `/workspace,/workspace-be`).
+
+### Multi-project (side-by-side repos)
+
+To serve additional repos (e.g. a Go monorepo mounted at `/workspace-be` alongside the LeanKG source tree at `/workspace`):
+
+1. Create `.dockerfile` (local-only, gitignored) — copy from `.dockerfile.example`. Set:
+   ```bash
+   HOST_PROJECT_PATH=/path/to/leankg
+   CONTAINER_PROJECT_PATH=/workspace
+   LEANKG_MCP_PROJECT=/workspace-be
+   LEANKG_PROJECT_DIRS=/workspace,/workspace-be
+   ```
+   Note the **comma-separated** `LEANKG_PROJECT_DIRS` -- `entrypoint.sh` uses `IFS=','`.
+
+2. Create `docker-compose.override.yml` (local-only, gitignored). The committed template adds the bind mount for the second repo:
+   ```yaml
+   services:
+     leankg:
+       volumes:
+         - /Users/you/work/be:/workspace-be
+   ```
+
+3. Start with the override file chained in:
+   ```bash
+   docker compose \
+     -f docker-compose.rocksdb.yml \
+     -f docker-compose.override.yml \
+     --env-file .dockerfile \
+     up -d
+   ```
+
+The override file's `volumes:` list is appended to the base compose, so the second bind mount appears alongside `/workspace` and the named RocksDB volume.
 
 Without Docker (host machine):
 

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -1,0 +1,26 @@
+# Local-only docker compose override for THIS machine.
+# Copy this file to `docker-compose.override.yml` and edit for your setup.
+# Both files are .gitignored so host-specific paths never leak.
+#
+# Usage:
+#   cp docker-compose.override.yml.example docker-compose.override.yml
+#   $EDITOR docker-compose.override.yml   # add your side-project bind mount(s)
+#   docker compose \
+#     -f docker-compose.rocksdb.yml \
+#     -f docker-compose.override.yml \
+#     --env-file .dockerfile up -d
+#
+# The `services.leankg.volumes` list below is APPENDED to the volumes in
+# docker-compose.rocksdb.yml. The named `leankg-rocksdb` volume is still
+# auto-created by the base file; only add additional bind mounts here.
+#
+# Important: any container path you bind-mount here MUST also appear in
+# `.dockerfile`'s `LEANKG_PROJECT_DIRS` (comma-separated) so the entrypoint
+# can find and index it on startup. See `.dockerfile.example`.
+
+services:
+  leankg:
+    volumes:
+      # Example: serve a side-by-side Go monorepo at /workspace-be
+      # (replace the host path with your actual repo location).
+      # - /Users/you/work/be:/workspace-be

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -21,6 +21,6 @@
 services:
   leankg:
     volumes:
-      # Example: serve a side-by-side Go monorepo at /workspace-be
+      # Example: serve a second repo at /workspace-other
       # (replace the host path with your actual repo location).
-      # - /Users/you/work/be:/workspace-be
+      # - /Users/you/work/other-repo:/workspace-other

--- a/docker-compose.rocksdb.yml
+++ b/docker-compose.rocksdb.yml
@@ -15,11 +15,14 @@ services:
       LEANKG_ROCKSDB_ROOT: /data/leankg-rocksdb
       MCP_HTTP_PORT: "9699"
       LEANKG_AUTO_INDEX: "1"
-      # The MCP project path and the project-dirs scan glob. Defaults are
-      # the single-project case (`./workspace`). Override via .dockerfile
-      # when running multiple projects side-by-side.
-      LEANKG_MCP_PROJECT: "${LEANKG_MCP_PROJECT:-/workspace}"
-      LEANKG_PROJECT_DIRS: "${LEANKG_PROJECT_DIRS:-/workspace}"
+      # `LEANKG_MCP_PROJECT` and `LEANKG_PROJECT_DIRS` are intentionally
+      # NOT set here. With both `env_file` (`.dockerfile`) and `environment:`
+      # declaring the same key, Compose lets `environment:` win, which silently
+      # ignored user overrides. The defaults live in `entrypoint.sh`:
+      #   LEANKG_MCP_PROJECT    -> /workspace if unset
+      #   LEANKG_PROJECT_DIRS   -> unset (entrypoint falls back to /workspace* glob)
+      # Override both by setting them in `.dockerfile` (comma-separated for
+      # LEANKG_PROJECT_DIRS, matching `entrypoint.sh`'s `IFS=','`).
       # Lower mmap default to keep RSS bounded; the previous 256 MiB blew
       # containers past the macOS Docker Desktop limit and triggered OOM kills.
       LEANKG_MMAP_SIZE: "67108864"

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -69,3 +69,58 @@ leankg index --lang go,ts,py,rs,java,kotlin
 # Exclude patterns
 leankg index --exclude vendor,node_modules,dist
 ```
+
+## Multi-Project Setup (Docker Compose)
+
+The containerized MCP server (RocksDB-backed, see `docker-compose.rocksdb.yml`) can serve multiple repositories side-by-side. Each repo gets its own auto-detected `?project=` route.
+
+**Required layout:**
+
+| What | Where | Why |
+|------|-------|-----|
+| `.dockerfile` | repo root (gitignored) | Holds host paths and per-project env vars |
+| `docker-compose.override.yml` | repo root (gitignored) | Adds bind mounts for side repos |
+| `LEANKG_PROJECT_DIRS` | inside `.dockerfile` | Comma-separated list of container paths to scan |
+
+**Start command (multi-project):**
+
+```bash
+docker compose \
+  -f docker-compose.rocksdb.yml \
+  -f docker-compose.override.yml \
+  --env-file .dockerfile \
+  up -d
+```
+
+**`.dockerfile` template:**
+
+```bash
+HOST_PROJECT_PATH=/path/to/leankg
+CONTAINER_PROJECT_PATH=/workspace
+LEANKG_MCP_PROJECT=/workspace              # default project the MCP server serves
+LEANKG_PROJECT_DIRS=/workspace,/workspace-other  # comma-separated!
+```
+
+**`docker-compose.override.yml` template:**
+
+```yaml
+services:
+  leankg:
+    volumes:
+      - /host/path/to/other-repo:/workspace-other
+```
+
+The override is **required** for any side repo to be mounted -- `docker-compose.rocksdb.yml` only mounts the primary `HOST_PROJECT_PATH`.
+
+If `LEANKG_PROJECT_DIRS` is unset, the entrypoint falls back to scanning `/workspace*`, `/test-project*` globs automatically.
+
+## MCP Project Routing
+
+When the HTTP server is started, every URL supports an optional `?project=` query parameter:
+
+| URL | Routes to |
+|-----|-----------|
+| `http://host:9699/mcp` | `LEANKG_MCP_PROJECT` (or default) |
+| `http://host:9699/mcp?project=/workspace-be` | `.leankg` DB inside `/workspace-be` |
+
+AI tool MCP configs must include the `?project=` param so each project queries the correct database. See `docs/agentic-instructions.md` for examples.

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -121,6 +121,6 @@ When the HTTP server is started, every URL supports an optional `?project=` quer
 | URL | Routes to |
 |-----|-----------|
 | `http://host:9699/mcp` | `LEANKG_MCP_PROJECT` (or default) |
-| `http://host:9699/mcp?project=/workspace-be` | `.leankg` DB inside `/workspace-be` |
+| `http://host:9699/mcp?project=/workspace-other` | `.leankg` DB inside `/workspace-other` |
 
 AI tool MCP configs must include the `?project=` param so each project queries the correct database. See `docs/agentic-instructions.md` for examples.


### PR DESCRIPTION
## Summary
- Stop `docker-compose.rocksdb.yml` from overriding `.dockerfile` values for `LEANKG_MCP_PROJECT` / `LEANKG_PROJECT_DIRS` (Compose `environment:` was winning over `env_file`, so multi-project overrides were silently ignored).
- Document the comma-separated `LEANKG_PROJECT_DIRS` convention and multi-project compose flow in `AGENTS.md`, `.dockerfile.example`, and `docs/cli-reference.md`.
- Add `docker-compose.override.yml.example` as a committed template for side-repo bind mounts.
- Use generic `/workspace-other` placeholders in docs (no personal `be/` paths).

## Test plan
- [ ] Copy `.dockerfile.example` → `.dockerfile` and set `LEANKG_MCP_PROJECT=/workspace-other`, `LEANKG_PROJECT_DIRS=/workspace,/workspace-other`
- [ ] Copy `docker-compose.override.yml.example` → `docker-compose.override.yml` with a second bind mount
- [ ] Run `docker compose -f docker-compose.rocksdb.yml -f docker-compose.override.yml --env-file .dockerfile config` and confirm merged env uses the `.dockerfile` values (not `/workspace` defaults)
- [ ] `docker compose ... up -d` and verify MCP serves the override project and both dirs are scanned/indexed
- [ ] Confirm single-project users without `.dockerfile` still fall back via `entrypoint.sh` defaults