### PR TITLE
fix(mcp): restore search availability on mega-graph boot

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,11 +117,11 @@ get_context(file="…", project="/workspace")
 
 **Agent checklist (new chat / no prior context):**
 
-1. `curl -sf --max-time 2 http://localhost:9699/health` — if this fails, **skip LeanKG** and use Grep/Glob/Read (default mode)
-2. If health OK: `mcp_status(project="/workspace")` for LeanKG source work
+1. Prefer Docker MCP when `curl http://localhost:9699/health` is ok
+2. Call `mcp_status(project="/workspace")` first for LeanKG source work
 3. For other indexed trees, use the container side of binds listed in local `LEANKG_PROJECT_DIRS` (gitignored `.dockerfile`)
 4. Never invent or paste personal host bind paths into commits, docs, or chat
-5. Do **not** fall back to `mcp_init` / local CLI when HTTP is down — default Cursor tools only
+5. Host-path `mcp_init` / local SQLite is only for non-Docker stdio workflows
 
 Chat sessions do **not** share memory. This section is the durable source of truth so agents do not re-discover mounts every session.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -117,11 +117,11 @@ get_context(file="…", project="/workspace")
 
 **Agent checklist (new chat / no prior context):**
 
-1. Prefer Docker MCP when `curl http://localhost:9699/health` is ok
-2. Call `mcp_status(project="/workspace")` first for LeanKG source work
+1. `curl -sf --max-time 2 http://localhost:9699/health` — if this fails, **skip LeanKG** and use Grep/Glob/Read (default mode)
+2. If health OK: `mcp_status(project="/workspace")` for LeanKG source work
 3. For other indexed trees, use the container side of binds listed in local `LEANKG_PROJECT_DIRS` (gitignored `.dockerfile`)
 4. Never invent or paste personal host bind paths into commits, docs, or chat
-5. Host-path `mcp_init` / local SQLite is only for non-Docker stdio workflows
+5. Do **not** fall back to `mcp_init` / local CLI when HTTP is down — default Cursor tools only
 
 Chat sessions do **not** share memory. This section is the durable source of truth so agents do not re-discover mounts every session.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -187,6 +187,8 @@ Turning embed on later (or restarting the container with the same volume) must *
 
 **Docker PID 1 + `embed.lock`:** MCP runs as PID 1 in the container. A leftover `<project>/.leankg/embed.lock` containing `1` from a killed prior run used to look “alive” forever and skip `LEANKG_EMBED_BACKGROUND` spawn. Current code treats same-PID locks as stale unless an in-process embed is already active in this process (and clears non-`running` status leftovers). Manual escape: `rm -f "$LEANKG_MCP_PROJECT/.leankg/embed.lock"` then recreate the container.
 
+**Boot must not block search:** `entrypoint.sh` ontology sync is timed (default 45s) or skippable via `LEANKG_ONTOLOGY_SYNC_ON_BOOT=skip`. A hung sync used to prevent `mcp-http` from binding, so `search_code` / `find_function` looked completely broken. In-process `LEANKG_EMBED_BACKGROUND=1` is **skipped on mega-graphs** unless `LEANKG_EMBED_BACKGROUND_MEGA=1` (prefer offline `embed --wait`).
+
 ### One-line run (published image — no Rust)
 
 Index + INT8 embed + MCP (recommended):

