### PR TITLE
fix(api): return 500 instead of panicking when ApiKeyStore init fails

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -32,7 +32,16 @@ pub async fn auth_middleware(
         return (StatusCode::UNAUTHORIZED, "Invalid Authorization format").into_response();
     };
 
-    let store = ApiKeyStore::new().map_err(|e| e.to_string()).unwrap();
+    let store = match ApiKeyStore::new() {
+        Ok(store) => store,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Auth error: {}", e),
+            )
+                .into_response();
+        }
+    };
     match store.validate_key(&token) {
         Ok(Some(_key_id)) => {
             request
@@ -93,7 +102,16 @@ pub async fn team_token_middleware(
         return (StatusCode::UNAUTHORIZED, "Missing X-LeanKG-Token header").into_response();
     }
 
-    let store = ApiKeyStore::new().map_err(|e| e.to_string()).unwrap();
+    let store = match ApiKeyStore::new() {
+        Ok(store) => store,
+        Err(e) => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Auth error: {}", e),
+            )
+                .into_response();
+        }
+    };
     match store.validate_key(&token) {
         Ok(Some(key_id)) => {
             request.extensions_mut().insert(TeamAuthContext {


### PR DESCRIPTION
## Summary

`auth_middleware` and `team_token_middleware` build the API-key store with `ApiKeyStore::new().map_err(|e| e.to_string()).unwrap()`. When `ApiKeyStore::new()` returns an error (a disk error or a permissions problem on the key store), the `unwrap()` panics inside the middleware — taking down request handling rather than failing the single request.

Auth middleware runs on every protected request, so a transient, per-node I/O condition should degrade to a failed request, not a panicked server thread. Both sites already have a graceful `500` path for the closely-related `store.validate_key(...)` error; the store-construction error was the one spot that still aborted. This replaces the `unwrap()` at both sites in `src/api/auth.rs` with a `match` that returns `500 Internal Server Error`, matching that existing pattern. The success path is unchanged.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## Testing

`cargo check` passes on the patched tree. The change is mechanical: each site now returns the same `(StatusCode::INTERNAL_SERVER_ERROR, format!("Auth error: {}", e)).into_response()` already used a few lines down for a `validate_key` error, so the success path is byte-for-byte identical and only the previously-panicking error path changes. I did not run the full integration suite (it needs external setup unrelated to this change).

- [ ] Unit tests pass (`cargo test`)
- [ ] Integration tests pass
- [x] Manual verification

## Checklist

- [x] Code follows project conventions
- [x] Self-review completed
- [ ] Documentation updated (if needed)
- [x] No new warnings or errors

## Breaking Changes

None. The success path is unchanged; only the error path changes from a panic to a `500` response.

## Related Issues

Closes #70.

## Additional Context

Both middlewares (`auth_middleware`, `team_token_middleware`) carried the identical `unwrap()`; both are fixed the same way.

AI was used for assistance.
