### PR TITLE
fix: mega HNSW semantic_search OOM (FR-SEM-07 / REL-054)

### DIFF
--- a/docs/prd-task-tracker.json
+++ b/docs/prd-task-tracker.json
@@ -2,10 +2,10 @@
   "generated": "2026-07-20",
   "source": "docs/prd.md",
   "counts": {
-    "DONE": 337,
+    "DONE": 340,
     "PARTIAL": 11,
-    "PENDING": 18,
-    "NOT_DONE": 56,
+    "PENDING": 17,
+    "NOT_DONE": 54,
     "WONT_DO": 3,
     "OPEN": 1
   },
@@ -15,8 +15,8 @@
       "kind": "User Story",
       "title": "Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP",
       "priority": "Must Have",
-      "status": "PENDING",
-      "notes": "OPEN P0 2026-07-20 \u2014 evidence docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md; small /workspace HNSW GREEN",
+      "status": "DONE",
+      "notes": "DONE 2026-07-20 \u2014 keyed hydration + has_any; evidence docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md",
       "section": "3.14 Semantic MCP Agent UX Enhancements (US-SEM) \u2014 v3.7.1",
       "prd_line": null,
       "focus": "P0",
@@ -28,8 +28,8 @@
       "kind": "FR",
       "title": "Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit",
       "priority": "Must Have",
-      "status": "NOT_DONE",
-      "notes": "P0 \u2014 remove all_elements from HNSW semantic seed hydration; peak RSS must not OOM MCP on ~641k-element graphs",
+      "status": "DONE",
+      "notes": "DONE 2026-07-20 \u2014 get_elements_by_qualified_names; skip index_size when ann_top_k set; has_any gates",
       "section": "5.15 Semantic MCP Agent UX Enhancements (v3.7.1)",
       "prd_line": null,
       "focus": "P0",
@@ -41,8 +41,8 @@
       "kind": "Release",
       "title": "Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart",
       "priority": "Must Have",
-      "status": "NOT_DONE",
-      "notes": "P0 release gate; complements REL-051 small-graph smoke; record peak RSS + latency in docs/reports/",
+      "status": "DONE",
+      "notes": "DONE 2026-07-20 \u2014 docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md; residual model RSS under ~3.9GiB cgroup noted",
       "section": "5.15 Semantic MCP Agent UX Enhancements (v3.7.1)",
       "prd_line": null,
       "focus": "P0",
@@ -5556,12 +5556,12 @@
     "update_rule": "Edit this file (and JSON) when closing work. Link new IDs from PRD narrative sections.",
     "sort": "focus(P0..P3) \u2192 MoSCoW \u2192 VE suborder \u2192 status \u2192 id",
     "focus_legend": {
-      "P0": "Mega-graph HNSW semantic_search OOM (US-SEM-06 / FR-SEM-07 / REL-054) \u2014 CURRENT highest; embed-resume + VE DONE",
+      "P0": "Mega-graph HNSW semantic_search OOM (US-SEM-06 / FR-SEM-07 / REL-054) \u2014 DONE 2026-07-20; next open focus P1",
       "P1": "Other Must Have",
       "P2": "Should Have",
       "P3": "Could Have / aspirational OPEN"
     },
-    "updated": "2026-07-20-mega-sem-oom",
-    "sync_note": "v3.7.5: added US-SEM-06, FR-SEM-07, REL-054 as open P0 from mega Docker MCP OOM evidence."
+    "updated": "2026-07-20-rel-054-closed",
+    "sync_note": "v3.7.5: US-SEM-06 / FR-SEM-07 / REL-054 DONE after keyed hydration + mega Docker smoke."
   }
 }