--- a/docs/analysis/root_cause_mcp_search_unavailable-2026-07-19.md
+++ b/docs/analysis/root_cause_mcp_search_unavailable-2026-07-19.md
@@ -1,0 +1,79 @@
+# Root Cause Analysis: LeanKG search / lookup unavailable
+
+**Date:** 2026-07-19  
+**Symptom:** `search_code`, `find_function`, and other lookup tools appear broken (empty reply, connection reset, or Cursor MCP timeout).  
+**Status:** Root cause identified; fixes in `fix/mcp-boot-search`.
+
+## Issue Description
+
+Agents and users could not search or look up code through LeanKG MCP on `:9699`. Health checks failed inside the container (`curl: (7) Failed to connect to 127.0.0.1:9699`), and host clients saw empty replies / connection resets.
+
+## Evidence
+
+| Observation | Detail |
+|-------------|--------|
+| Container | `Up … (unhealthy)` while port published |
+| Health log | `Couldn't connect to 127.0.0.1:9699` (MCP not listening yet) |
+| Process table | PID stuck on `leankg ontology sync --path <mcp-project>/ontology` for minutes at ~100% CPU |
+| Entrypoint order | Ontology sync runs **before** `leankg mcp-http` (`entrypoint.sh`) |
+| Amplifier | `LEANKG_EMBED_BACKGROUND=1` on mega-graph (~640k elements) calls `all_elements()`, RSS soft-cap pauses, container restarts → hits blocking sync again |
+| After killing stuck sync | `/health` → `{"status":"ok"}`; `search_code` / `find_function` return results |
+
+## Logic Flow (broken)
+
+```
+entrypoint start
+  → index_if_needed (skip if RocksDB exists)
+  → ontology sync (BLOCKING, opens mega RocksDB)  ← hang / multi-minute delay
+  → mcp-http listen                               ← never reached while hung
+  → /health fails → search tools appear "broken"
+```
+
+## Problematic Code Chunk
+
+```bash
+# entrypoint.sh (before fix)
+if [ -n "$ONTOLOGY_SOURCE_DIR" ]; then
+    ( cd "$MCP_PROJECT" && leankg ontology sync --path "$ONTOLOGY_SOURCE_DIR" )
+fi
+exec leankg mcp-http ...
+```
+
+```rust
+// embeddings/build.rs (before fix) — spawn path
+let total = graph.all_elements().map(|v| v.len()).unwrap_or(0);
+```
+
+## Root Cause
+
+1. **Primary:** Boot ontology sync is synchronous and can hang or run for minutes on large RocksDB projects, so MCP never binds and all search/lookup fails.
+2. **Amplifier:** In-process background embed on mega-graphs materializes the full element list, stresses memory/locks, causes unhealthy restarts, and re-enters the blocking sync.
+
+This is an **availability / boot-ordering** failure, not a broken `search_code` algorithm. Once MCP is listening, ontology-first discovery with name fallback returns results.
+
+## Suggested Fix (implemented)
+
+1. `entrypoint.sh`: default ontology sync with **timeout** (45s), skip when marker is fresh, support `LEANKG_ONTOLOGY_SYNC_ON_BOOT=skip|force|timeout`.
+2. MCP server: skip `LEANKG_EMBED_BACKGROUND` on mega-graphs unless `LEANKG_EMBED_BACKGROUND_MEGA=1`.
+3. Background embed: use `count_elements()` instead of `all_elements()` for the initial total.
+
+## Additional Logging
+
+- Entrypoint warns on timeout and still starts mcp-http.
+- MCP logs a clear warn when background embed is skipped on mega-graphs.
+
+## Recovery (ops)
+
+```bash
+# Prefer search availability over in-process mega embed
+# In local compose override: LEANKG_EMBED_BACKGROUND=0
+# After deploying entrypoint fix: LEANKG_ONTOLOGY_SYNC_ON_BOOT=timeout (default)
+docker compose -f docker-compose.rocksdb.yml -f docker-compose.override.yml --env-file .dockerfile up -d --force-recreate
+curl -sS http://localhost:9699/health
+```
+
+## Verification
+
+- `/health` returns ok within seconds of recreate
+- `search_code(query="main", project="/workspace")` returns `count > 0`
+- `find_function(name="main", project="/workspace")` returns functions

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -167,6 +167,16 @@ export LEANKG_MMAP_SIZE="${LEANKG_MMAP_SIZE:-67108864}"
 # the MCP project if present, otherwise falling back to /workspace/ontology
 # (the LeanKG source tree ships concepts.yaml + workflows.yaml there).
 # The sync target is always $MCP_PROJECT so the served DB has the ontology.
+#
+# CRITICAL (search availability): never block mcp-http forever on sync.
+# On mega-graphs, opening RocksDB + sync has been observed to hang for
+# minutes with /health failing (empty reply / connection reset) so
+# search_code / find_function appear completely broken.
+#
+# LEANKG_ONTOLOGY_SYNC_ON_BOOT:
+#   skip | 0     — do not sync (MCP starts immediately)
+#   force | 1    — blocking sync (legacy; can delay health for a long time)
+#   timeout|auto — default: sync with timeout, then start MCP either way
 ONTOLOGY_SOURCE_DIR=""
 for candidate in "$MCP_PROJECT" "/workspace"; do
     if [ -d "$candidate/ontology" ] && [ -f "$candidate/ontology/concepts.yaml" ]; then
@@ -174,10 +184,48 @@ for candidate in "$MCP_PROJECT" "/workspace"; do
         break
     fi
 done
+ONTOLOGY_SYNC_MODE="${LEANKG_ONTOLOGY_SYNC_ON_BOOT:-timeout}"
+ONTOLOGY_SYNC_TIMEOUT="${LEANKG_ONTOLOGY_SYNC_TIMEOUT_SECS:-45}"
+ONTOLOGY_MARKER="$MCP_PROJECT/.leankg/ontology_synced"
 if [ -n "$ONTOLOGY_SOURCE_DIR" ]; then
