### PR TITLE
fix(onrender): copy benches for Cargo manifest parse

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,8 @@ RUN echo "UI_EMBED_REV=${UI_EMBED_REV}" && npm run build
 WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
+# benches/ required — Cargo.toml [[bench]] targets fail manifest parse if missing.
+COPY benches ./benches
 COPY ontology/ ./ontology/
 # Always overwrite committed embed with freshly built ui-v2; refuse legacy title "ui".
 RUN rm -rf src/embed/* && cp -r ui-v2/dist/* src/embed/ \


### PR DESCRIPTION
## Summary

The Render `Dockerfile` did not copy the `benches/` directory into the build context. `Cargo.toml` declares `[[bench]]` targets, so `cargo build` fails during manifest parsing when those paths are missing.

This change adds `COPY benches ./benches` (with a short comment) alongside the existing `COPY src` step, matching what `Dockerfile.rocksdb` already does.

## Test plan

- [ ] Render deploy / Docker build completes manifest parse and compiles successfully

Made with [Cursor](https://cursor.com)