--- a/docs/prd-task-tracker.json
+++ b/docs/prd-task-tracker.json
@@ -1,15 +1,54 @@
 {
-  "generated": "2026-07-18",
+  "generated": "2026-07-20",
   "source": "docs/prd.md",
   "counts": {
-    "DONE": 326,
-    "PARTIAL": 12,
-    "PENDING": 19,
-    "NOT_DONE": 62,
+    "DONE": 337,
+    "PARTIAL": 11,
+    "PENDING": 18,
+    "NOT_DONE": 56,
     "WONT_DO": 3,
     "OPEN": 1
   },
   "tasks": [
+    {
+      "id": "US-SEM-06",
+      "kind": "User Story",
+      "title": "Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP",
+      "priority": "Must Have",
+      "status": "PENDING",
+      "notes": "OPEN P0 2026-07-20 \u2014 evidence docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md; small /workspace HNSW GREEN",
+      "section": "3.14 Semantic MCP Agent UX Enhancements (US-SEM) \u2014 v3.7.1",
+      "prd_line": null,
+      "focus": "P0",
+      "focus_rank": 0,
+      "ve_suborder": 0
+    },
+    {
+      "id": "FR-SEM-07",
+      "kind": "FR",
+      "title": "Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit",
+      "priority": "Must Have",
+      "status": "NOT_DONE",
+      "notes": "P0 \u2014 remove all_elements from HNSW semantic seed hydration; peak RSS must not OOM MCP on ~641k-element graphs",
+      "section": "5.15 Semantic MCP Agent UX Enhancements (v3.7.1)",
+      "prd_line": null,
+      "focus": "P0",
+      "focus_rank": 0,
+      "ve_suborder": 1
+    },
+    {
+      "id": "REL-054",
+      "kind": "Release",
+      "title": "Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart",
+      "priority": "Must Have",
+      "status": "NOT_DONE",
+      "notes": "P0 release gate; complements REL-051 small-graph smoke; record peak RSS + latency in docs/reports/",
+      "section": "5.15 Semantic MCP Agent UX Enhancements (v3.7.1)",
+      "prd_line": null,
+      "focus": "P0",
+      "focus_rank": 0,
+      "ve_suborder": 2
+    },
     {
       "id": "FR-HNSW-E",
       "kind": "FR",
@@ -5517,12 +5556,12 @@
     "update_rule": "Edit this file (and JSON) when closing work. Link new IDs from PRD narrative sections.",
     "sort": "focus(P0..P3) \u2192 MoSCoW \u2192 VE suborder \u2192 status \u2192 id",
     "focus_legend": {
-      "P0": "Day-2 Embed Resume (v3.7.2) \u2014 CURRENT highest; VE gate DONE on PR #80",
+      "P0": "Mega-graph HNSW semantic_search OOM (US-SEM-06 / FR-SEM-07 / REL-054) \u2014 CURRENT highest; embed-resume + VE DONE",
       "P1": "Other Must Have",
       "P2": "Should Have",
       "P3": "Could Have / aspirational OPEN"
     },
-    "updated": "2026-07-18-surf03",
-    "sync_note": "FR-SURF-03 / US-SURF-02 DONE: hard-removed mcp_hello, mcp_impact, get_doc_for_file."
+    "updated": "2026-07-20-mega-sem-oom",
+    "sync_note": "v3.7.5: added US-SEM-06, FR-SEM-07, REL-054 as open P0 from mega Docker MCP OOM evidence."
   }
 }

--- a/docs/prd-task-tracker.md
+++ b/docs/prd-task-tracker.md
@@ -1,12 +1,12 @@
 # LeanKG PRD Task Tracker (Single Session)
 
-**Last synced:** 2026-07-19 — US-GF-03 / REL-042 `query_graph` NL scoped subgraph (`FR-GF-05`/`FR-GF-06`); prior: hybrid LSP Go/TS + SURF soft-deprecate  
+**Last synced:** 2026-07-20 — **P0** mega-graph HNSW `semantic_search` OOM (`US-SEM-06` / `FR-SEM-07` / `REL-054`); evidence [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md)  
 **This file is the SoT for task inventory + status.**  
 **PRD narrative / ACs / HLD:** [`docs/prd.md`](prd.md)  
 
 > **Agent rule:** Implement in **Focus** order: **P0 → P1 → P2 → P3**.  
-> **P0 embed-resume:** core + Docker evidence **DONE**.  
-> **P1 this pass:** Hybrid LSP for Go/TS (`FR-LSP-A..D`, `US-CBM-B1`, `REL-039`) — in progress on `feature/hybrid-lsp-go-ts`.  
+> **P0 now:** Mega-safe HNSW semantic path (no `all_elements()` / no MCP OOM on ~641k-element mounts).  
+> **Prior P0 embed-resume:** core + Docker evidence **DONE** (PR #81 / #86).  
 > Open `prd.md` only for design narrative and acceptance criteria.
 
 ---
@@ -15,8 +15,8 @@
 
 | Focus | Meaning | When to work |
 |------:|---------|--------------|
-| **P0** | Day-2 Embed Resume | **DONE** on PR #81 |
-| **P1** | Other Must Have (SEM path filter + mega-graph ops landed; LSP/etc. remain) | Next open Must Have |
+| **P0** | Mega-graph HNSW `semantic_search` OOM (`US-SEM-06` / `FR-SEM-07` / `REL-054`) | **CURRENT** — do first |
+| **P1** | Other Must Have (SEM path filter + mega-graph ops landed; LSP/etc. remain) | After P0 |
 | **P2** | Should Have | Next |
 | **P3** | Could Have / aspirational `OPEN` | Backlog |
 
@@ -37,38 +37,43 @@
 
 | Metric | Count |
 |--------|------:|
-| **Total tracked** | **423** |
-| NOT_DONE | 62 |
-| PENDING | 19 |
-| PARTIAL | 12 |
+| **Total tracked** | **426** |
+| NOT_DONE | 56 |
+| PENDING | 18 |
+| PARTIAL | 11 |
 | OPEN | 1 |
-| DONE | 326 |
+| DONE | 337 |
 | WONT_DO | 3 |
-| Open work | **94** |
+| Open work | **86** |
 
 | Open by Focus | Count |
 |---------------|------:|
-| P0 | 0 |
-| P1 | 23 |
-| P2 | 62 |
+| P0 | 3 |
+| P1 | 17 |
+| P2 | 57 |
 | P3 | 9 |
 
 | Kind | Count |
 |------|------:|
-| FR | 220 |
-| Release | 53 |
-| User Story | 150 |
+| FR | 221 |
+| Release | 54 |
+| User Story | 151 |
 
 ---
 
 ## Active session — open work (sorted by priority)
 
-> **2026-07-18 — closed on PR #81:** embed-resume day-2; SEM path filter (Probes G/H); `LEANKG_SKIP_FRESHNESS_CHECK`; compose **cpus 6 / mem_reservation 3g / MCP mem_limit 6g**; 3-workspace vector counts (3,271 / 146,977 / 14,110) + semantic_search OK.
+> **2026-07-20 — P0 opened (v3.7.5):** Mega HNSW `semantic_search` OOM on `/workspace-other` (~641k elements). Small `/workspace` HNSW GREEN. Root symptom: unbounded `all_elements()` during HNSW seed hydration. Report: [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md).
+>
+> **2026-07-18 — closed on PR #81:** embed-resume day-2; SEM path filter (Probes G/H); `LEANKG_SKIP_FRESHNESS_CHECK`; compose **cpus 6 / mem_reservation 3g / MCP mem_limit 6g**; 3-workspace vector counts (3,271 / 146,977 / 14,110) + semantic_search OK on **small** graphs.
 >
 > **2026-07-18 — added (v3.7.4):** MCP tool surface rationalization — document prefer-order + delete 3 superseded tools first; soft-deprecate `wake_up` / `search_by_environment`; do **not** deprecate `mcp_status` / bootstrap ops tools. Registry baseline ≈85.
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
+| **P0** | `US-SEM-06` | User Story | **PENDING** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.… |
+| **P0** | `FR-SEM-07` | FR | **NOT_DONE** | Must Have | Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
+| **P0** | `REL-054` | Release | **NOT_DONE** | Must Have | Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P1** | `US-08` | User Story | **PARTIAL** | Must Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |
 | **P1** | `US-CBM-A2` | User Story | **PARTIAL** | Must Have | Ontology online ('kg_ontology_status', 'concept_search' non-empty after sync) | 3.11 CBM Structural Parity Stories (US-CBM) — merged f… |
 | **P1** | `US-CBM-B1` | User Story | **DONE** | Must Have | Typed call resolution Go + TypeScript MVP ('resolution_method=typed') | 3.11 CBM Structural Parity Stories (US-CBM) — merged f… |
@@ -170,6 +175,9 @@
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
+| **P0** | `US-SEM-06` | User Story | **PENDING** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.… |
+| **P0** | `FR-SEM-07` | FR | **NOT_DONE** | Must Have | Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
+| **P0** | `REL-054` | Release | **NOT_DONE** | Must Have | Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P0** | `FR-HNSW-E` | FR | **DONE** | Must Have | Incremental embed filter (foundation) — PARTIAL: day-2 resume/HNSW no-op/stale-blast trac… | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) + 5.12 |
 | **P0** | `US-EMBED-01` | User Story | **DONE** | Must Have | Second standalone Docker/CLI embed --wait on unchanged code skips fresh vectors (day-2 de… | 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 |
 | **P0** | `US-EMBED-02` | User Story | **DONE** | Must Have | Interrupted embed (CLI or Docker MCP) resumes; already-fresh vectors are not re-inferred | 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 |
@@ -597,6 +605,7 @@
 
 ## Sync notes
 
+- **2026-07-20 v3.7.5 P0:** `US-SEM-06` / `FR-SEM-07` / `REL-054` — mega-graph HNSW `semantic_search` OOM (`all_elements()`). Evidence: [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md). Prior embed-resume P0 remains DONE.
 - **PR [#81](https://github.com/FreePeak/LeanKG/pull/81):** embed-resume + SEM-06 + MG-AUTO-01 + OPS cpus6/3g/6g.
 - **v3.7.4 MCP surface:** added `US-SURF-01..05`, `FR-SURF-01..06`, `REL-053` (PRD §3.16 / §5.18). Prefer docstring prefer-order + 3 hard deletes; soft-deprecate `wake_up` / `search_by_environment`; keep `mcp_status` + bootstrap ops tools.
 - **FR-SURF-03 / US-SURF-02:** hard-removed `mcp_hello`, `mcp_impact`, `get_doc_for_file`; registry ~82–84 tools; `tests/redundant_tools_matrix.rs` asserts absence + full 84-tool classification (2026-07-20).

--- a/docs/prd-task-tracker.md
+++ b/docs/prd-task-tracker.md
@@ -1,11 +1,11 @@
 # LeanKG PRD Task Tracker (Single Session)
 
-**Last synced:** 2026-07-20 — **P0** mega-graph HNSW `semantic_search` OOM (`US-SEM-06` / `FR-SEM-07` / `REL-054`); evidence [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md)  
+**Last synced:** 2026-07-20 — **P0 CLOSED** mega HNSW OOM (`US-SEM-06` / `FR-SEM-07` / `REL-054`); evidence [`docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md`](reports/rel-054-mega-sem-oom-fix-2026-07-20.md)  
 **This file is the SoT for task inventory + status.**  
 **PRD narrative / ACs / HLD:** [`docs/prd.md`](prd.md)  
 
 > **Agent rule:** Implement in **Focus** order: **P0 → P1 → P2 → P3**.  
-> **P0 now:** Mega-safe HNSW semantic path (no `all_elements()` / no MCP OOM on ~641k-element mounts).  
+> **P0 mega HNSW OOM:** **DONE** (keyed hydration + cheap `has_any`; REL-054 smoke).  
 > **Prior P0 embed-resume:** core + Docker evidence **DONE** (PR #81 / #86).  
 > Open `prd.md` only for design narrative and acceptance criteria.
 
@@ -15,8 +15,8 @@
 
 | Focus | Meaning | When to work |
 |------:|---------|--------------|
-| **P0** | Mega-graph HNSW `semantic_search` OOM (`US-SEM-06` / `FR-SEM-07` / `REL-054`) | **CURRENT** — do first |
-| **P1** | Other Must Have (SEM path filter + mega-graph ops landed; LSP/etc. remain) | After P0 |
+| **P0** | Mega-graph HNSW `semantic_search` OOM (`US-SEM-06` / `FR-SEM-07` / `REL-054`) | **DONE** — next open P0 none |
+| **P1** | Other Must Have (SEM path filter + mega-graph ops landed; LSP/etc. remain) | Current open Must Have |
 | **P2** | Should Have | Next |
 | **P3** | Could Have / aspirational `OPEN` | Backlog |
 
@@ -38,17 +38,17 @@
 | Metric | Count |
 |--------|------:|
 | **Total tracked** | **426** |
-| NOT_DONE | 56 |
-| PENDING | 18 |
+| NOT_DONE | 54 |
+| PENDING | 17 |
 | PARTIAL | 11 |
 | OPEN | 1 |
-| DONE | 337 |
+| DONE | 340 |
 | WONT_DO | 3 |
-| Open work | **86** |
+| Open work | **83** |
 
 | Open by Focus | Count |
 |---------------|------:|
-| P0 | 3 |
+| P0 | 0 |
 | P1 | 17 |
 | P2 | 57 |
 | P3 | 9 |
@@ -63,7 +63,7 @@
 
 ## Active session — open work (sorted by priority)
 
-> **2026-07-20 — P0 opened (v3.7.5):** Mega HNSW `semantic_search` OOM on `/workspace-other` (~641k elements). Small `/workspace` HNSW GREEN. Root symptom: unbounded `all_elements()` during HNSW seed hydration. Report: [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md).
+> **2026-07-20 — P0 closed (v3.7.5):** Mega HNSW OOM fixed — keyed QN hydration + `has_any`; REL-054 smoke PASS. Evidence: [`docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md`](reports/rel-054-mega-sem-oom-fix-2026-07-20.md). Prior fail: [`main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md).
 >
 > **2026-07-18 — closed on PR #81:** embed-resume day-2; SEM path filter (Probes G/H); `LEANKG_SKIP_FRESHNESS_CHECK`; compose **cpus 6 / mem_reservation 3g / MCP mem_limit 6g**; 3-workspace vector counts (3,271 / 146,977 / 14,110) + semantic_search OK on **small** graphs.
 >
@@ -71,9 +71,9 @@
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
-| **P0** | `US-SEM-06` | User Story | **PENDING** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.… |
-| **P0** | `FR-SEM-07` | FR | **NOT_DONE** | Must Have | Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
-| **P0** | `REL-054` | Release | **NOT_DONE** | Must Have | Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
+| **P0** | `US-SEM-06` | User Story | **DONE** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.… |
+| **P0** | `FR-SEM-07` | FR | **DONE** | Must Have | Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
+| **P0** | `REL-054` | Release | **DONE** | Must Have | Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P1** | `US-08` | User Story | **PARTIAL** | Must Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |
 | **P1** | `US-CBM-A2` | User Story | **PARTIAL** | Must Have | Ontology online ('kg_ontology_status', 'concept_search' non-empty after sync) | 3.11 CBM Structural Parity Stories (US-CBM) — merged f… |
 | **P1** | `US-CBM-B1` | User Story | **DONE** | Must Have | Typed call resolution Go + TypeScript MVP ('resolution_method=typed') | 3.11 CBM Structural Parity Stories (US-CBM) — merged f… |
@@ -175,9 +175,9 @@
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
-| **P0** | `US-SEM-06` | User Story | **PENDING** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.… |
-| **P0** | `FR-SEM-07` | FR | **NOT_DONE** | Must Have | Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
-| **P0** | `REL-054` | Release | **NOT_DONE** | Must Have | Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
+| **P0** | `US-SEM-06` | User Story | **DONE** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.… |
+| **P0** | `FR-SEM-07` | FR | **DONE** | Must Have | Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP stays healthy under mem_limit | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
+| **P0** | `REL-054` | Release | **DONE** | Must Have | Live mega smoke: semantic_search + kg_semantic_context on /workspace-other without OOM/restart | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P0** | `FR-HNSW-E` | FR | **DONE** | Must Have | Incremental embed filter (foundation) — PARTIAL: day-2 resume/HNSW no-op/stale-blast trac… | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) + 5.12 |
 | **P0** | `US-EMBED-01` | User Story | **DONE** | Must Have | Second standalone Docker/CLI embed --wait on unchanged code skips fresh vectors (day-2 de… | 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 |
 | **P0** | `US-EMBED-02` | User Story | **DONE** | Must Have | Interrupted embed (CLI or Docker MCP) resumes; already-fresh vectors are not re-inferred | 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 |
@@ -605,7 +605,7 @@
 
 ## Sync notes
 
-- **2026-07-20 v3.7.5 P0:** `US-SEM-06` / `FR-SEM-07` / `REL-054` — mega-graph HNSW `semantic_search` OOM (`all_elements()`). Evidence: [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md). Prior embed-resume P0 remains DONE.
+- **2026-07-20 v3.7.5 P0 CLOSED:** `US-SEM-06` / `FR-SEM-07` / `REL-054` — keyed HNSW hydration + `has_any`; mega smoke PASS. Evidence: [`docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md`](reports/rel-054-mega-sem-oom-fix-2026-07-20.md). Prior fail: [`main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md).
 - **PR [#81](https://github.com/FreePeak/LeanKG/pull/81):** embed-resume + SEM-06 + MG-AUTO-01 + OPS cpus6/3g/6g.
 - **v3.7.4 MCP surface:** added `US-SURF-01..05`, `FR-SURF-01..06`, `REL-053` (PRD §3.16 / §5.18). Prefer docstring prefer-order + 3 hard deletes; soft-deprecate `wake_up` / `search_by_environment`; keep `mcp_status` + bootstrap ops tools.
 - **FR-SURF-03 / US-SURF-02:** hard-removed `mcp_hello`, `mcp_impact`, `get_doc_for_file`; registry ~82–84 tools; `tests/redundant_tools_matrix.rs` asserts absence + full 84-tool classification (2026-07-20).

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -1,23 +1,25 @@
 # LeanKG PRD - Consolidated Tracking Document
 
-**Version:** 3.7.4-mcp-surface
-**Date:** 2026-07-18
+**Version:** 3.7.5-mega-sem-oom
+**Date:** 2026-07-20
 **Status:** Active Development — **single source of truth** for product requirements + HLD
 **Author:** Product Owner
 **Target Users:** Software developers using AI coding tools (Cursor, OpenCode, Claude Code, Gemini CLI, etc.)
-**Codebase Version:** 0.19.0 (`origin/main` @ `e5d1490`)
+**Codebase Version:** 0.19.1 (`origin/main` @ `a89a2cc`)
 
 > **Task lists + status live in one place (humans + AI agents):**
 > - Markdown: [`docs/prd-task-tracker.md`](prd-task-tracker.md) — **all** US / FR / Release tasks + status (**sorted by Focus P0→P3**)
 > - Machine: [`docs/prd-task-tracker.json`](prd-task-tracker.json)
 >
-> **CURRENT P0 (highest):** **Day-2 embed resume** — core FRs DONE on `feature/embed-resume-day2` / PR [#81](https://github.com/FreePeak/LeanKG/pull/81). Remaining PARTIAL: mega-graph MCP auto-index OOM ops (`FR-MG-AUTO-01`, `LEANKG_SKIP_FRESHNESS_CHECK`) + optional live Docker smoke.
+> **CURRENT P0 (highest):** **Mega-graph HNSW `semantic_search` OOM** — `US-SEM-06` / `FR-SEM-07` / `REL-054`. Evidence: [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md). HNSW path still triggers `all_elements()` on ~641k-element mounts → MCP OOM/restart. Small `/workspace` HNSW remains GREEN.
 >
-> **Semantic MCP live probe 2026-07-18 GREEN** ([`docs/semantic-search-mcp-verification-2026-07-18.md`](semantic-search-mcp-verification-2026-07-18.md)): 3,271 vectors; no embed-resume regressions. **FR-SEM-06** path filter **DONE**. FR-SEM-01..03 remain P2.
+> **Prior P0 Day-2 embed resume COMPLETE** — PR [#81](https://github.com/FreePeak/LeanKG/pull/81) + `embed_control` idle resume on PR [#86](https://github.com/FreePeak/LeanKG/pull/86). Do **not** start new embed-resume work ahead of closing mega-sem OOM.
 >
-> **New track (v3.7.4):** **MCP tool surface rationalization** — §3.16 / §5.18 (`US-SURF-*` / `FR-SURF-*`). Prefer docstring prefer-order + 3 hard deletes over large merges/rebrands. Baseline registry ≈**85** tools (not 64).
+> **Semantic MCP live probe 2026-07-18 GREEN on small graph** ([`docs/semantic-search-mcp-verification-2026-07-18.md`](semantic-search-mcp-verification-2026-07-18.md)): 3,271 vectors. **FR-SEM-06** path filter **DONE**. FR-SEM-01..03 remain P2. Mega HNSW is a **new P0** (not covered by that small-graph probe).
 >
-> **P0 Vector Engine (v3.7) COMPLETE** — PR [#80](https://github.com/FreePeak/LeanKG/pull/80). Do **not** start new VE work ahead of closing embed-resume PARTIAL.
+> **Track (v3.7.4):** **MCP tool surface rationalization** — §3.16 / §5.18 (`US-SURF-*` / `FR-SURF-*`). Prefer docstring prefer-order + 3 hard deletes over large merges/rebrands. Baseline registry ≈**84–85** tools.
+>
+> **P0 Vector Engine (v3.7) COMPLETE** — PR [#80](https://github.com/FreePeak/LeanKG/pull/80).
 >
 > This PRD is the SoT for *mission, narrative ACs, HLD, NFRs, glossary*.  
 > The tracker is the SoT for *task inventory and Done/Pending/Partial status*.  
@@ -28,6 +30,20 @@
 ---
 
 ## Changelog
+
+### v3.7.5-mega-sem-oom - Mega-graph HNSW semantic_search OOM is P0 (2026-07-20)
+
+> **Trigger:** Post-merge Docker MCP validation on `main` @ `a89a2cc` ([`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md)). Find/lookup, ontology, flow, and `embed_control` idle resume **PASS** on `/workspace-other` (~641k elements, ~147k vectors). **`semantic_search` on mega FAIL:** RSS climbs ~3.3 GiB → `OOMKilled` / HTTP disconnect; logs show deprecated `all_elements()` + skip elements_cache. Same tool on `/workspace` **PASS** (`method: hnsw+rerank`).
+>
+> **Product intent:** Mega-graph agents must be able to run HNSW `semantic_search` / `kg_semantic_context` under documented MCP memory budgets **without** killing the HTTP server. Prefer-order (`concept_search` → `search_code`) is a temporary agent workaround, not the product fix.
+
+**Product actions this revision:**
+| ID | Priority | Focus | Intent |
+|----|----------|-------|--------|
+| US-SEM-06 / FR-SEM-07 | Must Have | **P0** | Mega-safe HNSW path: no unbounded `all_elements()`; ANN + paginated element hydration only; MCP stays healthy |
+| REL-054 | Must Have | **P0** | Live mega smoke: `semantic_search` + `kg_semantic_context` on `/workspace-other` without OOM/restart |
+
+**New content:** Section **3.14** US-SEM-06; Section **5.15** FR-SEM-07 + REL-054; Section **5.17** cross-link. Tracker Focus **P0** open queue = mega-sem OOM (embed-resume / VE remain DONE).
 
 ### v3.7.4-mcp-surface - MCP tool surface rationalization (2026-07-18)
 
@@ -996,7 +1012,7 @@ Palace Mapping:
 >
 > **Depends on:** FR-HNSW-D / FR-V2-06 / FR-V2-07 (shipped). **Does not** reopen Cozo vs LocalEngine cutover (FR-VE-GATE).
 >
-> **Tasks:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter `US-SEM-*` / `FR-SEM-*` / `REL-051`.
+> **Tasks:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter `US-SEM-*` / `FR-SEM-*` / `REL-051` / `REL-054`. **P0 open:** `US-SEM-06` / `FR-SEM-07` / `REL-054`.
 
 #### US-SEM-01 — Honest token accounting on truncated MCP payloads (Should Have)
 
@@ -1041,7 +1057,20 @@ Palace Mapping:
 - **Given** a query containing `"benchmark"`, **When** `semantic_search` runs, **Then** `src/benchmark/**` may appear (gated keep).
 - **Evidence baseline:** [`docs/semantic-search-mcp-verification-2026-07-18.md`](semantic-search-mcp-verification-2026-07-18.md) Probes G/H.
 
-### 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 — **P0 CURRENT**
+#### US-SEM-06 — Mega-graph HNSW semantic search must not OOM MCP (**P0** / Must Have)
+
+**As an** AI agent on a mega-graph Docker MCP mount (~600k+ elements, ~150k vectors), **I want** `semantic_search` and `kg_semantic_context` to complete under the documented MCP memory budget, **so that** natural-language retrieval does not kill `:9699` and strand the rest of the tool surface.
+
+**Acceptance criteria:**
+- **Given** an indexed mega project (`project=/workspace-other` or equivalent container mount) with an existing embedding index, **When** `semantic_search(query=…, limit≤5)` runs, **Then** the call returns `method: hnsw+rerank` (or documented degrade) **without** container `OOMKilled`, process crash, or HTTP disconnect; `/health` stays ok during and after the call.
+- **Given** the same setup, **When** `kg_semantic_context` runs a short NL query, **Then** the same stability ACs hold (no mega `all_elements()` dump).
+- **Given** logs during the call, **When** inspected, **Then** there is **no** unbounded `all_elements()` / full-graph element cache load for seed hydration (ANN candidates + paginated / keyed element fetch only).
+- **Given** the same binary on a small project (`/workspace`), **When** `semantic_search` runs, **Then** existing HNSW+rerank behavior remains GREEN (no regression).
+- **Evidence of failure (baseline):** [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md) — mega FAIL / small PASS; mem peak ~3.3 GiB before kill.
+
+**Temporary agent workaround (not the fix):** on mega-graphs prefer `concept_search` → `search_code` / `find_function` until FR-SEM-07 lands.
+
+### 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 — **DONE (prior P0)**
 
 > **Trigger:** Turning embedding on (standalone Docker `embed --wait`, or Docker MCP with `LEANKG_EMBED_BACKGROUND` / boot / setup) against a persisted RocksDB volume looks like a full cold rebuild — unacceptable CPU/RAM/time on mega-graphs.
 >
@@ -1365,9 +1394,11 @@ Agent A/B floors (also in NFR / tracker `FR-VE-BENCH-*`):
 
 ### 5.15 Semantic MCP Agent UX Enhancements (v3.7.1)
 
-> **FR checklist + status:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter `FR-SEM-*` / `REL-051` / `US-SEM-*`.
+> **FR checklist + status:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter `FR-SEM-*` / `REL-051` / `REL-054` / `US-SEM-*`. **Current P0:** `FR-SEM-07` / `REL-054`.
 >
-> **Evidence baseline (GREEN, no reopen):** [`docs/semantic-search-mcp-verification-2026-07-17.md`](semantic-search-mcp-verification-2026-07-17.md). Live probe confirms HNSW+rerank, ontology, `kg_*` schema health, and graph-enriched context. These FRs are **agent UX / ops / release hygiene** — not ANN recall fixes.
+> **Evidence baseline (GREEN, no reopen) — small graph:** [`docs/semantic-search-mcp-verification-2026-07-17.md`](semantic-search-mcp-verification-2026-07-17.md). Live probe confirms HNSW+rerank, ontology, `kg_*` schema health, and graph-enriched context.
+>
+> **Mega-graph gap (P0, 2026-07-20):** [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md) — HNSW path OOMs when seed hydration still touches `all_elements()`. FR-SEM-01..05 remain agent UX / ops / release hygiene — **FR-SEM-07 is the mega safety fix**.
 
 **Policy:**
 - Keep shipped retrieval path (FR-HNSW-D): embed → HNSW top-k → optional rerank → optional graph traverse
@@ -1382,14 +1413,17 @@ Agent A/B floors (also in NFR / tracker `FR-VE-BENCH-*`):
 | FR-SEM-04 | Should Have | Formal **live MCP semantic smoke** checklist (Docker `project=/workspace`) as release *complement*; template = verification docs 2026-07-17 / **2026-07-18** |
 | FR-SEM-05 | Could Have | Optional file-diversity / MMR post-filter after HNSW+rerank so top-k is not ≥70% one file by default collapse |
 | FR-SEM-06 | Must Have | Path filter in `FilterPolicy`: always drop `embed/assets/`; query-gate `src/benchmark/` unless query contains "benchmark" (Probes G/H) |
+| FR-SEM-07 | Must Have (**P0**) | **Mega-safe HNSW semantic path:** `semantic_search` / `kg_semantic_context` (and any helper they call for seed hydration) must **not** invoke unbounded `all_elements()` or load the full element set into RAM on graphs above `LEANKG_MAX_CACHE_ELEMENTS`. Hydrate ANN hit QNs via keyed/paginated DB reads only. Peak RSS must fit documented MCP `mem_limit` (compose default 6g; effective cgroup may be lower) without OOM/restart. Small-graph HNSW path must not regress. |
 | REL-051 | Should Have | Release note: live semantic smoke executed (or waived with reason) alongside embeddings cargo suite — **DONE** 2026-07-18 |
+| REL-054 | Must Have (**P0**) | Live mega smoke gate: on `/workspace-other` (or equivalent), `semantic_search` + `kg_semantic_context` succeed without OOM/HTTP drop; record peak RSS + latency in a `docs/reports/` note. Complements REL-051 (small-graph) |
 
 **Won't Do (this track):**
 - Replacing Cozo HNSW default before FR-VE-GATE callers honor LocalEngine
 - Treating transient HTTP flakes as ANN / ontology product failures
 - Dropping truncation entirely (mission is still lean tokens)
+- Raising OrbStack/host VM RAM alone as the “fix” for `all_elements()` on mega HNSW (ops headroom helps; code must still stop full-graph dumps)
 
-### 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) — **P0 CURRENT**
+### 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) — **DONE (prior P0)**
 
 > **FR checklist + status:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter `FR-EMBED-RESUME-*` / `US-EMBED-*` / `REL-052` / `FR-HNSW-E`.
 >
@@ -1424,14 +1458,17 @@ Agent A/B floors (also in NFR / tracker `FR-VE-BENCH-*`):
 
 ### 5.17 Mega-graph MCP auto-index + embed ops (v3.7.3)
 
-> **FR checklist + status:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter `FR-MG-AUTO-*` / `FR-OPS-EMBED-*`.
+> **FR checklist + status:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter `FR-MG-AUTO-*` / `FR-OPS-EMBED-*` / **P0** `FR-SEM-07` / `REL-054`.
 >
 > **Evidence:** [`docs/reports/embed-3-workspaces-2026-07-17.md`](reports/embed-3-workspaces-2026-07-17.md) — large multi-repo mounts trigger MCP incremental reindex on every start (RocksDB writes do not bump `.leankg/leankg.db` mtime), OOMs under 2g `mem_limit`, and flake semantic HTTP. `docker-compose.embed.yml` `cpus: "6"` failed on 5-vCPU hosts.
+>
+> **2026-07-20 follow-up:** Auto-index skip + compose CPU/mem knobs are **not sufficient** for mega HNSW query — see **FR-SEM-07** / **US-SEM-06** (P0). Evidence: [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md).
 
 | ID | Priority | Requirement |
 |----|----------|-------------|
 | FR-MG-AUTO-01 | Must Have | Honor `LEANKG_SKIP_FRESHNESS_CHECK=1` in MCP `auto_index_if_needed` (no wipe). Document ops: `LEANKG_AUTO_INDEX=0`, `auto_index_on_start: false`, MCP `mem_limit: 6g` / `mem_reservation: 3g` / `cpus: "6"` for mega-graphs (~147k vectors). Follow-up: RocksDB manifest mtime vs `leankg.db` |
 | FR-OPS-EMBED-CPU | Must Have | `docker-compose.embed.yml`: `cpus: "6"`, `mem_reservation: 3g`, `mem_limit: 10g`. MCP `docker-compose.rocksdb.yml`: multi-project default `cpus: "6"`, `mem_reservation: 3g`, `mem_limit: 6g` (override down for single-project Local 2g KPI) |
+| FR-SEM-07 / REL-054 | Must Have (**P0**) | Cross-link: mega-safe HNSW query path — owned in §5.15; ops evidence still recorded under mega-graph reports |
 
 **Won't Do:** `LEANKG_FORCE_REINDEX=1` as the fix for stale mega-graphs (wipes data).
 
@@ -1904,23 +1941,36 @@ All MCP tool responses use TOON (Token-Oriented Object Notation) format by defau
 
 ## 8. Release Criteria
 
-> **Release checklist + status:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter Kind=`Release` or section 8.* / FR-VE-GATE / REL-052.
+> **Release checklist + status:** [`prd-task-tracker.md`](prd-task-tracker.md) — filter Kind=`Release` or section 8.* / FR-VE-GATE / REL-052 / **REL-054**.
 
-### 8.5 v3.7.2 Embed Resume Gate (CURRENT P0)
+### 8.5 v3.7.2 Embed Resume Gate — **DONE (prior P0)**
 
-> **Status:** PENDING — tracker `REL-052` + `FR-EMBED-RESUME-*` / `US-EMBED-*`.
+> **Status:** **DONE** on PR [#81](https://github.com/FreePeak/LeanKG/pull/81) / [#86](https://github.com/FreePeak/LeanKG/pull/86) — tracker `REL-052` + `FR-EMBED-RESUME-*` / `US-EMBED-*` / `FR-EMBED-TOGGLE-01`.
 >
-> Ship day-2 resume before starting new P1 feature work. Vector Engine PR #80 may merge in parallel; it does **not** replace this gate.
->
-> **Implementation (2026-07-18 — `feature/embed-resume-day2`):** FR-EMBED-RESUME-01..04 + US-EMBED-01..03 **DONE** (unit + e2e + local CLI smoke: second `embed --wait` logs `nothing to embed … HNSW unchanged`). Remaining PARTIAL: optional live Docker MCP smoke / mega-graph wall-time note (`US-EMBED-04`, `FR-EMBED-RESUME-05/06`, `REL-052`).
+> **Current P0** is mega-graph HNSW query safety — see **§8.6** (`REL-054` / `FR-SEM-07`).
 
 **Gate checklist:**
-1. Unchanged second `embed --wait` on RocksDB volume: `embedded≈0`, `skipped_fresh` dominates (FR-EMBED-RESUME-01 / US-EMBED-01) — **DONE** (CLI smoke + e2e)
+1. Unchanged second `embed --wait` on RocksDB volume: `embedded≈0`, `skipped_fresh` dominates (FR-EMBED-RESUME-01 / US-EMBED-01) — **DONE**
 2. Zero-dirty path skips HNSW drop/rebuild (FR-EMBED-RESUME-02 / US-EMBED-03) — **DONE**
-3. Kill mid-run → resume dirty-only (FR-EMBED-RESUME-03 / US-EMBED-02) — **DONE** (per-batch `upsert_fresh`)
-4. No-op index does not stale-all (FR-EMBED-RESUME-04) — **DONE** (`mark_stale_if_changed`)
-5. Day-2 wall time ≪ cold on mega-graph; release note records numbers (FR-EMBED-RESUME-05 / REL-052) — **PARTIAL** (local tiny smoke green; mega-graph evidence optional)
-6. Docker embed-on resumes existing data; cold only when empty (FR-EMBED-RESUME-06 / US-EMBED-04) — **PARTIAL** (shared `build.rs` path + AGENTS; live Docker smoke optional)
+3. Kill mid-run → resume dirty-only (FR-EMBED-RESUME-03 / US-EMBED-02) — **DONE**
+4. No-op index does not stale-all (FR-EMBED-RESUME-04) — **DONE**
+5. Day-2 wall time ≪ cold on mega-graph; release note records numbers (FR-EMBED-RESUME-05 / REL-052) — **DONE** (MCP idle resume evidence 2026-07-20: `skipped_fresh: 147175`, ~2.7 s)
+6. Docker embed-on resumes existing data; cold only when empty (FR-EMBED-RESUME-06 / US-EMBED-04) — **DONE**
+
+### 8.6 v3.7.5 Mega-graph HNSW Semantic Safety Gate (**CURRENT P0**)
+
+> **Status:** **OPEN** — tracker `US-SEM-06` / `FR-SEM-07` / `REL-054`.
+>
+> Ship mega-safe HNSW `semantic_search` / `kg_semantic_context` before treating mega Docker MCP as production-ready for NL retrieval. Small-graph probe (REL-051) does **not** close this gate.
+>
+> **Failure baseline:** [`docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md) — mega OOM; `/workspace` HNSW GREEN.
+
+**Gate checklist:**
+1. No unbounded `all_elements()` (or equivalent full-graph RAM load) on HNSW semantic seed hydration (FR-SEM-07) — **NOT_DONE**
+2. `semantic_search` on `/workspace-other` returns without OOM/HTTP drop; `/health` stays ok (US-SEM-06 / REL-054) — **NOT_DONE**
+3. `kg_semantic_context` same mega stability AC — **NOT_DONE**
+4. Small `/workspace` HNSW+rerank remains GREEN (no regression) — **PASS** (baseline 2026-07-20)
+5. Report peak RSS + latency in `docs/reports/` after fix (REL-054) — **NOT_DONE**
 
 ## 9. Non-Functional Requirements
 

--- a/docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md
+++ b/docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md
@@ -1,0 +1,153 @@
+# LeanKG Docker MCP — post-merge `main` mega-graph tool validation
+
+**Date:** 2026-07-20  
+**Commit:** `a89a2cc` — `feat(mcp): embed_control idle resume + full tool redundancy audit (#86)`  
+**Binary:** `leankg 0.19.1`  
+**Transport:** HTTP MCP `http://localhost:9699/mcp`  
+**Container:** `leankg-leankg-1` (image rebuilt from local `main`)  
+**Tools registered:** 84 (includes `embed_control`)
+
+| Project arg (container) | Role |
+|-------------------------|------|
+| `/workspace` | LeanKG source (small graph) |
+| `/workspace-other` | Mega-graph monorepo mount (~641k elements) |
+
+Host bind paths and personal mount names are omitted; all examples use container placeholders only.
+
+---
+
+## 1. Executive summary
+
+| Area | Verdict | Notes |
+|------|---------|-------|
+| Pull + Docker rebuild + health | **PASS** | `main` @ `a89a2cc`; `/health` ok; MCP listens with `LEANKG_SKIP_FRESHNESS_CHECK` |
+| Find / lookup (`search_code`, `find_function`, `query_file`) | **PASS** on mega | User-like queries return ranked hits in seconds |
+| Ontology (`concept_search`, `kg_ontology_status`, `kg_context`) | **PASS** | Concept path works; auth query returned matched concepts + code refs |
+| Flow / graph (`get_callers`, `get_call_graph`, deps/impact, architecture) | **PASS** | Callers for `CreateOrder` returned truncated list; architecture/schema bounded |
+| `semantic_search` / `kg_semantic_context` on mega | **FAIL (OOM)** | HNSW path peaks ~3.3–3.4 GiB then disconnects; container restart |
+| Same semantic tools on `/workspace` | **PASS** | `method: hnsw+rerank`, `reranker_active: true` |
+| `embed_control` idle resume | **PASS** | Arm → silent 70 s → `skipped_fresh: 147175`, `embedded: 0`, ~2.7 s, vectors ~147420 |
+
+**Ship note:** Keyword find/lookup, ontology, and flow tools are usable on the mega mount. **Do not treat mega `semantic_search` as safe** under the current OrbStack/cgroup memory headroom (~3.9 GiB observed in `docker stats` even when compose `mem_limit` is 6–10 g). Prefer `concept_search` → `search_code` / `find_function` on mega until HNSW stops calling `all_elements()` (or memory headroom is raised).
+
+---
+
+## 2. Environment
+
+### 2.1 Rebuild
+
+```bash
+git pull origin main
+docker compose -f docker-compose.rocksdb.yml -f docker-compose.override.yml \
+  --env-file .dockerfile up --build -d
+```
+
+### 2.2 Boot knobs (values redacted to placeholders)
+
+| Variable | Value used |
+|----------|------------|
+| `LEANKG_DB_ENGINE` | `rocksdb` |
+| `LEANKG_PROJECT_DIRS` | `/workspace,/workspace-other,…` |
+| `LEANKG_MCP_PROJECT` | `/workspace-other` |
+| `LEANKG_SKIP_FRESHNESS_CHECK` | `1` |
+| `LEANKG_EMBED_ON_BOOT` | `0` |
+| `LEANKG_EMBED_BACKGROUND` | `0` |
+
+Compose defaults: `mem_limit: 6g`, `mem_reservation: 3g`, `cpus: "6"`. A temporary local override bump to `10g` did **not** raise the `docker stats` denominator (~3.894 GiB); mega HNSW still OOMed.
+
+### 2.3 Graph sizes (`mcp_status` include_counts)
+
+| Metric | `/workspace-other` |
+|--------|--------------------|
+| elements | **640 998** |
+| files | 28 249 |
+| functions | 390 301 |
+| classes | 32 208 |
+| relationships | **1 124 496** |
+| storage | RocksDB under `/data/leankg-rocksdb/projects/workspace-other-…` |
+
+---
+
+## 3. Focused results (user-like queries)
+
+Prefer-order validated where possible: `concept_search` → `semantic_search` → `search_code`; find via `find_function`.
+
+### 3.1 Find / lookup
+
+| Test | Tool | Latency | Status | Notes |
+|------|------|---------|--------|-------|
+| Status + counts | `mcp_status` | ~3.7 s | PASS | Mega counts as above |
+| `CreateOrder` | `search_code` | ~5.1 s | PASS | `count: 5`, `method: semantic+name_fallback` |
+| `RefundPayment` | `search_code` | ~5.7 s | PASS | `count: 4` |
+| `CreateOrder` | `find_function` | ~0.3 s | PASS | Multiple defs (token budget truncated) |
+| `ProcessRefund` | `find_function` | ~0.7 s | PASS | Empty `functions: []` (name absent) |
+| `*handler*.go` | `query_file` | ~7.7 s | PASS | `count: 0` on this mount/pattern |
+
+### 3.2 Ontology
+
+| Test | Tool | Latency | Status | Notes |
+|------|------|---------|--------|-------|
+| `user authentication login` | `concept_search` | ~7.4 s | PASS | `concept_match_count: 1`, `code_ref_count: 3`, no fallback |
+| `refund failure` | `concept_search` | ~7.0 s | PASS | No concept match (`code_ref_count: 0`); still ok response |
+| Coverage | `kg_ontology_status` | ~0.7 s | PASS | e.g. `domain_entity: 16`, `workflow: 10`, `failure_mode: 76` |
+| `checkout refund` | `kg_context` | ~0.8 s | PASS | Low confidence / empty expand on mega query |
+
+### 3.3 Flow / graph
+
+| Test | Tool | Latency | Status | Notes |
+|------|------|---------|--------|-------|
+| Callers of `CreateOrder` | `get_callers` | ~27 s | PASS | 15 callers returned (truncated) |
+| Call graph depth 1 | `get_call_graph` | ~1.3 s | PASS | Rel edges present |
+| `go.mod` deps / impact | `get_dependencies` / `get_impact_radius` | ~1–2 s | PASS | Empty/zero for root `go.mod` (expected if no edges) |
+| Explain / architecture / schema | `explain_node`, `get_architecture`, `get_graph_schema` | ~3–7 s | PASS | Bounded `max_items` |
+
+### 3.4 Semantic (HNSW) — careful
+
+| Project | Tool | Latency | Status | Evidence |
+|---------|------|---------|--------|----------|
+| `/workspace-other` | `semantic_search` (“refund failure…”) | ~106 s then drop | **FAIL** | `RemoteDisconnected`; prior run `OOMKilled=true`; mem peak ~3.37 GiB; logs: `all_elements()` + skip elements_cache (640998) |
+| `/workspace` | `semantic_search` (“how does MCP handle tools”) | ~9.7 s | **PASS** | `method: hnsw+rerank`, `ann_candidate_count: 50`, hits in `src/mcp/server.rs` |
+| `/workspace` | `kg_semantic_context` (“embedding control”) | ~7.7 s | **PASS** | Traversal from embed build seeds |
+
+**Root symptom:** mega HNSW path still triggers deprecated `all_elements()` and memory spike (ONNX + vector index + element dump) that exceeds effective cgroup headroom.
+
+---
+
+## 4. `embed_control` idle resume
+
+Sequence on `/workspace-other` (no MCP traffic during idle wait):
+
+1. `action=status` — prior completed run: `skipped_fresh: 147175`, `vectors_existing: 147420`, `phase: idle`
+2. `action=on` `mode=partial` `full=false` — `phase: waiting_idle` (“armed; will start when MCP idle…”)
+3. Silent sleep **70 s**
+4. `action=status` — `phase: completed`, `elapsed_s ≈ 2.74`, `embedded: 0`, `skipped_fresh: 147175`, `to_embed: 0`, `stale: 0`
+5. `action=off` — cooperative cancel; armed cleared
+
+**Verdict:** Day-2 zero-dirty resume behaves correctly (no full rebuild, honest skip counts, MCP stays healthy).
+
+---
+
+## 5. Aggregate focused suite
+
+| Metric | Value |
+|--------|-------|
+| Calls in focused suite | 25 |
+| PASS | 24 |
+| FAIL | 1 (`semantic_search` on mega) |
+| Final `/health` | ok |
+| Restarts during suite | 1 (after mega HNSW OOM/disconnect) |
+
+Earlier broader smoke (before memory monitoring) also saw cascade failures after the first HNSW OOM — expected once HTTP drops.
+
+---
+
+## 6. Recommendations
+
+1. **Agents on mega:** prefer `concept_search` → `search_code` / `find_function`; avoid `semantic_search` / `kg_semantic_context` until mega-safe.
+2. **Engineering:** remove `all_elements()` from HNSW / retrieval seed hydration; keep ANN + paginated element fetch only.
+3. **Ops:** OrbStack/`docker stats` showed ~3.9 GiB effective limit despite compose `mem_limit` 6–10 g — raise VM/cgroup headroom if mega HNSW must run in-process.
+4. **`embed_control`:** safe to arm for incremental resume on this volume; zero-dirty completes in a few seconds after idle gate.
+
+---
+
+*Report written 2026-07-20. Paths sanitized to `/workspace` / `/workspace-other` / `svc-x` placeholders only.*

--- a/docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md
+++ b/docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md
@@ -1,0 +1,74 @@
+# REL-054 — Mega-graph HNSW semantic OOM fix evidence (FR-SEM-07)
+
+**Date:** 2026-07-20  
+**Branch:** `feature/mega-sem-oom`  
+**Commits:** `670e202` (docs P0) → `d14dd8d` (keyed hydration) → `e8bb475` (`has_any` gate)  
+**Image:** `leankg-leankg:mega-sem-oom` (built from worktree + vendor; tagged `latest` for compose)  
+**Transport:** HTTP MCP `http://localhost:9699`  
+**Projects:** `/workspace` (small), `/workspace-other` (mega ~641k elements)
+
+Prior failure evidence: [`main-a89a2cc-docker-mega-tool-test-2026-07-20.md`](main-a89a2cc-docker-mega-tool-test-2026-07-20.md).
+
+---
+
+## 1. Verdict
+
+| Gate | Result |
+|------|--------|
+| Mega `semantic_search` (×2) | **PASS** — `method: hnsw+rerank`, HTTP kept |
+| Mega `kg_semantic_context` | **PASS** — ~58 s total (`retrieve` ~36 s), seeds + traverse |
+| Logs contain `all_elements()` during smoke | **False** (count `0`) |
+| `/workspace` `semantic_search` HNSW | **PASS** (GREEN, no regression) |
+| `/health` after mega pair | **ok** |
+| Tracker | `US-SEM-06` / `FR-SEM-07` / `REL-054` → **DONE** |
+
+**Root fix:** HNSW seed hydration no longer calls `GraphEngine::all_elements()`. It uses `get_elements_by_qualified_names` (keyed, includes `env`). Cheap `:limit 1` `has_any` replaces `list_all` gates; `index_size()`/`list_all` skipped when `ann_top_k` is set.
+
+---
+
+## 2. Smoke results
+
+| Call | Project | Outcome | Notes |
+|------|---------|---------|-------|
+| `semantic_search` query≈payment refund… | `/workspace-other` | PASS | `ann_top_k_used: 50`, 10 hits |
+| `kg_semantic_context` query≈access rights | `/workspace-other` | PASS | `latency_ms.total: 58389`, `reranker: bge-reranker-v2-m3` |
+| `semantic_search` query≈grpc interceptor | `/workspace-other` | PASS | `hnsw+rerank` |
+| `semantic_search` query≈mcp semantic… | `/workspace` | PASS | top hit `./src/mcp/handler.rs::semantic_search` |
+
+Peak RSS samples during mega path (docker stats, cgroup denom **~3.894 GiB**): ~2.6–3.3 GiB while tools completed. No `all_elements()` warn in container logs for the smoke window.
+
+### Residual note (not FR-SEM-07 regression)
+
+After several successive HNSW+rerank loads under the ~3.9 GiB effective OrbStack ceiling, Docker recorded one later `oom` / exit `137` while stacking an extra `/workspace` call (models still resident). That is **residual model RSS headroom**, not the pre-fix mega dump. Health recovered; `/workspace` HNSW re-verified GREEN after restart. Compose `mem_limit: 6g` still does not raise the observed stats denominator above ~3.9 GiB on this host.
+
+---
+
+## 3. Code changes (summary)
+
+1. `GraphEngine::get_elements_by_qualified_names` — keyed QN fetch **with `env`**.
+2. `SemanticRetrievalPipeline::fetch_elements_batch` — keyed only (ban `all_elements`).
+3. Skip `index_size()` when `opts.ann_top_k.is_some()`.
+4. `embeddings::state::has_any` — `:limit 1`; used by `embeddings_index_available` and `kg_semantic_context`.
+
+Unit/`hnsw_recall_e2e` (embeddings feature) green on the fix branch before Docker smoke.
+
+---
+
+## 4. Rebuild recipe (no host bind paths)
+
+```bash
+# Assemble Linux build context (vendor must be a real directory, not a broken symlink)
+rsync -a --exclude target --exclude .git \
+  .worktrees/feature/mega-sem-oom/ /tmp/leankg-mega-sem-oom-build/
+# copy vendor/ into build context as needed
+docker build -f Dockerfile.rocksdb -t leankg-leankg:mega-sem-oom /tmp/leankg-mega-sem-oom-build
+docker tag leankg-leankg:mega-sem-oom leankg-leankg:latest
+docker compose -f docker-compose.rocksdb.yml -f docker-compose.override.yml \
+  --env-file .dockerfile up -d --force-recreate --no-build leankg
+```
+
+Do **not** `docker cp` a macOS Mach-O `leankg` into the Linux container.
+
+---
+
+*REL-054 closed 2026-07-20 on `feature/mega-sem-oom`.*

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -49,7 +49,7 @@ pub use runtime::{
 #[allow(unused_imports)]
 pub use state::{
     count_by_state, create_hnsw_index, delete_state_rows, drop_hnsw_index,
-    ensure_embedding_state_table, list_all, list_orphans, list_stale,
+    ensure_embedding_state_table, has_any, list_all, list_orphans, list_stale,
     mark_stale_for_qualified_names, upsert_fresh, EmbeddingStateRow, FreshRow, StateCounts,
 };
 #[allow(unused_imports)]

--- a/src/embeddings/state.rs
+++ b/src/embeddings/state.rs
@@ -267,6 +267,14 @@ pub fn list_all(db: &CozoDb) -> Result<Vec<EmbeddingStateRow>, Box<dyn std::erro
     Ok(result.rows.iter().filter_map(row_to_state_row).collect())
 }
 
+/// Cheap non-empty probe for MCP HNSW gating (FR-SEM-07).
+/// Avoids loading every `embedding_state` row via [`list_all`].
+pub fn has_any(db: &CozoDb) -> Result<bool, Box<dyn std::error::Error>> {
+    let query = r#"?[qualified_name] := *embedding_state[qualified_name, usearch_key, content_hash, state, embedded_at] :limit 1"#;
+    let result = crate::db::schema::run_script(db, query, Default::default())?;
+    Ok(!result.rows.is_empty())
+}
+
 /// Maximum number of rows to inline into a single CozoDB `<~ [...]` literal.
 /// CozoDB's pest grammar parser recurses on large literals and can blow the
 /// stack or hit internal limits on thousand-row repos; chunking keeps each
@@ -464,5 +472,25 @@ mod tests {
             cozo::DataValue::Num(cozo::Num::Int(5)),
         ];
         assert!(row_to_state_row(&row).is_none());
+    }
+
+    #[test]
+    fn has_any_false_on_empty_then_true_after_upsert() {
+        // FR-SEM-07: MCP HNSW gate must use :limit 1, not list_all.
+        use crate::db::schema::init_db;
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = init_db(&tmp.path().join("has_any.db")).unwrap();
+        ensure_embedding_state_table(&db).unwrap();
+        assert!(!has_any(&db).unwrap());
+        upsert_fresh(
+            &db,
+            &[FreshRow {
+                qualified_name: "src/x.rs::f".to_string(),
+                usearch_key: 1,
+                content_hash: "h".to_string(),
+            }],
+        )
+        .unwrap();
+        assert!(has_any(&db).unwrap());
     }
 }

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -192,6 +192,57 @@ impl GraphEngine {
         }))
     }
 
+    /// Keyed lookup for a small set of qualified names (HNSW ANN hits).
+    ///
+    /// FR-SEM-07: never call [`Self::all_elements`] to hydrate ~top-k seeds —
+    /// that OOMs mega-graphs (~600k+ elements). Includes `env` (unlike
+    /// [`Self::find_element`]) so env filters in retrieval stay correct.
+    pub fn get_elements_by_qualified_names(
+        &self,
+        qns: &[String],
+    ) -> Result<std::collections::HashMap<String, CodeElement>, Box<dyn std::error::Error>> {
+        let mut out = std::collections::HashMap::with_capacity(qns.len());
+        if qns.is_empty() {
+            return Ok(out);
+        }
+        let tail = self.code_elements_tail();
+        let query = format!(
+            r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env] := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata{tail}], qualified_name = $qn"#
+        );
+        for qn in qns {
+            if qn.is_empty() || out.contains_key(qn) {
+                continue;
+            }
+            let mut params = std::collections::BTreeMap::new();
+            params.insert("qn".to_string(), serde_json::Value::String(qn.clone()));
+            let result = crate::db::schema::run_script(&self.db, &query, params)?;
+            let Some(row) = result.rows.first() else {
+                continue;
+            };
+            let parent_qualified = row[7].get_str().map(String::from);
+            let cluster_id = row[8].get_str().map(String::from);
+            let cluster_label = row[9].get_str().map(String::from);
+            let metadata_str = row[10].get_str().unwrap_or("{}");
+            let env = row[11].get_str().unwrap_or("local").to_string();
+            let elem = CodeElement {
+                qualified_name: row[0].get_str().unwrap_or("").to_string(),
+                element_type: row[1].get_str().unwrap_or("").to_string(),
+                name: row[2].get_str().unwrap_or("").to_string(),
+                file_path: row[3].get_str().unwrap_or("").to_string(),
+                line_start: row[4].get_int().unwrap_or(0) as u32,
+                line_end: row[5].get_int().unwrap_or(0) as u32,
+                language: row[6].get_str().unwrap_or("").to_string(),
+                parent_qualified,
+                cluster_id,
+                cluster_label,
+                metadata: serde_json::from_str(metadata_str).unwrap_or(serde_json::json!({})),
+                env,
+            };
+            out.insert(elem.qualified_name.clone(), elem);
+        }
+        Ok(out)
+    }
+
     #[allow(dead_code)]
     pub fn find_element_by_name(
         &self,
@@ -5608,6 +5659,55 @@ mod tests {
             ..Default::default()
         };
         engine.insert_element(&elem).unwrap();
+    }
+
+    #[test]
+    fn get_elements_by_qualified_names_returns_only_requested_with_env() {
+        // FR-SEM-07: keyed hydration must not require all_elements().
+        let (engine, _tmp) = make_test_engine();
+        let wanted = CodeElement {
+            qualified_name: "src/a.rs::keep_me".to_string(),
+            element_type: "function".to_string(),
+            name: "keep_me".to_string(),
+            file_path: "src/a.rs".to_string(),
+            line_start: 1,
+            line_end: 5,
+            language: "rust".to_string(),
+            ..Default::default()
+        };
+        let other = CodeElement {
+            qualified_name: "src/b.rs::skip_me".to_string(),
+            element_type: "function".to_string(),
+            name: "skip_me".to_string(),
+            file_path: "src/b.rs".to_string(),
+            line_start: 1,
+            line_end: 5,
+            language: "rust".to_string(),
+            ..Default::default()
+        };
+        engine.insert_element(&wanted).unwrap();
+        engine.insert_element(&other).unwrap();
+
+        let map = engine
+            .get_elements_by_qualified_names(&[
+                "src/a.rs::keep_me".to_string(),
+                "src/missing.rs::nope".to_string(),
+            ])
+            .unwrap();
+        assert_eq!(map.len(), 1);
+        let got = map.get("src/a.rs::keep_me").expect("keep_me present");
+        assert_eq!(got.name, "keep_me");
+        // insert_element uses schema default env='local'; keyed path must still
+        // populate the env column (not leave it empty via find_element Default).
+        assert_eq!(got.env, "local");
+        assert!(!map.contains_key("src/b.rs::skip_me"));
+    }
+
+    #[test]
+    fn get_elements_by_qualified_names_empty_input() {
+        let (engine, _tmp) = make_test_engine();
+        let map = engine.get_elements_by_qualified_names(&[]).unwrap();
+        assert!(map.is_empty());
     }
 
     #[test]

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -3954,12 +3954,8 @@ fn generate_documentation(file_path: &str, elements: &[CodeElement]) -> String {
 
 #[cfg(feature = "embeddings")]
 fn embeddings_index_available(db: &crate::db::schema::CozoDb) -> bool {
-    // Cheap check: any non-empty row in `embedding_vectors` means an
-    // embedding index exists for this DB. Avoids spinning up the embedder
-    // when no `leankg embed` has been run yet.
-    crate::embeddings::state::list_all(db)
-        .map(|rows| !rows.is_empty())
-        .unwrap_or(false)
+    // FR-SEM-07: :limit 1 probe — never list_all (~147k rows) just to gate HNSW.
+    crate::embeddings::state::has_any(db).unwrap_or(false)
 }
 
 #[cfg(feature = "embeddings")]

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -3644,9 +3644,9 @@ impl ToolHandler {
         let _project = args["project"].as_str().unwrap_or(".");
 
         // Vectors live in CozoDB now; freshness check is a state-table count.
-        let has_vectors = crate::embeddings::state::list_all(self.graph_engine.db())
-            .map(|rows| !rows.is_empty())
-            .unwrap_or(false);
+        // FR-SEM-07: cheap :limit 1 — never list_all (~147k rows) before retrieve.
+        let has_vectors =
+            crate::embeddings::state::has_any(self.graph_engine.db()).unwrap_or(false);
         if !has_vectors {
             return Err("No embedded vectors found. Run `leankg embed --init` \
                  to download models, then `leankg embed` to build the index."

--- a/src/retrieval/pipeline.rs
+++ b/src/retrieval/pipeline.rs
@@ -13,7 +13,7 @@ use crate::db::schema::{run_script, CozoDb};
 use crate::embeddings::models::{Embedder, RerankerStatus};
 use crate::retrieval::rerank::RerankStage;
 use cozo::DataValue;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 
 pub struct SemanticRetrievalPipeline {
     embedder: Embedder,
@@ -223,8 +223,14 @@ impl SemanticRetrievalPipeline {
         opts: &RetrieveOptions,
     ) -> Result<RetrievalResult, Box<dyn std::error::Error>> {
         // Resolve effective k: explicit override or adaptive on index size.
-        let index_size = self.index_size()?;
-        let effective_k = opts.ann_top_k.unwrap_or_else(|| adaptive_k(index_size));
+        // FR-SEM-07: when caller already set ann_top_k (MCP path), skip
+        // index_size() — it currently scans all embedding_state rows.
+        let (index_size, effective_k) = if let Some(k) = opts.ann_top_k {
+            (0usize, k)
+        } else {
+            let size = self.index_size()?;
+            (size, adaptive_k(size))
+        };
 
         // Stage 2: embed query, run CozoDB HNSW search.
         let qvec = self.embedder.embed(&[query.to_string()])?;
@@ -369,17 +375,9 @@ impl SemanticRetrievalPipeline {
         &self,
         qns: &[String],
     ) -> Result<HashMap<String, CodeElement>, Box<dyn std::error::Error>> {
-        if qns.is_empty() {
-            return Ok(HashMap::new());
-        }
+        // FR-SEM-07: keyed QN lookup only — never all_elements() (mega OOM).
         let engine = crate::graph::query::GraphEngine::new(self.db.clone());
-        let all = engine.all_elements()?;
-        let qn_set: HashSet<&str> = qns.iter().map(|s| s.as_str()).collect();
-        Ok(all
-            .into_iter()
-            .filter(|e| qn_set.contains(e.qualified_name.as_str()))
-            .map(|e| (e.qualified_name.clone(), e))
-            .collect())
+        engine.get_elements_by_qualified_names(qns)
     }
 }
 


### PR DESCRIPTION
## Summary
- Stop HNSW seed hydration from calling `all_elements()` (~641k rows); use keyed `get_elements_by_qualified_names` (includes `env`).
- Cheap `has_any` (`:limit 1`) replaces `list_all` gates; skip `index_size()` when `ann_top_k` is set.
- Closes P0 `US-SEM-06` / `FR-SEM-07` / `REL-054` with Docker mega smoke evidence.

## Test plan
- [x] Unit tests for keyed fetch + `has_any`
- [x] `cargo test --features embeddings` (`hnsw_recall_e2e`)
- [x] Docker mega `/workspace-other`: `semantic_search` ×2 + `kg_semantic_context` PASS (`hnsw+rerank`)
- [x] Logs: no `all_elements()` during smoke
- [x] `/workspace` HNSW regression GREEN
- [x] Evidence: `docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md`


Made with [Cursor](https://cursor.com)