-    echo "=== Syncing ontology from $ONTOLOGY_SOURCE_DIR into $MCP_PROJECT ==="
-    ( cd "$MCP_PROJECT" && leankg ontology sync --path "$ONTOLOGY_SOURCE_DIR" )
-    echo "=== Ontology sync done ==="
+    case "$ONTOLOGY_SYNC_MODE" in
+        skip|0|false|FALSE)
+            echo "=== Skipping ontology sync (LEANKG_ONTOLOGY_SYNC_ON_BOOT=$ONTOLOGY_SYNC_MODE) ==="
+            ;;
+        force|1|true|TRUE|foreground)
+            echo "=== Syncing ontology from $ONTOLOGY_SOURCE_DIR into $MCP_PROJECT (blocking) ==="
+            ( cd "$MCP_PROJECT" && leankg ontology sync --path "$ONTOLOGY_SOURCE_DIR" ) \
+                && mkdir -p "$(dirname "$ONTOLOGY_MARKER")" && touch "$ONTOLOGY_MARKER" \
+                || echo "WARN: ontology sync failed; continuing to mcp-http"
+            echo "=== Ontology sync done ==="
+            ;;
+        *)
+            # Default: skip if marker is newer than concepts.yaml (already synced).
+            CONCEPTS_FILE="$ONTOLOGY_SOURCE_DIR/concepts.yaml"
+            if [ -f "$ONTOLOGY_MARKER" ] && [ "$ONTOLOGY_MARKER" -nt "$CONCEPTS_FILE" ]; then
+                echo "=== Ontology already synced (marker newer than concepts.yaml); skipping ==="
+            else
+                echo "=== Syncing ontology from $ONTOLOGY_SOURCE_DIR (timeout ${ONTOLOGY_SYNC_TIMEOUT}s) ==="
+                set +e
+                if command -v timeout >/dev/null 2>&1; then
+                    ( cd "$MCP_PROJECT" && timeout "$ONTOLOGY_SYNC_TIMEOUT" leankg ontology sync --path "$ONTOLOGY_SOURCE_DIR" )
+                    sync_rc=$?
+                else
+                    ( cd "$MCP_PROJECT" && leankg ontology sync --path "$ONTOLOGY_SOURCE_DIR" )
+                    sync_rc=$?
+                fi
+                set -e
+                if [ "$sync_rc" -eq 0 ]; then
+                    mkdir -p "$(dirname "$ONTOLOGY_MARKER")" && touch "$ONTOLOGY_MARKER"
+                    echo "=== Ontology sync done ==="
+                elif [ "$sync_rc" -eq 124 ]; then
+                    echo "WARN: ontology sync timed out after ${ONTOLOGY_SYNC_TIMEOUT}s; starting mcp-http anyway (search stays available)"
+                else
+                    echo "WARN: ontology sync failed (rc=$sync_rc); starting mcp-http anyway"
+                fi
+            fi
+            ;;
+    esac
 else
     echo "No ontology directory found in $MCP_PROJECT or /workspace, skipping ontology sync"
 fi

--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -1206,10 +1206,9 @@ pub fn spawn_background_embed(
             }
         };
 
-    // Snapshot the initial element count ONCE (don't double-scan inside
-    // build_index_parallel). On the mega-graph heuristic, this is also
-    // where the function,method filter is applied.
-    let total = graph.all_elements().map(|v| v.len()).unwrap_or(0);
+    // Snapshot the initial element count ONCE without materializing every
+    // row (all_elements on mega-graphs OOM/locks MCP and breaks search).
+    let total = graph.count_elements().unwrap_or(0);
     write_status(total as u64, 0, 0, 0, "running");
 
     let graph_clone = graph.clone();

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -519,6 +519,23 @@ impl MCPServer {
                 return;
             }
         };
+        // Mega-graphs: in-process background embed calls all_elements() and
+        // contends with MCP on RocksDB/memory, which makes search tools hang
+        // or the container go unhealthy. Require an explicit opt-in.
+        let force_mega = std::env::var("LEANKG_EMBED_BACKGROUND_MEGA")
+            .ok()
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        if !force_mega && crate::ontology::safe_discover::is_mega_graph(&graph) {
+            let n = graph.count_elements().unwrap_or(0);
+            tracing::warn!(
+                "LEANKG_EMBED_BACKGROUND=1 skipped on mega-graph ({} elements). \
+                 Use offline `leankg embed --wait` or set LEANKG_EMBED_BACKGROUND_MEGA=1 \
+                 (not recommended under MCP mem_limit). Search tools stay available.",
+                n
+            );
+            return;
+        }
         let leankg_dir = self.get_db_path();
         let cfg = crate::embeddings::BackgroundEmbedConfig {
             batch_size,


### PR DESCRIPTION
## Summary
- **Root cause:** `entrypoint.sh` ran blocking `leankg ontology sync` before `mcp-http`. On mega-graph RocksDB this hung for minutes → `/health` failed and `search_code` / `find_function` looked completely broken.
- **Amplifier:** `LEANKG_EMBED_BACKGROUND=1` on mega-graphs called `all_elements()`, stressed memory, restarted the container, and re-entered the blocking sync.
- **Fix:** timed/skippable ontology sync; skip in-process background embed on mega-graphs unless `LEANKG_EMBED_BACKGROUND_MEGA=1`; use `count_elements()` for embed status totals.
- RCA: `docs/analysis/root_cause_mcp_search_unavailable-2026-07-19.md`

## Test plan
- [x] With fixed entrypoint mounted: sync times out at 45s, log shows WARN, MCP listens, `/health` ok
- [x] `search_code` / `find_function` on `/workspace` return results
- [ ] Rebuild image so Rust-side mega-embed skip is in the running binary
- [ ] Optional: set local override `LEANKG_EMBED_BACKGROUND=0` on mega MCP projects


Made with [Cursor](https://cursor.com)