### PR TITLE
fix: nested multi-repo auto-index + OOM-safe ontology queries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -165,6 +165,24 @@ Some mounts (e.g. a polyrepo directory that contains many service repos under `p
 - the project root itself is a git work tree, or
 - nested git repositories exist under that root.
 
+### Mega-graph / OOM-safe querying
+
+Workspaces above `LEANKG_MAX_CACHE_ELEMENTS` (default **50_000** elements) are treated as mega-graphs:
+
+- Discovery tools (`search_code`, `semantic_search`, `concept_search`, `query_file`) use **ontology-first + paginated** paths (`limit`/`offset`, max page 50).
+- Full-scan tools (`get_clusters`, `get_code_tree` without query, nav dumps, annotation full scans) **refuse** with a redirect hint instead of loading 600k+ rows.
+- Incremental auto-index **skips** full-graph dependent expansion on mega-graphs (override with `LEANKG_INCREMENTAL_SKIP_DEPENDENTS=1` to force skip always).
+- Prefer: `concept_search` → `semantic_search` → `search_code` → `kg_context` / `find_function`.
+
+Env knobs:
+
+| Variable | Default | Purpose |
+|----------|---------|---------|
+| `LEANKG_MAX_CACHE_ELEMENTS` | 50000 | Mega-graph threshold + in-memory cache gate |
+| `LEANKG_MAX_CLUSTER_ELEMENTS` | 50000 | Refuse Louvain clustering above this |
+| `LEANKG_CODE_TREE_CAP` | 50000 | Cap for small-graph code tree DB fetch |
+| `LEANKG_INCREMENTAL_SKIP_DEPENDENTS` | auto | Force-skip dependents in incremental index |
+
 ### Multi-project (side-by-side repos)
 
 To serve additional repos (e.g. another project mounted at `/workspace-other` alongside the LeanKG source tree at `/workspace`):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -157,6 +157,14 @@ Environment variables for RocksDB (defaults are built into compose):
 
 The MCP server selects its project via `LEANKG_MCP_PROJECT`; the entrypoint scans and auto-indexes any directory listed in `LEANKG_PROJECT_DIRS` (comma-separated, e.g. `/workspace,/workspace-other`).
 
+### Multi-repo workspace roots (nested git)
+
+Some mounts (e.g. a polyrepo directory that contains many service repos under `platform-*/*`) are **not** a git repository at the root. MCP auto-index still treats them as git-backed when nested `.git` directories are found (bounded depth scan). Freshness uses the latest `HEAD` commit time across nested repos; incremental indexing unions changed/untracked files from each nested repo with paths prefixed relative to the workspace root.
+
+`require_git_for_auto_index: true` in `leankg.yaml` therefore passes when either:
+- the project root itself is a git work tree, or
+- nested git repositories exist under that root.
+
 ### Multi-project (side-by-side repos)
 
 To serve additional repos (e.g. another project mounted at `/workspace-other` alongside the LeanKG source tree at `/workspace`):

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -29,6 +29,17 @@ fn normalize_path(path: &str) -> String {
     }
 }
 
+/// Maximum number of elements/relationships to cache in memory.
+/// Mega-graphs above this threshold skip the permanent cache to avoid
+/// unbounded RSS growth (see root_cause_docker_memory_2026-07-13.md RC1).
+/// Override via LEANKG_MAX_CACHE_ELEMENTS env var.
+fn max_cache_elements() -> usize {
+    std::env::var("LEANKG_MAX_CACHE_ELEMENTS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50_000)
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ChildrenResult {
     pub elements: Vec<CodeElement>,
@@ -470,6 +481,59 @@ impl GraphEngine {
         Ok((elements, total_count))
     }
 
+    /// Memory-efficient code element query for get_code_tree.
+    /// Filters by element_type at the database level (avoids loading all elements)
+    /// and caps results to prevent excessive memory on mega-graphs.
+    /// See root_cause_docker_memory_2026-07-13.md RC1.
+    pub fn get_code_elements_for_tree(
+        &self,
+        cap: usize,
+    ) -> Result<Vec<CodeElement>, Box<dyn std::error::Error>> {
+        let tail = self.code_elements_tail();
+        let cap = cap.min(50_000); // hard cap to protect memory
+        let query = format!(
+            r#"?[qualified_name, element_type, name, file_path, line_start, line_end] :=
+                *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata{tail}],
+                element_type in ["function", "struct", "class", "module", "interface", "enum", "trait"]
+                :limit {}"#,
+            cap
+        );
+        let result =
+            crate::db::schema::run_script(&self.db, &query, std::collections::BTreeMap::new())?;
+        let elements: Vec<CodeElement> = result
+            .rows
+            .iter()
+            .map(|row| CodeElement {
+                qualified_name: row[0].get_str().unwrap_or("").to_string(),
+                element_type: row[1].get_str().unwrap_or("").to_string(),
+                name: row[2].get_str().unwrap_or("").to_string(),
+                file_path: row[3].get_str().unwrap_or("").to_string(),
+                line_start: row[4].get_int().unwrap_or(0) as u32,
+                line_end: row[5].get_int().unwrap_or(0) as u32,
+                ..Default::default()
+            })
+            .collect();
+        Ok(elements)
+    }
+
+    /// Count code elements (function/struct/class/module/interface/enum/trait)
+    /// for accurate pagination metadata in get_code_tree.
+    pub fn count_code_elements(&self) -> Result<usize, Box<dyn std::error::Error>> {
+        let tail = self.code_elements_tail();
+        let query = format!(
+            r#"?[count(n)] :=
+                *code_elements[n, et, a, b, c, d, e, f, g, h, i, j{tail}],
+                et in ["function", "struct", "class", "module", "interface", "enum", "trait"]"#
+        );
+        let result =
+            crate::db::schema::run_script(&self.db, &query, std::collections::BTreeMap::new())?;
+        Ok(result
+            .rows
+            .first()
+            .and_then(|r| r[0].get_int())
+            .unwrap_or(0) as usize)
+    }
+
     /// Get relationships with pagination - memory efficient alternative to all_relationships()
     /// Avoids loading entire relationship set + building secondary index in memory
     pub fn get_relationships_paginated(
@@ -625,9 +689,19 @@ impl GraphEngine {
             })
             .collect();
 
-        // Store in cache ONLY when we have data
-        if !elements.is_empty() {
+        // Store in cache ONLY when we have data AND graph is not too large.
+        // Mega-graphs (> LEANKG_MAX_CACHE_ELEMENTS) are never cached to avoid
+        // unbounded RSS growth (see root_cause_docker_memory_2026-07-13.md RC1).
+        let max_cache = max_cache_elements();
+        if !elements.is_empty() && elements.len() <= max_cache {
             *self.elements_cache.write() = Some(elements.clone());
+        } else if elements.len() > max_cache {
+            tracing::warn!(
+                target: "leankg::mem",
+                elements = elements.len(),
+                max_cache,
+                "skipping elements_cache for large graph (LEANKG_MAX_CACHE_ELEMENTS)"
+            );
         }
 
         Ok(elements)
@@ -1100,9 +1174,21 @@ impl GraphEngine {
                 .push(idx);
         }
 
-        // Store in cache
-        *self.relationships_cache.write() = Some(relationships.clone());
-        *self.relationships_by_element.write() = Some(index);
+        // Store in cache ONLY when graph is not too large.
+        // Mega-graphs (> LEANKG_MAX_CACHE_ELEMENTS) skip cache to avoid
+        // unbounded RSS growth (see root_cause_docker_memory_2026-07-13.md RC1).
+        let max_cache = max_cache_elements();
+        if relationships.len() <= max_cache {
+            *self.relationships_cache.write() = Some(relationships.clone());
+            *self.relationships_by_element.write() = Some(index);
+        } else {
+            tracing::warn!(
+                target: "leankg::mem",
+                relationships = relationships.len(),
+                max_cache,
+                "skipping relationships_cache for large graph (LEANKG_MAX_CACHE_ELEMENTS)"
+            );
+        }
 
         Ok(relationships)
     }
@@ -3155,10 +3241,40 @@ impl GraphEngine {
         Ok(conflicts)
     }
 
+    /// FR-B22: Truncate a JSON array section to max_items entries, recording
+    /// truncation metadata if any items were dropped.
+    fn truncate_section(
+        section_name: &str,
+        items: Vec<serde_json::Value>,
+        max_items: Option<usize>,
+        truncated_sections: &mut Vec<serde_json::Value>,
+    ) -> Vec<serde_json::Value> {
+        match max_items {
+            Some(n) if items.len() > n => {
+                let original_count = items.len();
+                let truncated: Vec<serde_json::Value> = items.into_iter().take(n).collect();
+                truncated_sections.push(serde_json::json!({
+                    "section": section_name,
+                    "original_count": original_count,
+                    "returned_count": n,
+                }));
+                truncated
+            }
+            _ => items,
+        }
+    }
+
     /// FR-B20: Get architecture overview - languages, packages, entry points,
-    /// routes, hotspots, clusters, knowledge counts
-    pub fn get_architecture(&self) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    /// routes, hotspots, clusters, knowledge counts.
+    /// FR-B22: Honors token budgets via per-section max_items truncation.
+    /// When max_items is Some(n), each array section is capped at n entries and
+    /// truncated_sections reports which sections were trimmed and their original counts.
+    pub fn get_architecture(
+        &self,
+        max_items: Option<usize>,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
         let tail = self.code_elements_tail();
+        let mut truncated_sections: Vec<serde_json::Value> = Vec::new();
 
         let lang_query = format!(
             r#"?[language, count(language)] := *code_elements[_, _, _, _, _, _, language, _, _, _, _{tail}]
@@ -3290,6 +3406,26 @@ impl GraphEngine {
             })
             .collect();
 
+        let languages =
+            Self::truncate_section("languages", languages, max_items, &mut truncated_sections);
+        let entry_points = Self::truncate_section(
+            "entry_points",
+            entry_points,
+            max_items,
+            &mut truncated_sections,
+        );
+        let routes = Self::truncate_section("routes", routes, max_items, &mut truncated_sections);
+        let clusters =
+            Self::truncate_section("clusters", clusters, max_items, &mut truncated_sections);
+        let hotspots =
+            Self::truncate_section("hotspots", hotspots, max_items, &mut truncated_sections);
+        let relationship_counts = Self::truncate_section(
+            "relationship_summary",
+            relationship_counts,
+            max_items,
+            &mut truncated_sections,
+        );
+
         Ok(serde_json::json!({
             "languages": languages,
             "entry_points": entry_points,
@@ -3300,6 +3436,8 @@ impl GraphEngine {
             "knowledge_count": self.count_knowledge().unwrap_or(0),
             "total_elements": self.count_elements().unwrap_or(0),
             "total_files": self.count_files().unwrap_or(0),
+            "max_items": max_items,
+            "truncated_sections": truncated_sections,
         }))
     }
 
@@ -3314,9 +3452,14 @@ impl GraphEngine {
             .unwrap_or(0) as usize)
     }
 
-    /// FR-B21: Get graph schema - element type counts, relationship type counts
-    pub fn get_graph_schema(&self) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    /// FR-B21: Get graph schema - element type counts, relationship type counts.
+    /// FR-B22: Honors token budgets via per-section max_items truncation.
+    pub fn get_graph_schema(
+        &self,
+        max_items: Option<usize>,
+    ) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
         let tail = self.code_elements_tail();
+        let mut truncated_sections: Vec<serde_json::Value> = Vec::new();
         let type_query = format!(
             r#"?[element_type, count(element_type)] := *code_elements[
                 _, element_type, _, _, _, _, _, _, _, _, _{tail}
@@ -3354,11 +3497,26 @@ impl GraphEngine {
             })
             .collect();
 
+        let element_types = Self::truncate_section(
+            "element_types",
+            element_types,
+            max_items,
+            &mut truncated_sections,
+        );
+        let relationship_types = Self::truncate_section(
+            "relationship_types",
+            relationship_types,
+            max_items,
+            &mut truncated_sections,
+        );
+
         Ok(serde_json::json!({
             "element_types": element_types,
             "relationship_types": relationship_types,
             "total_elements": self.count_elements().unwrap_or(0),
             "total_relationships": self.count_relationships().unwrap_or(0),
+            "max_items": max_items,
+            "truncated_sections": truncated_sections,
         }))
     }
 
@@ -3816,7 +3974,7 @@ mod tests {
         insert_test_element(&engine, "func_b", "function");
         insert_test_element(&engine, "MyClass", "class");
 
-        let schema = engine.get_graph_schema().unwrap();
+        let schema = engine.get_graph_schema(None).unwrap();
         let obj = schema.as_object().unwrap();
         assert!(obj.contains_key("element_types"));
         assert!(obj.contains_key("relationship_types"));
@@ -3836,7 +3994,7 @@ mod tests {
             1,
             10,
         );
-        let arch = engine.get_architecture().unwrap();
+        let arch = engine.get_architecture(None).unwrap();
         let obj = arch.as_object().unwrap();
         assert!(obj.contains_key("languages"));
         assert!(obj.contains_key("entry_points"));
@@ -3851,7 +4009,7 @@ mod tests {
         insert_test_element(&engine, "main", "function");
         insert_test_element(&engine, "serve", "function");
         insert_test_element(&engine, "Start", "function");
-        let arch = engine.get_architecture().unwrap();
+        let arch = engine.get_architecture(None).unwrap();
         let obj = arch.as_object().unwrap();
         let eps = obj["entry_points"].as_array().unwrap();
         assert_eq!(eps.len(), 3, "Should find main, serve, Start");
@@ -3864,7 +4022,7 @@ mod tests {
         insert_test_element_full(&engine, "hot2", "function", "src/hot.rs", "rust", 6, 10);
         insert_test_element_full(&engine, "hot3", "function", "src/hot.rs", "rust", 11, 15);
         insert_test_element_full(&engine, "cold", "function", "src/cold.rs", "rust", 1, 5);
-        let arch = engine.get_architecture().unwrap();
+        let arch = engine.get_architecture(None).unwrap();
         let obj = arch.as_object().unwrap();
         let hs = obj["hotspots"].as_array().unwrap();
         assert!(!hs.is_empty(), "Should find hotspots");
@@ -3956,9 +4114,256 @@ mod tests {
     #[test]
     fn test_graph_schema_empty_db() {
         let (engine, _tmp) = make_test_engine();
-        let schema = engine.get_graph_schema().unwrap();
+        let schema = engine.get_graph_schema(None).unwrap();
         let obj = schema.as_object().unwrap();
         assert_eq!(obj["total_elements"].as_u64().unwrap(), 0);
         assert_eq!(obj["total_relationships"].as_u64().unwrap(), 0);
+    }
+
+    // ── FR-B22: Token budget / max_items truncation tests ──
+
+    #[test]
+    fn test_arch_max_items_truncates_languages() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "f1", "function", "src/a.rs", "rust", 1, 10);
+        insert_test_element_full(&engine, "f2", "function", "src/b.go", "go", 1, 10);
+        insert_test_element_full(&engine, "f3", "function", "src/c.ts", "typescript", 1, 10);
+        insert_test_element_full(&engine, "f4", "function", "src/d.py", "python", 1, 10);
+        insert_test_element_full(&engine, "f5", "function", "src/e.java", "java", 1, 10);
+
+        let arch = engine.get_architecture(Some(2)).unwrap();
+        let obj = arch.as_object().unwrap();
+        assert_eq!(obj["languages"].as_array().unwrap().len(), 2);
+        let trunc = obj["truncated_sections"].as_array().unwrap();
+        let lt = trunc
+            .iter()
+            .find(|t| t["section"].as_str() == Some("languages"));
+        assert!(lt.is_some());
+        assert_eq!(lt.unwrap()["original_count"].as_u64(), Some(5));
+        assert_eq!(lt.unwrap()["returned_count"].as_u64(), Some(2));
+    }
+
+    #[test]
+    fn test_arch_max_items_truncates_hotspots() {
+        let (engine, _tmp) = make_test_engine();
+        for i in 0..5 {
+            insert_test_element_full(
+                &engine,
+                &format!("f{}", i),
+                "function",
+                &format!("src/file_{}.rs", i),
+                "rust",
+                1,
+                10,
+            );
+        }
+        let arch = engine.get_architecture(Some(2)).unwrap();
+        let obj = arch.as_object().unwrap();
+        assert_eq!(obj["hotspots"].as_array().unwrap().len(), 2);
+        let trunc = obj["truncated_sections"].as_array().unwrap();
+        assert!(trunc
+            .iter()
+            .any(|t| t["section"].as_str() == Some("hotspots")));
+    }
+
+    #[test]
+    fn test_arch_max_items_truncates_entry_points() {
+        let (engine, _tmp) = make_test_engine();
+        for ep in &["main", "Main", "start", "serve", "Start"] {
+            insert_test_element_full(
+                &engine,
+                ep,
+                "function",
+                &format!("src/{}.rs", ep),
+                "rust",
+                1,
+                10,
+            );
+        }
+        let arch = engine.get_architecture(Some(2)).unwrap();
+        let obj = arch.as_object().unwrap();
+        assert_eq!(obj["entry_points"].as_array().unwrap().len(), 2);
+        let trunc = obj["truncated_sections"].as_array().unwrap();
+        let et = trunc
+            .iter()
+            .find(|t| t["section"].as_str() == Some("entry_points"));
+        assert!(et.is_some());
+        assert_eq!(et.unwrap()["original_count"].as_u64(), Some(5));
+    }
+
+    #[test]
+    fn test_arch_none_max_items_no_truncation() {
+        let (engine, _tmp) = make_test_engine();
+        for i in 0..10 {
+            insert_test_element_full(
+                &engine,
+                &format!("f{}", i),
+                "function",
+                &format!("src/f{}.rs", i),
+                "rust",
+                1,
+                10,
+            );
+        }
+        let arch = engine.get_architecture(None).unwrap();
+        let obj = arch.as_object().unwrap();
+        assert!(obj["truncated_sections"].as_array().unwrap().is_empty());
+        assert!(obj["max_items"].is_null());
+    }
+
+    #[test]
+    fn test_arch_max_items_larger_than_data() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "f1", "function", "src/a.rs", "rust", 1, 10);
+        let arch = engine.get_architecture(Some(100)).unwrap();
+        let obj = arch.as_object().unwrap();
+        assert!(obj["truncated_sections"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_arch_max_items_includes_field() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element(&engine, "func1", "function");
+        let arch = engine.get_architecture(Some(5)).unwrap();
+        let obj = arch.as_object().unwrap();
+        assert_eq!(obj["max_items"].as_u64(), Some(5));
+    }
+
+    #[test]
+    fn test_arch_max_items_one_minimal() {
+        let (engine, _tmp) = make_test_engine();
+        for i in 0..5 {
+            insert_test_element_full(
+                &engine,
+                &format!("f{}", i),
+                "function",
+                &format!("src/f{}.rs", i),
+                "rust",
+                1,
+                10,
+            );
+        }
+        let arch = engine.get_architecture(Some(1)).unwrap();
+        let obj = arch.as_object().unwrap();
+        for key in &[
+            "languages",
+            "entry_points",
+            "hotspots",
+            "clusters",
+            "relationship_summary",
+        ] {
+            assert!(
+                obj[*key].as_array().unwrap().len() <= 1,
+                "Section {} has >1 item",
+                key
+            );
+        }
+    }
+
+    #[test]
+    fn test_arch_max_items_preserves_scalars() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element(&engine, "f1", "function");
+        let arch = engine.get_architecture(Some(1)).unwrap();
+        let obj = arch.as_object().unwrap();
+        assert!(obj.contains_key("knowledge_count"));
+        assert!(obj.contains_key("total_elements"));
+        assert!(obj.contains_key("total_files"));
+    }
+
+    #[test]
+    fn test_arch_truncation_preserves_all_keys() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element(&engine, "f1", "function");
+        let arch = engine.get_architecture(Some(1)).unwrap();
+        let obj = arch.as_object().unwrap();
+        for key in &[
+            "languages",
+            "entry_points",
+            "routes",
+            "clusters",
+            "hotspots",
+            "relationship_summary",
+            "knowledge_count",
+            "total_elements",
+            "total_files",
+            "max_items",
+            "truncated_sections",
+        ] {
+            assert!(
+                obj.contains_key(*key),
+                "Missing key after truncation: {}",
+                key
+            );
+        }
+    }
+
+    #[test]
+    fn test_schema_max_items_truncates_element_types() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element(&engine, "f1", "function");
+        insert_test_element(&engine, "s1", "struct");
+        insert_test_element(&engine, "e1", "enum");
+        insert_test_element(&engine, "c1", "class");
+        insert_test_element(&engine, "i1", "interface");
+        let schema = engine.get_graph_schema(Some(2)).unwrap();
+        let obj = schema.as_object().unwrap();
+        assert_eq!(obj["element_types"].as_array().unwrap().len(), 2);
+        let trunc = obj["truncated_sections"].as_array().unwrap();
+        let et = trunc
+            .iter()
+            .find(|t| t["section"].as_str() == Some("element_types"));
+        assert!(et.is_some());
+        assert_eq!(et.unwrap()["original_count"].as_u64(), Some(5));
+    }
+
+    #[test]
+    fn test_schema_max_items_truncates_rel_types() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "a", "function", "src/a.rs", "rust", 1, 10);
+        insert_test_element_full(&engine, "b", "function", "src/b.rs", "rust", 1, 10);
+        insert_test_element_full(&engine, "c", "function", "src/c.rs", "rust", 1, 10);
+        insert_test_element_full(&engine, "d", "function", "src/d.rs", "rust", 1, 10);
+        insert_test_rel(&engine, "src/a.rs::a", "src/b.rs::b", "calls", 0.9);
+        insert_test_rel(&engine, "src/c.rs::c", "src/d.rs::d", "imports", 0.8);
+        insert_test_rel(&engine, "src/a.rs::a", "src/c.rs::c", "references", 0.7);
+        let schema = engine.get_graph_schema(Some(1)).unwrap();
+        let obj = schema.as_object().unwrap();
+        assert_eq!(obj["relationship_types"].as_array().unwrap().len(), 1);
+        let trunc = obj["truncated_sections"].as_array().unwrap();
+        let rt = trunc
+            .iter()
+            .find(|t| t["section"].as_str() == Some("relationship_types"));
+        assert!(rt.is_some());
+        assert_eq!(rt.unwrap()["original_count"].as_u64(), Some(3));
+    }
+
+    #[test]
+    fn test_schema_none_max_items_no_truncation() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element(&engine, "f1", "function");
+        let schema = engine.get_graph_schema(None).unwrap();
+        let obj = schema.as_object().unwrap();
+        assert!(obj["truncated_sections"].as_array().unwrap().is_empty());
+        assert!(obj["max_items"].is_null());
+    }
+
+    #[test]
+    fn test_schema_max_items_includes_field() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element(&engine, "f1", "function");
+        let schema = engine.get_graph_schema(Some(5)).unwrap();
+        let obj = schema.as_object().unwrap();
+        assert_eq!(obj["max_items"].as_u64(), Some(5));
+    }
+
+    #[test]
+    fn test_schema_max_items_preserves_scalars() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element(&engine, "f1", "function");
+        let schema = engine.get_graph_schema(Some(1)).unwrap();
+        let obj = schema.as_object().unwrap();
+        assert!(obj.contains_key("total_elements"));
+        assert!(obj.contains_key("total_relationships"));
     }
 }

--- a/src/indexer/git.rs
+++ b/src/indexer/git.rs
@@ -43,7 +43,14 @@ impl GitAnalyzer {
 
     pub fn get_changed_files_since_last_commit(
     ) -> Result<GitChangedFiles, Box<dyn std::error::Error>> {
+        Self::get_changed_files_since_last_commit_at(Path::new("."))
+    }
+
+    pub fn get_changed_files_since_last_commit_at(
+        path: &Path,
+    ) -> Result<GitChangedFiles, Box<dyn std::error::Error>> {
         let output = Command::new("git")
+            .current_dir(path)
             .args(["diff", "--name-status", "HEAD"])
             .output()?;
 
@@ -86,8 +93,15 @@ impl GitAnalyzer {
     }
 
     pub fn get_untracked_files() -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        Self::get_untracked_files_at(Path::new("."))
+    }
+
+    pub fn get_untracked_files_at(path: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        // Note: historically used the invalid subcommand `ls_files` (underscore),
+        // which always failed and returned no untracked files.
         let output = Command::new("git")
-            .args(["ls_files", "--others", "--exclude-standard"])
+            .current_dir(path)
+            .args(["ls-files", "--others", "--exclude-standard"])
             .output()?;
 
         if !output.status.success() {
@@ -130,7 +144,13 @@ impl GitAnalyzer {
     }
 
     pub fn is_git_repo() -> bool {
+        Self::is_git_repo_at(Path::new("."))
+    }
+
+    /// True when `path` is inside a git work tree (uses `git -C`).
+    pub fn is_git_repo_at(path: &Path) -> bool {
         Command::new("git")
+            .current_dir(path)
             .args(["rev-parse", "--is-inside-work-tree"])
             .output()
             .map(|o| o.status.success())
@@ -138,7 +158,12 @@ impl GitAnalyzer {
     }
 
     pub fn get_repo_root() -> Option<String> {
+        Self::get_repo_root_at(Path::new("."))
+    }
+
+    pub fn get_repo_root_at(path: &Path) -> Option<String> {
         let output = Command::new("git")
+            .current_dir(path)
             .args(["rev-parse", "--show-toplevel"])
             .output()
             .ok()?;
@@ -151,7 +176,12 @@ impl GitAnalyzer {
     }
 
     pub fn get_last_commit_time() -> Result<i64, Box<dyn std::error::Error>> {
+        Self::get_last_commit_time_at(Path::new("."))
+    }
+
+    pub fn get_last_commit_time_at(path: &Path) -> Result<i64, Box<dyn std::error::Error>> {
         let output = Command::new("git")
+            .current_dir(path)
             .args(["log", "-1", "--format=%ct", "HEAD"])
             .output()?;
 

--- a/src/indexer/git_workspace.rs
+++ b/src/indexer/git_workspace.rs
@@ -1,0 +1,274 @@
+//! Multi-repo workspace helpers for LeanKG auto-index.
+//!
+//! Some project roots (e.g. a polyrepo mount like `/workspace-be`) are not
+//! themselves git repositories but contain many nested repos under platform
+//! folders. Auto-index previously required the CWD to be a single git root
+//! and skipped those workspaces entirely.
+
+use crate::indexer::git::{GitAnalyzer, GitChangedFiles};
+use std::path::{Path, PathBuf};
+
+/// Max directory depth below the workspace root when searching for nested `.git`.
+const NESTED_GIT_MAX_DEPTH: usize = 4;
+
+const SKIP_DIR_NAMES: &[&str] = &[
+    ".git",
+    "node_modules",
+    "vendor",
+    "target",
+    "dist",
+    "build",
+    ".worktrees",
+    ".claude",
+    "browser-data",
+];
+
+/// True when `root` is a git work tree, or contains nested git repos.
+pub fn has_git_context(root: &Path) -> bool {
+    GitAnalyzer::is_git_repo_at(root) || !discover_nested_git_repos(root).is_empty()
+}
+
+/// Discover nested git repository roots under `root` (bounded depth).
+///
+/// A directory is treated as a repo root when it contains a `.git` directory
+/// or a `.git` file (worktree / submodule gitfile). Once a repo is found, that
+/// tree is not walked further.
+pub fn discover_nested_git_repos(root: &Path) -> Vec<PathBuf> {
+    let mut repos = Vec::new();
+    if !root.is_dir() {
+        return repos;
+    }
+
+    // Root itself may be a repo; callers usually check that first, but include
+    // it for completeness when scanning from a parent.
+    if GitAnalyzer::is_git_repo_at(root) {
+        repos.push(root.to_path_buf());
+        return repos;
+    }
+
+    let mut stack: Vec<(PathBuf, usize)> = vec![(root.to_path_buf(), 0)];
+    while let Some((dir, depth)) = stack.pop() {
+        if depth >= NESTED_GIT_MAX_DEPTH {
+            continue;
+        }
+        let entries = match std::fs::read_dir(&dir) {
+            Ok(e) => e,
+            Err(_) => continue,
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            let file_type = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if !file_type.is_dir() {
+                continue;
+            }
+            let name = entry.file_name();
+            let name_str = name.to_string_lossy();
+            if SKIP_DIR_NAMES.iter().any(|s| *s == name_str.as_ref()) {
+                continue;
+            }
+
+            let git_marker = path.join(".git");
+            if git_marker.exists() {
+                // Nested repo found — record and do not descend.
+                repos.push(path);
+                continue;
+            }
+            stack.push((path, depth + 1));
+        }
+    }
+
+    repos.sort();
+    repos
+}
+
+/// Latest HEAD commit timestamp across the root repo or all nested repos.
+pub fn workspace_last_commit_time(root: &Path) -> Result<i64, Box<dyn std::error::Error>> {
+    if GitAnalyzer::is_git_repo_at(root) {
+        return GitAnalyzer::get_last_commit_time_at(root);
+    }
+
+    let repos = discover_nested_git_repos(root);
+    if repos.is_empty() {
+        return Err("No git repository found at workspace root or nested paths".into());
+    }
+
+    let mut max_ts: i64 = 0;
+    let mut any_ok = false;
+    for repo in &repos {
+        match GitAnalyzer::get_last_commit_time_at(repo) {
+            Ok(ts) => {
+                any_ok = true;
+                max_ts = max_ts.max(ts);
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "Skipping nested repo {} for commit time: {}",
+                    repo.display(),
+                    e
+                );
+            }
+        }
+    }
+
+    if !any_ok {
+        return Err("Failed to read commit time from any nested git repo".into());
+    }
+    Ok(max_ts)
+}
+
+/// Aggregate working-tree changes from every nested repo, paths relative to `root`.
+pub fn workspace_changed_files(root: &Path) -> Result<GitChangedFiles, Box<dyn std::error::Error>> {
+    if GitAnalyzer::is_git_repo_at(root) {
+        return GitAnalyzer::get_changed_files_since_last_commit_at(root);
+    }
+
+    let repos = discover_nested_git_repos(root);
+    if repos.is_empty() {
+        return Err("No git repository found for incremental indexing".into());
+    }
+
+    let mut modified = Vec::new();
+    let mut added = Vec::new();
+    let mut deleted = Vec::new();
+
+    for repo in &repos {
+        let prefix = relative_prefix(root, repo);
+        let changed = GitAnalyzer::get_changed_files_since_last_commit_at(repo)?;
+        modified.extend(prefix_paths(&prefix, changed.modified));
+        added.extend(prefix_paths(&prefix, changed.added));
+        deleted.extend(prefix_paths(&prefix, changed.deleted));
+    }
+
+    Ok(GitChangedFiles {
+        modified,
+        added,
+        deleted,
+    })
+}
+
+/// Aggregate untracked files from every nested repo, paths relative to `root`.
+pub fn workspace_untracked_files(root: &Path) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    if GitAnalyzer::is_git_repo_at(root) {
+        return GitAnalyzer::get_untracked_files_at(root);
+    }
+
+    let repos = discover_nested_git_repos(root);
+    let mut out = Vec::new();
+    for repo in &repos {
+        let prefix = relative_prefix(root, repo);
+        let files = GitAnalyzer::get_untracked_files_at(repo)?;
+        out.extend(prefix_paths(&prefix, files));
+    }
+    Ok(out)
+}
+
+fn relative_prefix(root: &Path, repo: &Path) -> String {
+    repo.strip_prefix(root)
+        .map(|p| p.to_string_lossy().replace('\\', "/"))
+        .unwrap_or_default()
+}
+
+fn prefix_paths(prefix: &str, files: Vec<String>) -> Vec<String> {
+    if prefix.is_empty() {
+        return files;
+    }
+    files
+        .into_iter()
+        .map(|f| format!("{}/{}", prefix, f.replace('\\', "/")))
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::Command;
+
+    fn init_repo(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        assert!(Command::new("git")
+            .args(["init"])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success());
+        // Identity required for commit on some CI images.
+        let _ = Command::new("git")
+            .args(["config", "user.email", "test@example.com"])
+            .current_dir(path)
+            .status();
+        let _ = Command::new("git")
+            .args(["config", "user.name", "test"])
+            .current_dir(path)
+            .status();
+        std::fs::write(path.join("main.go"), "package main\n").unwrap();
+        assert!(Command::new("git")
+            .args(["add", "main.go"])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success());
+        assert!(Command::new("git")
+            .args(["commit", "-m", "init"])
+            .current_dir(path)
+            .status()
+            .unwrap()
+            .success());
+    }
+
+    #[test]
+    fn has_git_context_false_for_empty_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!has_git_context(dir.path()));
+    }
+
+    #[test]
+    fn has_git_context_true_for_root_repo() {
+        let dir = tempfile::tempdir().unwrap();
+        init_repo(dir.path());
+        assert!(has_git_context(dir.path()));
+    }
+
+    #[test]
+    fn discovers_nested_repos_under_platform_layout() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let nested_a = root.join("platform-food").join("be-restaurant");
+        let nested_b = root.join("platform-core").join("be-autos");
+        init_repo(&nested_a);
+        init_repo(&nested_b);
+        // Non-git platform folder should not count.
+        std::fs::create_dir_all(root.join("docs")).unwrap();
+
+        let repos = discover_nested_git_repos(root);
+        assert_eq!(repos.len(), 2);
+        assert!(has_git_context(root));
+        assert!(!GitAnalyzer::is_git_repo_at(root));
+
+        let ts = workspace_last_commit_time(root).unwrap();
+        assert!(ts > 0);
+    }
+
+    #[test]
+    fn workspace_changed_files_prefixes_nested_paths() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = dir.path();
+        let nested = root.join("platform-food").join("be-mailer");
+        init_repo(&nested);
+        std::fs::write(nested.join("extra.go"), "package main\n").unwrap();
+
+        let changed = workspace_changed_files(root).unwrap();
+        let untracked = workspace_untracked_files(root).unwrap();
+        assert!(
+            untracked
+                .iter()
+                .any(|f| f == "platform-food/be-mailer/extra.go"),
+            "untracked={:?}",
+            untracked
+        );
+        // dirty working tree may also appear as untracked only; ensure no panic.
+        let _ = changed;
+    }
+}

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1117,31 +1117,41 @@ pub async fn incremental_index_sync(
         graph.remove_relationships_by_source(deleted_file)?;
     }
 
-    let all_relationships = graph.all_relationships()?;
-    let rel_tuples: Vec<(String, String)> = all_relationships
-        .iter()
-        .map(|r| (r.source_qualified.clone(), r.target_qualified.clone()))
-        .collect();
-
+    // Mega-graphs (nested multi-repo workspaces like BE): never load all
+    // relationships just to expand dependents — that alone can add ~0.5–0.8 GiB
+    // and OOM a 6 GiB Docker container. See research_docker_memory_impact_2026-07-13.md.
     let mut dependent_files: Vec<String> = Vec::new();
-    for changed_file in &changed_files {
-        let file_name = std::path::Path::new(changed_file)
-            .file_name()
-            .and_then(|n| n.to_str())
-            .unwrap_or(changed_file);
+    if crate::ontology::safe_discover::skip_incremental_dependents(graph) {
+        tracing::warn!(
+            target: "leankg::mem",
+            changed = changed_files.len(),
+            "incremental_index: skipping full-graph dependent expansion on mega-graph / LEANKG_INCREMENTAL_SKIP_DEPENDENTS"
+        );
+    } else {
+        let all_relationships = graph.all_relationships()?;
+        let rel_tuples: Vec<(String, String)> = all_relationships
+            .iter()
+            .map(|r| (r.source_qualified.clone(), r.target_qualified.clone()))
+            .collect();
 
-        let deps = find_dependents(file_name, &rel_tuples);
-        for dep in deps {
-            let dep_path = std::path::Path::new(&dep);
-            if !dep_path.is_absolute() {
-                dependent_files.push(format!("{}/{}", workspace_root, dep));
-            } else {
-                dependent_files.push(dep);
+        for changed_file in &changed_files {
+            let file_name = std::path::Path::new(changed_file)
+                .file_name()
+                .and_then(|n| n.to_str())
+                .unwrap_or(changed_file);
+
+            let deps = find_dependents(file_name, &rel_tuples);
+            for dep in deps {
+                let dep_path = std::path::Path::new(&dep);
+                if !dep_path.is_absolute() {
+                    dependent_files.push(format!("{}/{}", workspace_root, dep));
+                } else {
+                    dependent_files.push(dep);
+                }
             }
         }
+        dependent_files.dedup();
     }
-
-    dependent_files.dedup();
 
     let mut all_files_to_process: Vec<String> = Vec::new();
     let mut seen: HashSet<String> = HashSet::new();

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1,6 +1,7 @@
 pub mod cicd;
 pub mod extractor;
 pub mod git;
+pub mod git_workspace;
 pub mod microservice;
 pub mod parser;
 pub mod process_processor;
@@ -1063,13 +1064,21 @@ pub async fn incremental_index_sync(
     parser_manager: &mut ParserManager,
     root_path: &str,
 ) -> Result<IncrementalIndexResult, Box<dyn std::error::Error>> {
-    if !GitAnalyzer::is_git_repo() {
-        return Err("Not a git repository. Cannot perform incremental indexing.".into());
+    let root = std::path::Path::new(root_path);
+    if !crate::indexer::git_workspace::has_git_context(root) {
+        return Err(
+            "Not a git repository (and no nested git repos found). Cannot perform incremental indexing."
+                .into(),
+        );
     }
 
-    let repo_root = GitAnalyzer::get_repo_root().unwrap_or_else(|| root_path.to_string());
+    let workspace_root = if GitAnalyzer::is_git_repo_at(root) {
+        GitAnalyzer::get_repo_root_at(root).unwrap_or_else(|| root_path.to_string())
+    } else {
+        root_path.to_string()
+    };
 
-    let changed = GitAnalyzer::get_changed_files_since_last_commit()?;
+    let changed = crate::indexer::git_workspace::workspace_changed_files(root)?;
 
     let deleted_files: Vec<String> = changed
         .deleted
@@ -1078,7 +1087,7 @@ pub async fn incremental_index_sync(
             if std::path::Path::new(f).is_absolute() {
                 f.clone()
             } else {
-                format!("{}/{}", repo_root, f)
+                format!("{}/{}", workspace_root, f)
             }
         })
         .collect();
@@ -1088,7 +1097,7 @@ pub async fn incremental_index_sync(
     all_changed.extend(changed.added);
     all_changed.extend(changed.deleted);
 
-    let untracked = GitAnalyzer::get_untracked_files()?;
+    let untracked = crate::indexer::git_workspace::workspace_untracked_files(root)?;
     let indexable_untracked = filter_indexable_files(&untracked);
     all_changed.extend(indexable_untracked);
 
@@ -1098,7 +1107,7 @@ pub async fn incremental_index_sync(
             if std::path::Path::new(f).is_absolute() {
                 f.clone()
             } else {
-                format!("{}/{}", repo_root, f)
+                format!("{}/{}", workspace_root, f)
             }
         })
         .collect();
@@ -1125,7 +1134,7 @@ pub async fn incremental_index_sync(
         for dep in deps {
             let dep_path = std::path::Path::new(&dep);
             if !dep_path.is_absolute() {
-                dependent_files.push(format!("{}/{}", repo_root, dep));
+                dependent_files.push(format!("{}/{}", workspace_root, dep));
             } else {
                 dependent_files.push(dep);
             }

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1000,6 +1000,83 @@ impl ToolHandler {
             .ok_or("Missing 'pattern' parameter")?;
 
         let element_type_filter = args["element_type"].as_str().map(String::from);
+        let limit = crate::ontology::safe_discover::clamp_limit(
+            args["limit"].as_i64().unwrap_or(50) as usize,
+        );
+        let offset = args["offset"].as_i64().unwrap_or(0).max(0) as usize;
+
+        // Mega-graph: ontology/semantic discover instead of full table scan.
+        if crate::ontology::safe_discover::is_mega_graph(&self.graph_engine) {
+            let page = crate::ontology::safe_discover::discover(
+                &self.graph_engine,
+                pattern,
+                args["env"].as_str().unwrap_or("local"),
+                limit,
+                offset,
+                true,
+            )
+            .map_err(|e| e.to_string())?;
+            let mut matches: Vec<Value> = page
+                .results
+                .iter()
+                .filter(|e| {
+                    let pattern_match = if pattern.contains('*') || pattern.contains('?') {
+                        self.glob_match(pattern, &e.file_path)
+                            || self.glob_match(pattern, &e.qualified_name)
+                    } else {
+                        e.file_path.contains(pattern) || e.qualified_name.contains(pattern)
+                    };
+                    let type_match = element_type_filter
+                        .as_ref()
+                        .map(|et| &e.element_type == et)
+                        .unwrap_or(true);
+                    pattern_match && type_match
+                })
+                .map(|e| {
+                    json!({
+                        "qualified_name": e.qualified_name,
+                        "name": e.name,
+                        "type": e.element_type,
+                        "file": e.file_path,
+                        "line": e.line_start
+                    })
+                })
+                .collect();
+            // If ontology path filtered everything, fall back to typed name search page.
+            if matches.is_empty() {
+                let probe = pattern.trim_matches(|c| c == '*' || c == '?' || c == '/');
+                let found = self
+                    .graph_engine
+                    .search_by_name_typed(probe, element_type_filter.as_deref(), limit + offset)
+                    .map_err(|e| e.to_string())?;
+                matches = found
+                    .into_iter()
+                    .skip(offset)
+                    .take(limit)
+                    .filter(|e| {
+                        e.file_path.contains(probe)
+                            || e.qualified_name.contains(probe)
+                            || probe.is_empty()
+                    })
+                    .map(|e| {
+                        json!({
+                            "qualified_name": e.qualified_name,
+                            "name": e.name,
+                            "type": e.element_type,
+                            "file": e.file_path,
+                            "line": e.line_start
+                        })
+                    })
+                    .collect();
+            }
+            return Ok(json!({
+                "results": matches,
+                "count": matches.len(),
+                "limit": limit,
+                "offset": offset,
+                "method": "ontology_or_name_paginated"
+            }));
+        }
 
         let elements = self
             .graph_engine
@@ -1021,7 +1098,8 @@ impl ToolHandler {
                     .unwrap_or(true);
                 pattern_match && type_match
             })
-            .take(50)
+            .skip(offset)
+            .take(limit)
             .map(|e| {
                 json!({
                     "qualified_name": e.qualified_name,
@@ -1033,7 +1111,13 @@ impl ToolHandler {
             })
             .collect();
 
-        Ok(json!({ "files": matches }))
+        Ok(json!({
+            "results": matches,
+            "count": matches.len(),
+            "limit": limit,
+            "offset": offset,
+            "method": "scan"
+        }))
     }
 
     fn get_dependencies(&self, args: &Value) -> Result<Value, String> {
@@ -1341,32 +1425,42 @@ impl ToolHandler {
 
     fn search_code(&self, args: &Value) -> Result<Value, String> {
         let query = args["query"].as_str().ok_or("Missing 'query' parameter")?;
-        let limit = args["limit"].as_i64().unwrap_or(20).min(50) as usize;
+        let limit = args["limit"].as_i64().unwrap_or(20) as usize;
+        let offset = args["offset"].as_i64().unwrap_or(0).max(0) as usize;
         let element_type = args["element_type"].as_str();
-        let use_ontology = args["use_ontology"].as_bool().unwrap_or(false);
+        let env = args["env"].as_str().unwrap_or("local");
+        // Mega-graphs default to ontology-first; small graphs keep legacy opt-in.
+        let mega = crate::ontology::safe_discover::is_mega_graph(&self.graph_engine);
+        let use_ontology = args["use_ontology"].as_bool().unwrap_or(mega);
 
-        // Concept-gated workflow: extract keywords -> scan concept ontology ->
-        // load concept -> query db. Only used when explicitly requested; falls
-        // back to plain name search if no concept matches.
-        if use_ontology {
-            let env = args["env"].as_str().unwrap_or("local");
-            let query_engine =
-                crate::ontology::OntologyQueryEngine::new(self.graph_engine.db().clone());
-            let result = query_engine
-                .concept_search(query, env, limit)
-                .map_err(|e| format!("Concept search failed: {}", e))?;
-            if result.concept_match_count > 0 || !result.linked_code.is_empty() {
-                return Ok(self.format_concept_search_result(&result));
+        if use_ontology || mega {
+            let mut page = crate::ontology::safe_discover::discover(
+                &self.graph_engine,
+                query,
+                env,
+                limit,
+                offset,
+                true,
+            )
+            .map_err(|e| format!("Ontology-first search failed: {}", e))?;
+
+            // Optional element_type filter on the page (already bounded).
+            if let Some(et) = element_type {
+                page.results.retain(|e| e.element_type == et);
+                page.total_estimate = page.results.len();
+                page.has_more = false;
             }
-            // else fall through to plain name search
+            return Ok(crate::ontology::safe_discover::discover_page_to_json(&page));
         }
 
+        let limit = crate::ontology::safe_discover::clamp_limit(limit);
         let elements = self
             .graph_engine
-            .search_by_name_typed(query, element_type, limit)
+            .search_by_name_typed(query, element_type, limit.saturating_add(offset))
             .map_err(|e| e.to_string())?;
-
-        let matches: Vec<_> = elements
+        let total_estimate = elements.len();
+        let page: Vec<_> = elements.into_iter().skip(offset).take(limit).collect();
+        let matches: Vec<_> = page
             .iter()
             .map(|e| {
                 json!({
@@ -1381,7 +1475,15 @@ impl ToolHandler {
             })
             .collect();
 
-        Ok(json!({ "results": matches }))
+        Ok(json!({
+            "results": matches,
+            "count": matches.len(),
+            "limit": limit,
+            "offset": offset,
+            "total_estimate": total_estimate,
+            "has_more": offset + matches.len() < total_estimate,
+            "method": "name"
+        }))
     }
 
     fn concept_search(&self, args: &Value) -> Result<Value, String> {
@@ -1471,6 +1573,13 @@ impl ToolHandler {
         let file_pattern = args["file_pattern"].as_str();
         let limit = args["limit"].as_i64().unwrap_or(20) as usize;
 
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "search_annotations",
+        ) {
+            return Ok(refusal);
+        }
+
         let all_elements = self
             .graph_engine
             .all_elements()
@@ -1537,117 +1646,44 @@ impl ToolHandler {
     fn semantic_search(&self, args: &Value) -> Result<Value, String> {
         let query = args["query"].as_str().ok_or("Missing 'query'")?;
         let env = args["env"].as_str().unwrap_or("local");
-        let limit = args["limit"].as_i64().unwrap_or(5) as usize;
+        let limit = args["limit"].as_i64().unwrap_or(20) as usize;
+        let offset = args["offset"].as_i64().unwrap_or(0).max(0) as usize;
 
-        let results = self.perform_semantic_search(query, env, limit)?;
+        // Always ontology-first + paginated — never load env-wide element dumps.
+        let page = crate::ontology::safe_discover::discover(
+            &self.graph_engine,
+            query,
+            env,
+            limit,
+            offset,
+            true,
+        )
+        .map_err(|e| format!("Semantic search failed: {}", e))?;
 
-        Ok(json!({
-            "query": query,
-            "env": env,
-            "results": results,
-            "count": results.len(),
-            "method": "keyword+fuzzy"
-        }))
-    }
-
-    fn perform_semantic_search(
-        &self,
-        query: &str,
-        env: &str,
-        limit: usize,
-    ) -> Result<Vec<Value>, String> {
-        let query_lower = query.to_lowercase();
-        let keywords: Vec<&str> = query_lower.split_whitespace().collect();
-
-        let mut elements = db::get_elements_by_env(self.graph_engine.db(), env, 1000)
-            .map_err(|e| format!("DB error: {}", e))?;
-        let mut seen: std::collections::HashSet<String> = elements
-            .iter()
-            .map(|elem| elem.qualified_name.clone())
-            .collect();
-
-        for keyword in &keywords {
-            for elem in self
-                .graph_engine
-                .search_by_name_typed(keyword, None, 50)
-                .map_err(|e| format!("DB error: {}", e))?
-            {
-                if seen.insert(elem.qualified_name.clone()) {
-                    elements.push(elem);
-                }
-            }
+        let mut body = crate::ontology::safe_discover::discover_page_to_json(&page);
+        if let Some(obj) = body.as_object_mut() {
+            obj.insert(
+                "method".to_string(),
+                json!(format!("ontology+semantic({})", page.method)),
+            );
         }
-
-        let mut scored: Vec<(f64, &db::models::CodeElement)> = elements
-            .iter()
-            .map(|elem| {
-                let name_lower = elem.name.to_lowercase();
-                let type_lower = elem.element_type.to_lowercase();
-                let qn_lower = elem.qualified_name.to_lowercase();
-                let file_lower = elem.file_path.to_lowercase();
-
-                let mut score = 0.0;
-                for kw in &keywords {
-                    if name_lower.contains(kw) {
-                        score += 3.0;
-                    }
-                    if type_lower.contains(kw) {
-                        score += 2.0;
-                    }
-                    if qn_lower.contains(kw) {
-                        score += 1.0;
-                    }
-                    if file_lower.contains(kw) {
-                        score += 1.0;
-                    }
-                }
-
-                if name_lower == query_lower {
-                    score += 10.0;
-                }
-
-                (-score, elem)
-            })
-            .filter(|(score, _)| *score < 0.0)
-            .collect();
-
-        scored.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap());
-
-        let results: Vec<Value> = scored
-            .into_iter()
-            .take(limit)
-            .map(|(score, elem)| {
-                json!({
-                    "qualified_name": elem.qualified_name,
-                    "name": elem.name,
-                    "element_type": elem.element_type,
-                    "file_path": elem.file_path,
-                    "score": -score,
-                    "env": elem.env,
-                })
-            })
-            .collect();
-
-        Ok(results)
+        Ok(body)
     }
 
     fn generate_doc(&self, args: &Value) -> Result<Value, String> {
         let file = args["file"].as_str().ok_or("Missing 'file' parameter")?;
 
-        let elements = self
+        // File-scoped DB query — never all_elements().
+        let file_elements = self
             .graph_engine
-            .all_elements()
-            .map_err(|e| e.to_string())?;
-
-        let file_elements: Vec<CodeElement> = elements
+            .get_elements_by_file(file)
+            .map_err(|e| e.to_string())?
             .into_iter()
             .filter(|e| {
                 let fp = &e.file_path;
-                fp.contains(file)
-                    && !fp.contains("/.claude/worktrees/")
-                    && !fp.contains("/.worktrees/")
+                !fp.contains("/.claude/worktrees/") && !fp.contains("/.worktrees/")
             })
-            .collect();
+            .collect::<Vec<_>>();
 
         let doc = generate_documentation(file, &file_elements);
 
@@ -1656,45 +1692,44 @@ impl ToolHandler {
 
     fn find_large_functions(&self, args: &Value) -> Result<Value, String> {
         let min_lines = args["min_lines"].as_u64().unwrap_or(50) as u32;
-        let limit = args["limit"].as_i64().unwrap_or(50) as usize;
+        let limit = crate::ontology::safe_discover::clamp_limit(
+            args["limit"].as_i64().unwrap_or(50) as usize,
+        );
+        let offset = args["offset"].as_i64().unwrap_or(0).max(0) as usize;
 
-        let elements = self
+        // DB-filtered oversized query — never all_elements(). Cap fetch for memory.
+        let fetch_cap = (limit + offset).min(500).max(limit);
+        let mut elements = self
             .graph_engine
-            .all_elements()
+            .find_oversized_functions(min_lines)
             .map_err(|e| e.to_string())?;
-
-        let total: usize = elements
-            .iter()
-            .filter(|e| {
-                e.element_type == "function"
-                    && (e.line_end.saturating_sub(e.line_start)) >= min_lines
-                    && !e.file_path.contains("/.claude/worktrees/")
-                    && !e.file_path.contains("/.worktrees/")
-            })
-            .count();
-
+        elements.retain(|e| {
+            !e.file_path.contains("/.claude/worktrees/") && !e.file_path.contains("/.worktrees/")
+        });
+        let total = elements.len();
         let large_functions: Vec<_> = elements
-            .iter()
-            .filter(|e| {
-                e.element_type == "function"
-                    && (e.line_end.saturating_sub(e.line_start)) >= min_lines
-                    && !e.file_path.contains("/.claude/worktrees/")
-                    && !e.file_path.contains("/.worktrees/")
-            })
+            .into_iter()
+            .skip(offset)
+            .take(fetch_cap.min(limit))
             .map(|e| {
                 json!({
                     "qualified_name": e.qualified_name,
                     "name": e.name,
                     "file": e.file_path,
-                    "lines": e.line_end - e.line_start,
+                    "lines": e.line_end.saturating_sub(e.line_start),
                     "line_start": e.line_start,
                     "line_end": e.line_end
                 })
             })
-            .take(limit)
             .collect();
 
-        Ok(json!({ "large_functions": large_functions, "total": total, "limit": limit }))
+        Ok(json!({
+            "large_functions": large_functions,
+            "total": total,
+            "limit": limit,
+            "offset": offset,
+            "has_more": offset + large_functions.len() < total
+        }))
     }
 
     fn get_tested_by(&self, args: &Value) -> Result<Value, String> {
@@ -1769,6 +1804,13 @@ impl ToolHandler {
     }
 
     fn get_doc_structure(&self, _args: &Value) -> Result<Value, String> {
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_doc_structure",
+        ) {
+            return Ok(refusal);
+        }
+
         let elements = self
             .graph_engine
             .all_elements()
@@ -1875,6 +1917,13 @@ impl ToolHandler {
     }
 
     fn get_doc_tree(&self, _args: &Value) -> Result<Value, String> {
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_doc_tree",
+        ) {
+            return Ok(refusal);
+        }
+
         let elements = self
             .graph_engine
             .all_elements()
@@ -1923,24 +1972,47 @@ impl ToolHandler {
         let limit = args["limit"].as_i64().unwrap_or(100) as usize;
         let offset = args["offset"].as_i64().unwrap_or(0) as usize;
 
+        // Prefer ontology/semantic discovery on mega-graphs instead of tree dumps.
+        if let Some(q) = args["query"].as_str() {
+            if !q.is_empty() {
+                let page = crate::ontology::safe_discover::discover(
+                    &self.graph_engine,
+                    q,
+                    args["env"].as_str().unwrap_or("local"),
+                    limit,
+                    offset,
+                    true,
+                )
+                .map_err(|e| e.to_string())?;
+                let mut body = crate::ontology::safe_discover::discover_page_to_json(&page);
+                if let Some(obj) = body.as_object_mut() {
+                    obj.insert("code_tree_mode".to_string(), json!("ontology_discover"));
+                }
+                return Ok(body);
+            }
+        }
+
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_code_tree",
+        ) {
+            return Ok(refusal);
+        }
+
+        // Small graphs: DB-level filtered query with hard cap (no all_elements).
+        let cap = std::env::var("LEANKG_CODE_TREE_CAP")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(50_000);
         let elements = self
             .graph_engine
-            .all_elements()
+            .get_code_elements_for_tree(cap)
             .map_err(|e| e.to_string())?;
 
-        // Group elements by file, keeping file_path with each group
         let mut files_map: std::collections::BTreeMap<String, (String, Vec<Value>)> =
             std::collections::BTreeMap::new();
 
         for elem in &elements {
-            let is_code_element = matches!(
-                elem.element_type.as_str(),
-                "function" | "struct" | "class" | "module" | "interface" | "enum" | "trait"
-            );
-            if !is_code_element {
-                continue;
-            }
-
             let parts: Vec<&str> = elem.file_path.split('/').collect();
             if parts.is_empty() {
                 continue;
@@ -1961,8 +2033,8 @@ impl ToolHandler {
             }));
         }
 
-        // Convert to array of {file, file_path, elements} objects for TOON optimization
         let total = files_map.len();
+        let truncated = elements.len() >= cap;
         let code_tree: Vec<Value> = files_map
             .into_iter()
             .skip(offset)
@@ -1976,7 +2048,14 @@ impl ToolHandler {
             })
             .collect();
 
-        Ok(json!({ "code_tree": code_tree, "total": total, "offset": offset, "limit": limit }))
+        Ok(json!({
+            "code_tree": code_tree,
+            "total": total,
+            "offset": offset,
+            "limit": limit,
+            "truncated": truncated,
+            "cap": cap
+        }))
     }
 
     fn find_related_docs(&self, args: &Value) -> Result<Value, String> {
@@ -2006,6 +2085,38 @@ impl ToolHandler {
         use crate::graph::clustering::{Cluster, CommunityDetector};
 
         let limit = args["limit"].as_i64().unwrap_or(100) as usize;
+
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_clusters",
+        ) {
+            return Ok(refusal);
+        }
+
+        let max_cluster_elements = std::env::var("LEANKG_MAX_CLUSTER_ELEMENTS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(50_000);
+        let element_count = self
+            .graph_engine
+            .count_elements()
+            .map_err(|e| e.to_string())?;
+        if element_count > max_cluster_elements {
+            tracing::warn!(
+                target: "leankg::mem",
+                elements = element_count,
+                max = max_cluster_elements,
+                "get_clusters refused: graph too large"
+            );
+            return Ok(json!({
+                "clusters": [],
+                "stats": { "total_clusters": 0, "total_members": 0, "avg_cluster_size": 0.0 },
+                "error": format!(
+                    "Clustering refused: graph has {} elements (max {}). Use concept_search / semantic_search with pagination, or shard the project.",
+                    element_count, max_cluster_elements
+                )
+            }));
+        }
 
         let detector = CommunityDetector::new(self.graph_engine.db());
         let clusters = match detector.detect_communities() {
@@ -2110,6 +2221,13 @@ impl ToolHandler {
         let file = args["file"].as_str();
         let graph_id = args["graph_id"].as_str();
 
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_nav_graph",
+        ) {
+            return Ok(refusal);
+        }
+
         let all_elements = self
             .graph_engine
             .all_elements()
@@ -2168,6 +2286,13 @@ impl ToolHandler {
     fn find_route(&self, args: &Value) -> Result<Value, String> {
         let route = args["route"].as_str().ok_or("Missing 'route' parameter")?;
 
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "find_route",
+        ) {
+            return Ok(refusal);
+        }
+
         let all_elements = self
             .graph_engine
             .all_elements()
@@ -2197,6 +2322,13 @@ impl ToolHandler {
     fn get_screen_args(&self, args: &Value) -> Result<Value, String> {
         let destination = args["destination"].as_str().unwrap_or("");
         let limit = args["limit"].as_i64().unwrap_or(20) as usize;
+
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_screen_args",
+        ) {
+            return Ok(refusal);
+        }
 
         let all_elements = self
             .graph_engine
@@ -2236,6 +2368,13 @@ impl ToolHandler {
             .as_str()
             .ok_or("Missing 'destination' parameter")?;
 
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_nav_callers",
+        ) {
+            return Ok(refusal);
+        }
+
         let all_rels = self
             .graph_engine
             .all_relationships()
@@ -2263,6 +2402,13 @@ impl ToolHandler {
 
         let cluster_id = args["cluster_id"].as_str();
         let cluster_label = args["cluster_label"].as_str();
+
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_cluster_context",
+        ) {
+            return Ok(refusal);
+        }
 
         let detector = CommunityDetector::new(self.graph_engine.db());
         let clusters = match detector.detect_communities() {
@@ -3111,17 +3257,31 @@ impl ToolHandler {
         }))
     }
 
-    /// FR-B20: Get architecture overview
-    fn get_architecture(&self, _args: &Value) -> Result<Value, String> {
+    /// FR-B20: Get architecture overview (paginated / truncated sections).
+    fn get_architecture(&self, args: &Value) -> Result<Value, String> {
+        let max_items = args["max_items"].as_u64().map(|v| v as usize).or_else(|| {
+            if crate::ontology::safe_discover::is_mega_graph(&self.graph_engine) {
+                Some(20)
+            } else {
+                None
+            }
+        });
         self.graph_engine
-            .get_architecture()
+            .get_architecture(max_items)
             .map_err(|e| format!("Failed to get architecture: {}", e))
     }
 
-    /// FR-B21: Get graph schema overview
-    fn get_graph_schema(&self, _args: &Value) -> Result<Value, String> {
+    /// FR-B21: Get graph schema overview (paginated / truncated sections).
+    fn get_graph_schema(&self, args: &Value) -> Result<Value, String> {
+        let max_items = args["max_items"].as_u64().map(|v| v as usize).or_else(|| {
+            if crate::ontology::safe_discover::is_mega_graph(&self.graph_engine) {
+                Some(20)
+            } else {
+                None
+            }
+        });
         self.graph_engine
-            .get_graph_schema()
+            .get_graph_schema(max_items)
             .map_err(|e| format!("Failed to get graph schema: {}", e))
     }
 

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -1212,18 +1212,31 @@ impl MCPServer {
             return Ok(());
         }
 
-        let is_git = crate::indexer::GitAnalyzer::is_git_repo();
+        let is_git = crate::indexer::git_workspace::has_git_context(&project_root);
         if config.mcp.require_git_for_auto_index && !is_git {
-            tracing::info!("Not a git repo, skipping auto-index");
+            tracing::info!(
+                "No git repo (or nested repos) under {}, skipping auto-index",
+                project_root.display()
+            );
             return Ok(());
         }
 
         let last_commit_time = if !is_git {
-            tracing::info!("Not a git repo but require_git_for_auto_index=false, forcing reindex");
+            tracing::info!(
+                "No git context under {} but require_git_for_auto_index=false, forcing reindex",
+                project_root.display()
+            );
             i64::MAX
         } else {
-            match crate::indexer::GitAnalyzer::get_last_commit_time() {
-                Ok(t) => t,
+            match crate::indexer::git_workspace::workspace_last_commit_time(&project_root) {
+                Ok(t) => {
+                    tracing::info!(
+                        "Git workspace freshness: last nested/root commit ts={} at {}",
+                        t,
+                        project_root.display()
+                    );
+                    t
+                }
                 Err(e) => {
                     tracing::warn!("Failed to get last commit time: {}", e);
                     return Ok(());
@@ -1356,9 +1369,16 @@ impl MCPServer {
             return Ok(());
         }
 
-        // Check git status to determine if indexing is needed
+        // Check git status to determine if indexing is needed (supports nested multi-repo roots)
         let last_commit_time = if config.mcp.require_git_for_auto_index {
-            match Self::get_git_commit_time_for_path(&project_root) {
+            if !crate::indexer::git_workspace::has_git_context(&project_root) {
+                tracing::debug!(
+                    "No git context under {}, skipping auto-index",
+                    project_root.display()
+                );
+                return Ok(());
+            }
+            match crate::indexer::git_workspace::workspace_last_commit_time(&project_root) {
                 Ok(t) => t,
                 Err(e) => {
                     tracing::debug!(
@@ -1434,24 +1454,6 @@ impl MCPServer {
 
         tracing::debug!("Auto-index complete for {}", project_root.display());
         Ok(())
-    }
-
-    /// Get last git commit timestamp for a specific path
-    fn get_git_commit_time_for_path(path: &PathBuf) -> Result<i64, String> {
-        let output = std::process::Command::new("git")
-            .current_dir(path)
-            .args(["log", "-1", "--format=%ct", "HEAD"])
-            .output()
-            .map_err(|e| format!("Failed to run git: {}", e))?;
-
-        if !output.status.success() {
-            return Err("Failed to get last commit time".to_string());
-        }
-
-        let timestamp_str = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        timestamp_str
-            .parse::<i64>()
-            .map_err(|e| format!("Failed to parse timestamp: {}", e))
     }
 
     async fn trigger_reindex(&self) -> Result<(), String> {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -736,7 +736,7 @@ impl ToolRegistry {
             },
             ToolDefinition {
                 name: "semantic_search".to_string(),
-                description: "Ontology-first semantic discovery with pagination. Scans concept ontology then falls back to bounded name search. Safe on mega-graphs / nested multi-repo workspaces (never loads full element tables).".to_string(),
+                description: "Natural language semantic discovery with pagination. Ontology-first: scans concept ontology then falls back to bounded name search. Safe on mega-graphs / nested multi-repo workspaces (never loads full element tables).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -247,15 +247,16 @@ impl ToolRegistry {
             },
             ToolDefinition {
                 name: "search_code".to_string(),
-                description: "Search code elements by name/type. Set use_ontology=true to run the concept-gated workflow first (extract keywords -> scan concept ontology -> load concept -> query db); falls back to name search if no concept matches.".to_string(),
+                description: "Ontology-first paginated code search. On mega-graphs (>LEANKG_MAX_CACHE_ELEMENTS) defaults to concept ontology → code_refs → DB, then semantic name fallback. Never full-table scans large workspaces. Use limit/offset for pagination.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
-                        "query": {"type": "string", "description": "Search query string (raw words/concepts allowed when use_ontology=true)"},
+                        "query": {"type": "string", "description": "Search query string (raw words/concepts allowed)"},
                         "element_type": {"type": "string", "enum": ["file", "function", "struct", "class", "module", "import"], "description": "Filter by element type"},
-                        "limit": {"type": "integer", "default": 20, "description": "Maximum number of results (default: 20, max: 50)"},
-                        "use_ontology": {"type": "boolean", "default": false, "description": "If true, first scan the concept ontology and resolve matched concept code_refs against the DB before falling back to name search."},
-                        "env": {"type": "string", "default": "local", "description": "Environment scope for the ontology scan (used only when use_ontology=true)"},
+                        "limit": {"type": "integer", "default": 20, "description": "Page size (default: 20, max: 50)"},
+                        "offset": {"type": "integer", "default": 0, "description": "Pagination offset"},
+                        "use_ontology": {"type": "boolean", "default": true, "description": "Concept-gated workflow first. Defaults true on mega-graphs; set false only for tiny projects."},
+                        "env": {"type": "string", "default": "local", "description": "Environment scope for the ontology scan"},
                         "project": {"type": "string", "description": "Optional: project path to search in (resolves to nearest .leankg directory)"}
                     },
                     "required": ["query"]
@@ -735,13 +736,14 @@ impl ToolRegistry {
             },
             ToolDefinition {
                 name: "semantic_search".to_string(),
-                description: "Natural language search for graph nodes. Falls back to keyword and fuzzy matching when exact names are unknown. Returns top matching nodes with similarity scores.".to_string(),
+                description: "Ontology-first semantic discovery with pagination. Scans concept ontology then falls back to bounded name search. Safe on mega-graphs / nested multi-repo workspaces (never loads full element tables).".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
                         "query": {"type": "string", "description": "Natural language query (e.g., 'service that handles refunds')"},
                         "env": {"type": "string", "enum": ["production", "staging", "local"], "default": "local", "description": "Environment to search"},
-                        "limit": {"type": "integer", "default": 5, "description": "Maximum results (default: 5)"},
+                        "limit": {"type": "integer", "default": 20, "description": "Page size (default: 20, max: 50)"},
+                        "offset": {"type": "integer", "default": 0, "description": "Pagination offset"},
                         "project": {"type": "string", "description": "Optional: project path"}
                     },
                     "required": ["query"]
@@ -843,10 +845,11 @@ impl ToolRegistry {
             },
             ToolDefinition {
                 name: "get_architecture".to_string(),
-                description: "Get architecture overview: languages, packages, entry points, routes, hotspots, clusters, knowledge counts, relationship summary. Single-call alternative to running multiple individual queries.".to_string(),
+                description: "Get architecture overview: languages, packages, entry points, routes, hotspots, clusters, knowledge counts, relationship summary. Single-call alternative to running multiple individual queries. Supports max_items to cap each section for token budget control.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
+                        "max_items": {"type": "integer", "description": "Optional: per-section item cap for token budget control."},
                         "project": {"type": "string", "description": "Optional: project path (resolves to nearest .leankg directory)"}
                     },
                     "required": []
@@ -854,10 +857,11 @@ impl ToolRegistry {
             },
             ToolDefinition {
                 name: "get_graph_schema".to_string(),
-                description: "Get graph schema overview: element type counts, relationship type counts. Use to understand database structure and find available element/relationship patterns.".to_string(),
+                description: "Get graph schema overview: element type counts, relationship type counts. Use to understand database structure and find available element/relationship patterns. Supports max_items to cap each section for token budget control.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
+                        "max_items": {"type": "integer", "description": "Optional: per-section item cap for token budget control."},
                         "project": {"type": "string", "description": "Optional: project path (resolves to nearest .leankg directory)"}
                     },
                     "required": []

--- a/src/ontology/mod.rs
+++ b/src/ontology/mod.rs
@@ -2,6 +2,7 @@ pub mod concept;
 pub mod loader;
 pub mod procedural;
 pub mod query;
+pub mod safe_discover;
 
 // Re-export for convenience
 #[allow(unused_imports)]
@@ -22,6 +23,12 @@ pub use query::{
     calculate_match_score, extract_keywords, normalize_path, ConceptSearchResult, KgSelfTestEntry,
     KgSelfTestReport, MatchedConcept, OntologyContextResult, OntologyNodeInfo, OntologyQueryEngine,
     OntologyStatus,
+};
+#[allow(unused_imports)]
+pub use safe_discover::{
+    clamp_limit, discover, discover_page_to_json, is_mega_graph, mega_graph_refusal,
+    mega_graph_threshold, refuse_full_scan_if_mega, skip_incremental_dependents, DiscoverPage,
+    DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT,
 };
 
 use serde::{Deserialize, Serialize};

--- a/src/ontology/safe_discover.rs
+++ b/src/ontology/safe_discover.rs
@@ -1,0 +1,294 @@
+//! Ontology-first, paginated discovery for mega-graphs.
+//!
+//! Large nested-git workspaces (e.g. BE with 600k+ elements) must never
+//! materialize the full graph for discovery. Callers should go through:
+//!   1. concept ontology scan
+//!   2. semantic / name search with hard pagination
+//!   3. targeted file/QN lookups
+//!
+//! Full-table helpers (`all_elements` / `all_relationships`) are refused when
+//! the graph exceeds `LEANKG_MAX_CACHE_ELEMENTS` (default 50_000).
+
+use crate::db::models::CodeElement;
+use crate::graph::GraphEngine;
+use crate::ontology::{ConceptSearchResult, OntologyQueryEngine};
+use serde_json::{json, Value};
+
+/// Default page size for discovery tools.
+pub const DEFAULT_PAGE_LIMIT: usize = 20;
+/// Hard ceiling for any single discovery page.
+pub const MAX_PAGE_LIMIT: usize = 50;
+
+/// Mega-graph threshold (same default as in-memory cache gate).
+pub fn mega_graph_threshold() -> usize {
+    std::env::var("LEANKG_MAX_CACHE_ELEMENTS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(50_000)
+}
+
+pub fn clamp_limit(limit: usize) -> usize {
+    if limit == 0 {
+        DEFAULT_PAGE_LIMIT
+    } else {
+        limit.min(MAX_PAGE_LIMIT)
+    }
+}
+
+/// True when element count exceeds the mega-graph threshold.
+pub fn is_mega_graph(engine: &GraphEngine) -> bool {
+    engine
+        .count_elements()
+        .map(|n| n > mega_graph_threshold())
+        .unwrap_or(true)
+}
+
+/// Standard refusal payload when a tool would full-scan a mega-graph.
+pub fn mega_graph_refusal(tool: &str, element_count: usize) -> Value {
+    let max = mega_graph_threshold();
+    json!({
+        "error": format!(
+            "{tool} refused: graph has {element_count} elements (max {max} for full-scan tools)"
+        ),
+        "element_count": element_count,
+        "max_full_scan": max,
+        "hint": "Use concept_search, semantic_search, or search_code (ontology-first, paginated with limit/offset). Avoid get_clusters / full-tree scans on mega-graphs.",
+        "recommended_tools": [
+            "concept_search",
+            "semantic_search",
+            "search_code",
+            "kg_context",
+            "find_function",
+            "query_file"
+        ]
+    })
+}
+
+/// If mega-graph, return refusal; otherwise None (caller may proceed).
+pub fn refuse_full_scan_if_mega(engine: &GraphEngine, tool: &str) -> Option<Value> {
+    match engine.count_elements() {
+        Ok(n) if n > mega_graph_threshold() => Some(mega_graph_refusal(tool, n)),
+        Ok(_) => None,
+        Err(e) => Some(json!({
+            "error": format!("{tool} refused: failed to count elements: {e}"),
+            "hint": "Use concept_search / semantic_search with pagination."
+        })),
+    }
+}
+
+#[derive(Debug)]
+pub struct DiscoverPage {
+    pub query: String,
+    pub env: String,
+    pub limit: usize,
+    pub offset: usize,
+    pub method: String,
+    pub concept: Option<ConceptSearchResult>,
+    pub results: Vec<CodeElement>,
+    pub total_estimate: usize,
+    pub has_more: bool,
+}
+
+/// Ontology-first discovery with pagination.
+///
+/// Order:
+/// 1. `OntologyQueryEngine::concept_search` (concept ontology → code_refs)
+/// 2. If empty: paginated name search over keywords (no full-table load)
+pub fn discover(
+    engine: &GraphEngine,
+    query: &str,
+    env: &str,
+    limit: usize,
+    offset: usize,
+    prefer_ontology: bool,
+) -> Result<DiscoverPage, Box<dyn std::error::Error>> {
+    let limit = clamp_limit(limit);
+    let env = if env.is_empty() { "local" } else { env };
+
+    if prefer_ontology {
+        let oq = OntologyQueryEngine::new(engine.db().clone());
+        // Fetch a slightly larger concept page then slice for offset.
+        let fetch = limit
+            .saturating_add(offset)
+            .min(MAX_PAGE_LIMIT * 4)
+            .max(limit);
+        let concept = oq.concept_search(query, env, fetch)?;
+        if concept.concept_match_count > 0 || !concept.linked_code.is_empty() {
+            let mut merged = concept.linked_code.clone();
+            if merged.is_empty() {
+                merged = concept.fallback_results.clone();
+            }
+            let total_estimate = merged.len();
+            let page: Vec<CodeElement> = merged.into_iter().skip(offset).take(limit).collect();
+            let has_more = offset + page.len() < total_estimate;
+            return Ok(DiscoverPage {
+                query: query.to_string(),
+                env: env.to_string(),
+                limit,
+                offset,
+                method: "ontology+concept".to_string(),
+                concept: Some(concept),
+                results: page,
+                total_estimate,
+                has_more,
+            });
+        }
+    }
+
+    // Semantic / name fallback: keyword probes with DB-level typed search only.
+    let query_lower = query.to_lowercase();
+    let keywords: Vec<&str> = query_lower.split_whitespace().collect();
+    let probes: Vec<&str> = if keywords.is_empty() {
+        vec![query]
+    } else {
+        keywords
+    };
+
+    let mut seen = std::collections::HashSet::new();
+    let mut scored: Vec<(i32, CodeElement)> = Vec::new();
+
+    for probe in probes.iter().take(8) {
+        let hits =
+            engine.search_by_name_typed(probe, None, limit.saturating_add(offset).max(limit))?;
+        for elem in hits {
+            if !seen.insert(elem.qualified_name.clone()) {
+                continue;
+            }
+            let name_l = elem.name.to_lowercase();
+            let qn_l = elem.qualified_name.to_lowercase();
+            let mut score = 0;
+            if name_l == query_lower {
+                score += 100;
+            }
+            if name_l.contains(&query_lower) {
+                score += 40;
+            }
+            for kw in &probes {
+                if name_l.contains(kw) {
+                    score += 10;
+                }
+                if qn_l.contains(kw) {
+                    score += 3;
+                }
+            }
+            if score > 0 {
+                scored.push((score, elem));
+            }
+        }
+    }
+
+    scored.sort_by_key(|b| std::cmp::Reverse(b.0));
+    let total_estimate = scored.len();
+    let page: Vec<CodeElement> = scored
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|(_, e)| e)
+        .collect();
+    let has_more = offset + page.len() < total_estimate;
+
+    Ok(DiscoverPage {
+        query: query.to_string(),
+        env: env.to_string(),
+        limit,
+        offset,
+        method: if prefer_ontology {
+            "semantic+name_fallback".to_string()
+        } else {
+            "semantic+name".to_string()
+        },
+        concept: None,
+        results: page,
+        total_estimate,
+        has_more,
+    })
+}
+
+pub fn discover_page_to_json(page: &DiscoverPage) -> Value {
+    let results: Vec<Value> = page
+        .results
+        .iter()
+        .map(|e| {
+            json!({
+                "qualified_name": e.qualified_name,
+                "name": e.name,
+                "type": e.element_type,
+                "element_type": e.element_type,
+                "file": e.file_path,
+                "file_path": e.file_path,
+                "line": e.line_start,
+                "line_start": e.line_start,
+                "language": e.language,
+                "env": e.env,
+            })
+        })
+        .collect();
+
+    let mut body = json!({
+        "query": page.query,
+        "env": page.env,
+        "method": page.method,
+        "results": results,
+        "count": results.len(),
+        "limit": page.limit,
+        "offset": page.offset,
+        "total_estimate": page.total_estimate,
+        "has_more": page.has_more,
+        "pagination": {
+            "limit": page.limit,
+            "offset": page.offset,
+            "has_more": page.has_more,
+            "next_offset": if page.has_more { Some(page.offset + page.limit) } else { None::<usize> }
+        }
+    });
+
+    if let Some(concept) = &page.concept {
+        body["matched_concepts"] = json!(concept
+            .matched_concepts
+            .iter()
+            .map(|c| json!({
+                "gid": c.gid,
+                "name": c.name,
+                "element_type": c.element_type,
+                "match_score": c.match_score,
+                "match_reason": c.match_reason,
+                "code_refs": c.code_refs,
+            }))
+            .collect::<Vec<_>>());
+        body["concept_match_count"] = json!(concept.concept_match_count);
+        body["fallback_used"] = json!(concept.fallback_used);
+    }
+
+    body
+}
+
+/// Whether incremental indexing should skip full-graph dependent expansion.
+pub fn skip_incremental_dependents(engine: &GraphEngine) -> bool {
+    if std::env::var("LEANKG_INCREMENTAL_SKIP_DEPENDENTS")
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    is_mega_graph(engine)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clamp_limit_caps_at_max_page() {
+        assert_eq!(clamp_limit(0), DEFAULT_PAGE_LIMIT);
+        assert_eq!(clamp_limit(10), 10);
+        assert_eq!(clamp_limit(10_000), MAX_PAGE_LIMIT);
+    }
+
+    #[test]
+    fn mega_graph_refusal_mentions_ontology_tools() {
+        let v = mega_graph_refusal("get_clusters", 600_000);
+        let s = v.to_string();
+        assert!(s.contains("concept_search"));
+        assert!(s.contains("600000"));
+    }
+}

--- a/tests/phase1_benchmark_test.rs
+++ b/tests/phase1_benchmark_test.rs
@@ -580,7 +580,7 @@ fn bench_architecture_returns_all_keys() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
     let arch = engine
-        .get_architecture()
+        .get_architecture(None)
         .expect("get_architecture should succeed");
     let obj = arch.as_object().unwrap();
 
@@ -594,6 +594,8 @@ fn bench_architecture_returns_all_keys() {
         "knowledge_count",
         "total_elements",
         "total_files",
+        "max_items",
+        "truncated_sections",
     ];
     for key in &required {
         assert!(obj.contains_key(*key), "Missing key: {}", key);
@@ -604,7 +606,7 @@ fn bench_architecture_returns_all_keys() {
 fn bench_architecture_detects_rust_language() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     let langs = obj["languages"].as_array().unwrap();
     let rust = langs
@@ -618,7 +620,7 @@ fn bench_architecture_detects_rust_language() {
 fn bench_architecture_finds_main_entry_point() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     let eps = obj["entry_points"].as_array().unwrap();
     assert!(!eps.is_empty(), "Should find entry points");
@@ -632,7 +634,7 @@ fn bench_architecture_finds_main_entry_point() {
 fn bench_architecture_finds_hotspots() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     let hs = obj["hotspots"].as_array().unwrap();
     assert!(!hs.is_empty(), "Should find hotspots");
@@ -647,7 +649,7 @@ fn bench_architecture_finds_hotspots() {
 fn bench_architecture_finds_clusters() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     let clusters = obj["clusters"].as_array().unwrap();
     assert_eq!(
@@ -661,7 +663,7 @@ fn bench_architecture_finds_clusters() {
 fn bench_architecture_counts_relationships() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     let rels = obj["relationship_summary"].as_array().unwrap();
     let calls = rels
@@ -681,7 +683,7 @@ fn bench_architecture_counts_relationships() {
 fn bench_schema_counts_element_types() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let schema = engine.get_graph_schema().unwrap();
+    let schema = engine.get_graph_schema(None).unwrap();
     let obj = schema.as_object().unwrap();
     let types = obj["element_types"].as_array().unwrap();
 
@@ -706,7 +708,7 @@ fn bench_schema_counts_element_types() {
 fn bench_schema_counts_relationship_types() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let schema = engine.get_graph_schema().unwrap();
+    let schema = engine.get_graph_schema(None).unwrap();
     let obj = schema.as_object().unwrap();
     let rels = obj["relationship_types"].as_array().unwrap();
 
@@ -727,7 +729,7 @@ fn bench_schema_counts_relationship_types() {
 fn bench_schema_totals_correct() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
-    let schema = engine.get_graph_schema().unwrap();
+    let schema = engine.get_graph_schema(None).unwrap();
     let obj = schema.as_object().unwrap();
     assert_eq!(obj["total_elements"].as_u64().unwrap(), 39);
     assert_eq!(obj["total_relationships"].as_u64().unwrap(), 19);
@@ -825,7 +827,7 @@ fn bench_resolution_method_present_in_metadata() {
     let (engine, _tmp) = make_engine();
     index_leankg_self(&engine);
     // The calls we inserted have resolution_method in metadata
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     let rels = obj["relationship_summary"].as_array().unwrap();
     let calls_count = rels
@@ -1035,7 +1037,7 @@ fn bench_routes_appear_in_architecture() {
     };
     engine.insert_element(&route_elem).unwrap();
 
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     let routes = obj["routes"].as_array().unwrap();
     assert!(!routes.is_empty(), "Architecture should include routes");
@@ -1043,4 +1045,170 @@ fn bench_routes_appear_in_architecture() {
         .iter()
         .find(|r| r["path"].as_str().unwrap() == "/health");
     assert!(health.is_some(), "Should find /health route");
+}
+
+// ── FR-B22: Token budget truncation benchmark tests ──
+
+#[test]
+fn bench_arch_max_items_truncates_hotspots() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let full = engine.get_architecture(None).unwrap();
+    let full_hs = full["hotspots"].as_array().unwrap().len();
+
+    let arch = engine.get_architecture(Some(2)).unwrap();
+    let obj = arch.as_object().unwrap();
+    assert_eq!(obj["hotspots"].as_array().unwrap().len(), 2);
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+    let hs = trunc
+        .iter()
+        .find(|t| t["section"].as_str() == Some("hotspots"));
+    assert!(hs.is_some());
+    assert_eq!(hs.unwrap()["original_count"].as_u64(), Some(full_hs as u64));
+}
+
+#[test]
+fn bench_arch_max_items_truncates_relationships() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let arch = engine.get_architecture(Some(1)).unwrap();
+    let obj = arch.as_object().unwrap();
+    assert_eq!(obj["relationship_summary"].as_array().unwrap().len(), 1);
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+    let rs = trunc
+        .iter()
+        .find(|t| t["section"].as_str() == Some("relationship_summary"));
+    assert!(rs.is_some());
+    assert_eq!(rs.unwrap()["original_count"].as_u64(), Some(2));
+}
+
+#[test]
+fn bench_arch_max_items_reports_all_truncated() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let arch = engine.get_architecture(Some(1)).unwrap();
+    let obj = arch.as_object().unwrap();
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+    let names: Vec<&str> = trunc.iter().filter_map(|t| t["section"].as_str()).collect();
+    assert!(names.contains(&"hotspots"), "hotspots should be truncated");
+    assert!(names.contains(&"clusters"), "clusters should be truncated");
+}
+
+#[test]
+fn bench_arch_max_items_none_returns_full() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let arch = engine.get_architecture(None).unwrap();
+    let obj = arch.as_object().unwrap();
+    assert!(obj["truncated_sections"].as_array().unwrap().is_empty());
+    assert!(obj["max_items"].is_null());
+    assert_eq!(obj["relationship_summary"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn bench_arch_max_items_one_minimal() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let arch = engine.get_architecture(Some(1)).unwrap();
+    let obj = arch.as_object().unwrap();
+    for key in &[
+        "languages",
+        "entry_points",
+        "hotspots",
+        "clusters",
+        "relationship_summary",
+    ] {
+        assert!(
+            obj[*key].as_array().unwrap().len() <= 1,
+            "Section {} >1 item",
+            key
+        );
+    }
+    assert_eq!(obj["max_items"].as_u64(), Some(1));
+}
+
+#[test]
+fn bench_arch_truncation_reduces_token_size() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let full = engine.get_architecture(None).unwrap();
+    let truncated = engine.get_architecture(Some(1)).unwrap();
+    assert!(
+        truncated.to_string().len() < full.to_string().len(),
+        "Truncated should be smaller than full"
+    );
+}
+
+#[test]
+fn bench_schema_max_items_truncates_types() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let full = engine.get_graph_schema(None).unwrap();
+    let full_types = full["element_types"].as_array().unwrap().len();
+
+    let schema = engine.get_graph_schema(Some(2)).unwrap();
+    let obj = schema.as_object().unwrap();
+    assert_eq!(obj["element_types"].as_array().unwrap().len(), 2);
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+    let et = trunc
+        .iter()
+        .find(|t| t["section"].as_str() == Some("element_types"));
+    assert!(et.is_some());
+    assert_eq!(
+        et.unwrap()["original_count"].as_u64(),
+        Some(full_types as u64)
+    );
+}
+
+#[test]
+fn bench_schema_max_items_truncates_rel_types() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let schema = engine.get_graph_schema(Some(1)).unwrap();
+    let obj = schema.as_object().unwrap();
+    assert_eq!(obj["relationship_types"].as_array().unwrap().len(), 1);
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+    let rt = trunc
+        .iter()
+        .find(|t| t["section"].as_str() == Some("relationship_types"));
+    assert!(rt.is_some());
+    assert_eq!(rt.unwrap()["original_count"].as_u64(), Some(2));
+}
+
+#[test]
+fn bench_schema_truncation_preserves_totals() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let schema = engine.get_graph_schema(Some(1)).unwrap();
+    let obj = schema.as_object().unwrap();
+    assert_eq!(obj["total_elements"].as_u64().unwrap(), 39);
+    assert_eq!(obj["total_relationships"].as_u64().unwrap(), 19);
+}
+
+#[test]
+fn bench_arch_max_items_five_partial() {
+    let (engine, _tmp) = make_engine();
+    index_leankg_self(&engine);
+
+    let arch = engine.get_architecture(Some(5)).unwrap();
+    let obj = arch.as_object().unwrap();
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+
+    // languages has only 1 entry, should NOT be truncated with max_items=5
+    let lang_trunc = trunc
+        .iter()
+        .find(|t| t["section"].as_str() == Some("languages"));
+    assert!(
+        lang_trunc.is_none(),
+        "languages (1 item) should not be truncated with max_items=5"
+    );
 }

--- a/tests/phase1_integration_test.rs
+++ b/tests/phase1_integration_test.rs
@@ -225,7 +225,7 @@ fn test_get_architecture_on_leankg_patterns() {
     let (engine, _tmp) = make_engine();
     populate_with_leankg_patterns(&engine);
     let arch = engine
-        .get_architecture()
+        .get_architecture(None)
         .expect("get_architecture should succeed");
     let obj = arch.as_object().unwrap();
 
@@ -265,7 +265,7 @@ fn test_get_graph_schema_on_leankg_patterns() {
     let (engine, _tmp) = make_engine();
     populate_with_leankg_patterns(&engine);
     let schema = engine
-        .get_graph_schema()
+        .get_graph_schema(None)
         .expect("get_graph_schema should succeed");
     let obj = schema.as_object().unwrap();
 
@@ -347,7 +347,7 @@ fn test_find_dead_code_on_leankg_patterns() {
 #[test]
 fn test_architecture_structure_contract() {
     let (engine, _tmp) = make_engine();
-    let arch = engine.get_architecture().unwrap();
+    let arch = engine.get_architecture(None).unwrap();
     let obj = arch.as_object().unwrap();
     for key in &[
         "languages",
@@ -359,6 +359,8 @@ fn test_architecture_structure_contract() {
         "knowledge_count",
         "total_elements",
         "total_files",
+        "max_items",
+        "truncated_sections",
     ] {
         assert!(obj.contains_key(*key), "Architecture missing key: {}", key);
     }
@@ -367,13 +369,15 @@ fn test_architecture_structure_contract() {
 #[test]
 fn test_graph_schema_structure_contract() {
     let (engine, _tmp) = make_engine();
-    let schema = engine.get_graph_schema().unwrap();
+    let schema = engine.get_graph_schema(None).unwrap();
     let obj = schema.as_object().unwrap();
     for key in &[
         "element_types",
         "relationship_types",
         "total_elements",
         "total_relationships",
+        "max_items",
+        "truncated_sections",
     ] {
         assert!(obj.contains_key(*key), "Schema missing key: {}", key);
     }
@@ -420,4 +424,129 @@ fn test_resolution_method_in_metadata() {
         .get_callers("validate", Some("src/utils.rs"))
         .unwrap();
     assert!(!callers.is_empty(), "Should find callers");
+}
+
+// ── FR-B22: Token budget truncation integration tests ──
+
+#[test]
+fn test_arch_truncation_with_leankg_patterns() {
+    let (engine, _tmp) = make_engine();
+    populate_with_leankg_patterns(&engine);
+    let arch = engine.get_architecture(Some(1)).unwrap();
+    let obj = arch.as_object().unwrap();
+
+    // Each array section should have at most 1 item
+    for key in &[
+        "languages",
+        "entry_points",
+        "hotspots",
+        "clusters",
+        "relationship_summary",
+    ] {
+        let arr = obj[*key].as_array().unwrap();
+        assert!(
+            arr.len() <= 1,
+            "Section {} should have <=1 item with max_items=1, got {}",
+            key,
+            arr.len()
+        );
+    }
+    // truncated_sections should not be empty (multiple sections have >1 item)
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+    assert!(!trunc.is_empty(), "Should report truncated sections");
+}
+
+#[test]
+fn test_schema_truncation_with_leankg_patterns() {
+    let (engine, _tmp) = make_engine();
+    populate_with_leankg_patterns(&engine);
+    let schema = engine.get_graph_schema(Some(1)).unwrap();
+    let obj = schema.as_object().unwrap();
+
+    // element_types has multiple types (function, struct, enum), should be truncated to 1
+    assert_eq!(obj["element_types"].as_array().unwrap().len(), 1);
+    // relationship_types has calls + tested_by, should be truncated to 1
+    assert_eq!(obj["relationship_types"].as_array().unwrap().len(), 1);
+
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+    assert!(!trunc.is_empty(), "Should report truncated sections");
+}
+
+#[test]
+fn test_arch_truncation_preserves_structure() {
+    let (engine, _tmp) = make_engine();
+    populate_with_leankg_patterns(&engine);
+    let arch = engine.get_architecture(Some(1)).unwrap();
+    let obj = arch.as_object().unwrap();
+    for key in &[
+        "languages",
+        "entry_points",
+        "routes",
+        "clusters",
+        "hotspots",
+        "relationship_summary",
+        "knowledge_count",
+        "total_elements",
+        "total_files",
+        "max_items",
+        "truncated_sections",
+    ] {
+        assert!(
+            obj.contains_key(*key),
+            "Missing key after truncation: {}",
+            key
+        );
+    }
+}
+
+#[test]
+fn test_arch_truncation_reports_original_counts() {
+    let (engine, _tmp) = make_engine();
+    populate_with_leankg_patterns(&engine);
+
+    // First get full result to know original counts
+    let full = engine.get_architecture(None).unwrap();
+    let full_obj = full.as_object().unwrap();
+    let full_clusters = full_obj["clusters"].as_array().unwrap().len();
+
+    // Now truncate to 1
+    let arch = engine.get_architecture(Some(1)).unwrap();
+    let obj = arch.as_object().unwrap();
+    let trunc = obj["truncated_sections"].as_array().unwrap();
+
+    let cluster_trunc = trunc
+        .iter()
+        .find(|t| t["section"].as_str() == Some("clusters"));
+    if full_clusters > 1 {
+        assert!(
+            cluster_trunc.is_some(),
+            "clusters should be in truncated_sections"
+        );
+        assert_eq!(
+            cluster_trunc.unwrap()["original_count"].as_u64(),
+            Some(full_clusters as u64)
+        );
+    }
+}
+
+#[test]
+fn test_arch_none_no_truncation_with_patterns() {
+    let (engine, _tmp) = make_engine();
+    populate_with_leankg_patterns(&engine);
+    let arch = engine.get_architecture(None).unwrap();
+    let obj = arch.as_object().unwrap();
+    assert!(obj["truncated_sections"].as_array().unwrap().is_empty());
+    assert!(obj["max_items"].is_null());
+}
+
+#[test]
+fn test_schema_truncation_preserves_scalars() {
+    let (engine, _tmp) = make_engine();
+    populate_with_leankg_patterns(&engine);
+    let schema = engine.get_graph_schema(Some(1)).unwrap();
+    let obj = schema.as_object().unwrap();
+    assert!(obj.contains_key("total_elements"));
+    assert!(obj.contains_key("total_relationships"));
+    // total_elements should still be 20 (not affected by truncation)
+    assert_eq!(obj["total_elements"].as_u64().unwrap(), 20);
 }


### PR DESCRIPTION
## Summary
- Detect nested `.git` trees under multi-repo workspace roots so `require_git_for_auto_index` no longer falsely skips MCP auto-index
- Use latest nested `HEAD` commit time for freshness; aggregate changed/untracked files across nested repos for incremental indexing
- Fix broken `git ls_files` → `ls-files` for untracked detection
- Route discovery through concept ontology and semantic/name search with hard pagination (`limit`/`offset`, max page 50)
- Refuse full-scan tools and skip incremental dependent expansion on mega-graphs (`LEANKG_MAX_CACHE_ELEMENTS`, default 50k)

## Test plan
- [x] `cargo test --release --lib indexer::git_workspace`
- [x] `cargo test --release --lib indexer::git`
- [x] Pre-commit `fmt` + `clippy` passed
- [ ] Rebuild Docker image from this branch and restart with multi-repo project dirs
- [ ] Confirm boot log no longer shows `Not a git repo, skipping auto-index`
- [ ] Confirm mega-graph tools refuse full scans / paginate instead of OOM