### PR TITLE
feat: hard-delete wake_up and search_by_environment (Wave 1a)

### DIFF
--- a/.claude-plugin/leankg-bootstrap.md
+++ b/.claude-plugin/leankg-bootstrap.md
@@ -25,7 +25,8 @@ LeanKG uses a single HTTP server supporting multiple projects. Each tool accepts
 | `get_call_graph` | Get function call chains |
 | `find_large_functions` | Find oversized functions |
 | `get_tested_by` | Get test coverage for a function/file |
-| `get_doc_for_file` | Get documentation for a file |
+| `get_overview_context` | Session-start L0+L1 overview |
+| `find_related_docs` | Find documentation related to a code change |
 | `get_traceability` | Get full traceability chain |
 | `get_code_tree` | Get codebase structure |
 | `get_doc_tree` | Get documentation tree |

--- a/.cursor-plugin/leankg-bootstrap.md
+++ b/.cursor-plugin/leankg-bootstrap.md
@@ -21,7 +21,8 @@ LeanKG provides these MCP tools for codebase navigation and analysis:
 | `get_call_graph` | Get function call chains |
 | `find_large_functions` | Find oversized functions |
 | `get_tested_by` | Get test coverage for a function/file |
-| `get_doc_for_file` | Get documentation for a file |
+| `get_overview_context` | Session-start L0+L1 overview |
+| `find_related_docs` | Find documentation related to a code change |
 | `get_traceability` | Get full traceability chain |
 | `get_code_tree` | Get codebase structure |
 | `get_doc_tree` | Get documentation tree |

--- a/.cursor-plugin/skills/using-leankg/SKILL.md
+++ b/.cursor-plugin/skills/using-leankg/SKILL.md
@@ -1,119 +1,114 @@
 ---
 name: using-leankg
-description: Use for ANY code search, navigation, or finding code logic - "where is X", "find logic Y", "how does Z work", impact analysis, dependencies. LeanKG is MANDATORY first.
+description: >-
+  Code search via LeanKG MCP when HTTP :9699 is healthy; otherwise skip LeanKG
+  and use default Grep/Glob/Read. Invoke before code navigation when LeanKG may apply.
 ---
 
-<EXTREMELY_IMPORTANT>
-STRICT ENFORCEMENT: You MUST follow the 4-Tier Search Fallback Chain EXACTLY.
+# LeanKG Code Search (HTTP-gated)
 
-1. ALWAYS start with `mcp_status` to check LeanKG readiness
-2. If NOT ready, invoke `mcp_init` or `mcp_index` to initialize
-3. Use LeanKG MCP tools for ALL searches (Tier 1)
-4. ONLY fall back to `leankg` CLI if MCP fails (Tier 2)
-5. ONLY fall back to `rtk` if CLI fails (Tier 3)
-6. ONLY fall back to `grep`/`rg` as ABSOLUTE LAST RESORT (Tier 4)
+**LeanKG is preferred when the MCP HTTP server is up.** If health fails, exit this skill immediately and use default Cursor/editor tools.
 
-**NO EXCEPTIONS. NO RATIONALIZATION. Follow the chain.**
-</EXTREMELY_IMPORTANT>
-
-## MANDATORY 4-Tier Search Fallback Chain
-
-```
-When user asks "where is X", "find logic Y", "how does Z work", etc:
-           |
-           v
-TIER 1: LeanKG MCP Server (leankg_mcp_* tools)
-           |
-           mcp_status (ALWAYS check first)
-           search_code("X") or find_function("X") or query_file("X")
-           |
-           +-- Results found --> get_context(file) to read content --> DONE
-           +-- MCP down/error --> TIER 2
-           |
-           v
-TIER 2: leankg CLI command
-           |
-           leankg query "X" --kind name
-           |
-           +-- Results found --> DONE
-           +-- Empty/error --> TIER 3
-           |
-           v
-TIER 3: rtk (rich toolkit grep)
-           |
-           rtk grep "X" --path .
-           rtk file "pattern" --path .
-           |
-           +-- Results found --> DONE
-           +-- Empty --> TIER 4
-           |
-           v
-TIER 4: grep/rg (ABSOLUTE LAST RESORT)
-           |
-           rg "X"
-           grep -rn "X" --include="*.ext"
-```
-
-## ABSOLUTE BANS
-
-- NEVER skip directly to grep/rg when LeanKG is available
-- NEVER use Glob to find code files before checking LeanKG
-- NEVER use Grep tool before exhausting Tiers 1-3
-- The ONLY exception: searching non-code files (config, docs, data files)
-
-## Tier 1: LeanKG MCP Tools (Use in this order)
-
-| Step | Tool | When to Use |
-|------|------|-------------|
-| 1 | `mcp_status` | ALWAYS check first |
-| 2 | `search_code("X")` | Find code by name/type |
-| 3 | `find_function("X")` | Locate function definitions |
-| 4 | `query_file("*X*")` | Find files by name |
-| 5 | `get_impact_radius(file)` | Blast radius for changes |
-| 6 | `get_context(file)` | READ file content (token-optimized) |
-| 7 | `get_dependencies(file)` | Get imports |
-| 8 | `get_dependents(file)` | Get reverse dependencies |
-| 9 | `get_tested_by(file)` | Find tests |
-| 10 | `get_callers("func")` | Find who calls a function |
-| 11 | `get_call_graph("func")` | Full call graph |
-
-## Tier 2: leankg CLI (Only if MCP fails)
+## Gate (ALWAYS FIRST)
 
 ```bash
-leankg status
-leankg query "X" --kind name
-leankg impact file 3
+curl -sf --max-time 2 http://localhost:9699/health
 ```
 
-## Tier 3: rtk Fallback (Only if leankg CLI empty)
+| Result | Next step |
+|--------|-----------|
+| Success (2xx) | Continue with LeanKG MCP below |
+| Fail / timeout / connection refused | **Exit skill.** Use `Grep`, `Glob`, `Read`. Do **not** call LeanKG MCP, `mcp_init`, or leankg CLI |
 
-```bash
-rtk grep "X" --path .
-rtk file "pattern" --path .
+Re-check health only if the user asks or you have reason to believe the server came back.
+
+---
+
+## When HTTP is healthy: LeanKG MCP
+
+### Project path (Docker vs host)
+
+When talking to Docker MCP on `:9699`, pass the **container mount** as `project=`:
+
+| Target | `project=` |
+|--------|------------|
+| This LeanKG repo | `/workspace` |
+| Extra bind (compose override) | `/workspace-other` (or the container side of the bind) |
+
+Do **not** pass a Mac host path (e.g. `/Users/.../leankg`) as `project` against Docker RocksDB.
+
+### Prefer-order (discover → exact)
+
+**Session start (overview):**
+```
+get_overview_context(project=…)  # L0+L1 summary — not load_layer(L0) alone
+→ optional load_layer for progressive budgets
+→ get_architecture for deep single-call overview
 ```
 
-## Tier 4: grep/rg (ABSOLUTE LAST RESORT)
+Natural-language / domain questions:
 
-```bash
-rg "X"
-grep -rn "X" --include="*.ext"
+```
+1. mcp_status(project=…)
+2. concept_search(query=…)     # domain concepts first
+3. semantic_search(query=…)    # HNSW ANN if embeddings exist
+4. search_code / find_function # name/type fallback
+5. get_context / get_impact_radius / get_dependencies / …
+   on the returned qualified_name or file — never full-graph dumps
 ```
 
-## Critical: After search_code returns file paths
+Exact symbol / file known:
 
-**IMPORTANT:** When `search_code` returns results with file paths:
-1. Use `get_context(file_path)` to READ the actual file content
-2. Do NOT just report the file paths - show the code
+```
+mcp_status → find_function / query_file → get_context → impact/deps tools
+```
 
-## Common Triggers
+### Finding Code
 
-| User says... | Start with |
-|--------------|------------|
-| "where is X" | `search_code("X")` or `find_function("X")` |
-| "find the logic" | `search_code("logic_name")` |
-| "how does X work" | `get_context(file)` after search_code |
-| "what calls X" | `get_callers("X")` or `get_call_graph("X")` |
-| "what breaks if I change X" | `get_impact_radius("X")` |
-| "find all files named X" | `query_file("X")` |
-| "who imports X" | `get_dependents("X")` |
-| "what does X depend on" | `get_dependencies("X")` |
+| Task | Tool | Example |
+|------|------|---------|
+| Domain / NL search | `concept_search` | `concept_search(query="authentication", project="/workspace")` |
+| Semantic / meaning | `semantic_search` | `semantic_search(query="payment refund", project="/workspace")` |
+| Name / type search | `search_code` | `search_code(query="Handler", project="/workspace")` |
+| Function definition | `find_function` | `find_function(name="ProcessOrder", project="/workspace")` |
+| File by pattern | `query_file` | `query_file(pattern="auth", project="/workspace")` |
+| Callers / call graph | `get_callers` / `get_call_graph` | pass `project=` |
+
+### Reading & Context (after discovery)
+
+| Task | Tool |
+|------|------|
+| File / symbol context | `get_context` |
+| Blast radius | `get_impact_radius` |
+| Imports / dependents | `get_dependencies` / `get_dependents` |
+| Tests | `get_tested_by` |
+| NL subgraph | `query_graph` (frontier-local; mega-safe) |
+| Session overview | `get_overview_context` |
+| Environment filter | `env=` on `search_code` / `semantic_search` / `concept_search` / `kg_*` |
+
+### Hard-removed tools (do not call)
+
+`mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`
+
+### If mcp_status is not ready (but HTTP health was OK)
+
+Try other known container mounts from `LEANKG_PROJECT_DIRS`, then fall back to default Grep/Glob/Read.
+
+**Do not** run `mcp_init` or local CLI indexing as a substitute when the preferred path is Docker HTTP MCP.
+
+### If LeanKG returns EMPTY results
+
+Fall back to default mode: `Grep`, `Glob`, `Read`.
+
+---
+
+## Default mode (HTTP down OR LeanKG empty)
+
+```
+Grep / Glob / Read
+```
+
+No Tier 2 leankg CLI. No forced `mcp_init`. Default editor tools are enough.
+
+**BAN:** Do not call LeanKG tools when `:9699` health failed.
+**BAN:** Do not materialize full element/relationship tables on mega graphs — use keyed / ANN / frontier tools only.

--- a/.opencode/plugins/leankg.js
+++ b/.opencode/plugins/leankg.js
@@ -25,10 +25,11 @@ LeanKG is a lightweight knowledge graph for codebase understanding.
 - \`get_dependents\` - Get files depending on target
 - \`get_context\` - Get AI-optimized context for a file
 - \`get_tested_by\` - Get test coverage info
+- \`get_overview_context\` - Session-start L0+L1 overview
+- \`find_related_docs\` - Find documentation related to a change
 - \`query_file\` - Find files by name/pattern
 - \`get_call_graph\` - Get function call chains
 - \`find_large_functions\` - Find oversized functions
-- \`get_doc_for_file\` - Get documentation for a file
 - \`get_traceability\` - Get full traceability chain
 - \`get_code_tree\` - Get codebase structure
 - \`get_doc_tree\` - Get documentation tree

--- a/.opencode/skills/using-leankg/SKILL.md
+++ b/.opencode/skills/using-leankg/SKILL.md
@@ -1,101 +1,114 @@
 ---
 name: using-leankg
-description: Use when user asks about codebase navigation, searching, finding code, impact analysis, or dependencies - LeanKG is the default grep replacement
+description: >-
+  Code search via LeanKG MCP when HTTP :9699 is healthy; otherwise skip LeanKG
+  and use default Grep/Glob/Read. Invoke before code navigation when LeanKG may apply.
 ---
 
-<EXTREMELY_IMPORTANT>
-If you think there is even a 1% chance a skill might apply to what you are doing, you ABSOLUTELY MUST invoke the skill.
+# LeanKG Code Search (HTTP-gated)
 
-IF A SKILL APPLIES TO YOUR TASK, YOU DO NOT HAVE A CHOICE. YOU MUST USE IT.
+**LeanKG is preferred when the MCP HTTP server is up.** If health fails, exit this skill immediately and use default Cursor/editor tools.
 
-This is not negotiable. This is not optional. You cannot rationalize your way out of this.
-</EXTREMELY_IMPORTANT>
-
-## LeanKG - Default Grep Replacement
-
-**LeanKG is the MANDATORY first resort for ALL codebase searches.**
-
-## Rule: LeanKG First, Grep Fallback
-
-**Invoke LeanKG tools BEFORE any grep/ripgrep usage.**
-
-```
-User asks "Where is X?" or searches for code
-          |
-          v
-1. mcp_status - check if LeanKG is ready
-          |
-          +-- NOT READY --> mcp_init with project .leankg path
-          |
-          v (READY)
-2. Use LeanKG tools FIRST:
-   - search_code("X") for symbol search
-   - find_function("X") for function definitions
-   - query_file("X") for file search
-   - get_impact_radius(file) for blast radius
-   - get_tested_by(file) for test coverage
-          |
-          v
-3. LeanKG returns results:
-          |
-          +-- EMPTY --> Fall back to grep/ripgrep
-          |
-          v (HAS RESULTS)
-4. Return LeanKG results (token-optimized)
-```
-
-## Tool Mapping
-
-| Instead of | Use LeanKG | Grep Fallback |
-|------------|------------|---------------|
-| `grep -rn "X" --include="*.rs"` | `search_code` or `find_function` | `grep -rn "X" --include="*.rs"` |
-| `find . -name "*X*"` | `query_file` | `find . -name "*X*"` |
-| Manual dependency tracing | `get_impact_radius` | N/A |
-| `grep -rn "X" tests/` | `get_tested_by` | `grep -rn "X" tests/` |
-| Reading entire files | `get_context` (token-optimized) | `cat file.rs` |
-
-## MCP Tools Reference
-
-| Tool | Purpose |
-|------|---------|
-| `mcp_status` | Check if LeanKG is initialized |
-| `mcp_init` | Initialize LeanKG (creates .leankg, indexes) |
-| `mcp_index` | Force re-index |
-| `search_code` | Search code elements by name/type |
-| `find_function` | Locate function definitions |
-| `query_file` | Find files by name/pattern |
-| `get_impact_radius` | Calculate blast radius (N hops) |
-| `get_dependencies` | Get direct imports |
-| `get_dependents` | Get files depending on target |
-| `get_context` | Get AI-optimized context |
-| `get_call_graph` | Get function call chains |
-| `find_large_functions` | Find oversized functions |
-| `get_tested_by` | Get test coverage |
-| `get_clusters` | Get functional clusters |
-| `get_review_context` | Focused subgraph for reviews |
-| `detect_changes` | Pre-commit risk analysis |
-
-## When LeanKG Returns Empty
-
-If LeanKG tools return empty results, this is NOT an error. Fall back to grep:
+## Gate (ALWAYS FIRST)
 
 ```bash
-# Rust
-grep -rn "X" --include="*.rs"
-
-# Go
-grep -rn "X" --include="*.go"
-
-# TypeScript
-grep -rn "X" --include="*.ts" --include="*.tsx"
-
-# Python
-grep -rn "X" --include="*.py"
+curl -sf --max-time 2 http://localhost:9699/health
 ```
 
-## Auto-Init Behavior
+| Result | Next step |
+|--------|-----------|
+| Success (2xx) | Continue with LeanKG MCP below |
+| Fail / timeout / connection refused | **Exit skill.** Use `Grep`, `Glob`, `Read`. Do **not** call LeanKG MCP, `mcp_init`, or leankg CLI |
 
-LeanKG automatically initializes on first use:
-- If `.leankg` does not exist, it creates one automatically
-- If index is stale (>5 min since last git commit), it re-indexes automatically
-- Set `auto_index_on_start: false` in `leankg.yaml` to disable
+Re-check health only if the user asks or you have reason to believe the server came back.
+
+---
+
+## When HTTP is healthy: LeanKG MCP
+
+### Project path (Docker vs host)
+
+When talking to Docker MCP on `:9699`, pass the **container mount** as `project=`:
+
+| Target | `project=` |
+|--------|------------|
+| This LeanKG repo | `/workspace` |
+| Extra bind (compose override) | `/workspace-other` (or the container side of the bind) |
+
+Do **not** pass a Mac host path (e.g. `/Users/.../leankg`) as `project` against Docker RocksDB.
+
+### Prefer-order (discover → exact)
+
+**Session start (overview):**
+```
+get_overview_context(project=…)  # L0+L1 summary — not load_layer(L0) alone
+→ optional load_layer for progressive budgets
+→ get_architecture for deep single-call overview
+```
+
+Natural-language / domain questions:
+
+```
+1. mcp_status(project=…)
+2. concept_search(query=…)     # domain concepts first
+3. semantic_search(query=…)    # HNSW ANN if embeddings exist
+4. search_code / find_function # name/type fallback
+5. get_context / get_impact_radius / get_dependencies / …
+   on the returned qualified_name or file — never full-graph dumps
+```
+
+Exact symbol / file known:
+
+```
+mcp_status → find_function / query_file → get_context → impact/deps tools
+```
+
+### Finding Code
+
+| Task | Tool | Example |
+|------|------|---------|
+| Domain / NL search | `concept_search` | `concept_search(query="authentication", project="/workspace")` |
+| Semantic / meaning | `semantic_search` | `semantic_search(query="payment refund", project="/workspace")` |
+| Name / type search | `search_code` | `search_code(query="Handler", project="/workspace")` |
+| Function definition | `find_function` | `find_function(name="ProcessOrder", project="/workspace")` |
+| File by pattern | `query_file` | `query_file(pattern="auth", project="/workspace")` |
+| Callers / call graph | `get_callers` / `get_call_graph` | pass `project=` |
+
+### Reading & Context (after discovery)
+
+| Task | Tool |
+|------|------|
+| File / symbol context | `get_context` |
+| Blast radius | `get_impact_radius` |
+| Imports / dependents | `get_dependencies` / `get_dependents` |
+| Tests | `get_tested_by` |
+| NL subgraph | `query_graph` (frontier-local; mega-safe) |
+| Session overview | `get_overview_context` |
+| Environment filter | `env=` on `search_code` / `semantic_search` / `concept_search` / `kg_*` |
+
+### Hard-removed tools (do not call)
+
+`mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`
+
+### If mcp_status is not ready (but HTTP health was OK)
+
+Try other known container mounts from `LEANKG_PROJECT_DIRS`, then fall back to default Grep/Glob/Read.
+
+**Do not** run `mcp_init` or local CLI indexing as a substitute when the preferred path is Docker HTTP MCP.
+
+### If LeanKG returns EMPTY results
+
+Fall back to default mode: `Grep`, `Glob`, `Read`.
+
+---
+
+## Default mode (HTTP down OR LeanKG empty)
+
+```
+Grep / Glob / Read
+```
+
+No Tier 2 leankg CLI. No forced `mcp_init`. Default editor tools are enough.
+
+**BAN:** Do not call LeanKG tools when `:9699` health failed.
+**BAN:** Do not materialize full element/relationship tables on mega graphs — use keyed / ANN / frontier tools only.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -253,7 +253,7 @@ Workspaces above `LEANKG_MAX_CACHE_ELEMENTS` (default **50_000** elements) are t
 - Full-scan tools (`get_clusters`, `get_code_tree` without query, nav dumps, annotation full scans) **refuse** with a redirect hint instead of loading 600k+ rows.
 - Incremental auto-index **skips** full-graph dependent expansion on mega-graphs (override with `LEANKG_INCREMENTAL_SKIP_DEPENDENTS=1` to force skip always).
 - Search prefer-order: `concept_search` → `semantic_search` → `search_code`. Semantic context: `semantic_search` → `kg_semantic_context` (embeddings) → `kg_context`.
-- Overview prefer: `get_overview_context` (soft-deprecated: `wake_up`; do not replace with `load_layer(L0)` alone). Prefer `env=` on search/`kg_*` instead of `search_by_environment`. Full redundancy audit: [`docs/reports/mcp-tool-redundancy-impact-2026-07-20.md`](docs/reports/mcp-tool-redundancy-impact-2026-07-20.md).
+- Overview prefer: `get_overview_context` (not `load_layer(L0)` alone). Use `env=` on search/`kg_*` for environment scoping. Hard-removed: `wake_up`, `search_by_environment`. Audit: [`docs/reports/mcp-tool-redundancy-impact-2026-07-20.md`](docs/reports/mcp-tool-redundancy-impact-2026-07-20.md).
 
 Env knobs:
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project are documented in this file.
 
 ## [Unreleased]
 
+### Changed
+- MCP: hard-delete `wake_up` and `search_by_environment`; prefer
+  `get_overview_context` and `env=` on search/`kg_*` (~81 tools with
+  embeddings). Agent docs, install hooks, and plugin manifests synced
+  (Wave 1a / REL-062).
+
 ### Added
 - Procedural ontology auto-update while serving: debounce-watch
   `ontology/workflows.yaml` + `concepts.yaml`, post-index refresh,

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,7 +115,20 @@ Local-only mount lists live in gitignored `.dockerfile` / `docker-compose.overri
 #### Step 1: Always Try LeanKG First
 1. Call `mcp_status(project="/workspace")` to check if LeanKG is ready for this repo
 2. If Docker MCP is down / not ready, try other mounts from `LEANKG_PROJECT_DIRS`, then local `mcp_init` only as last resort
-3. Use appropriate LeanKG tool with `project="/workspace"`: `search_code`, `find_function`, `query_file`, `get_impact_radius`, `get_dependencies`, `get_dependents`, `get_tested_by`, `get_context`
+3. **Session overview:** `get_overview_context(project="/workspace")` — not `load_layer(L0)` alone
+4. Use appropriate LeanKG tools with `project="/workspace"`: `concept_search` → `semantic_search` → `search_code`, `find_function`, `query_file`, `get_impact_radius`, `get_dependencies`, `get_dependents`, `get_tested_by`, `get_context`
+5. **Environment filter:** `env=` on search / `kg_*` (hard-removed: `search_by_environment`)
+
+#### Prefer-order (canonical)
+
+| Chain | Tools |
+|-------|-------|
+| Overview | `get_overview_context` → optional `load_layer` → `get_architecture` |
+| Search | `concept_search` → `semantic_search` → `search_code` |
+| Env | `env=` on search / `kg_*` |
+| File context | `get_context` (default) |
+
+Hard-removed: `mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`
 
 #### Step 2: Fallback Only If LeanKG Fails
 - LeanKG returns empty results OR

--- a/docs/agentic-instructions.md
+++ b/docs/agentic-instructions.md
@@ -39,6 +39,7 @@ bash scripts/install.sh cursor
 
 | Task | Prefer (HTTP up) | Fallback (HTTP down / empty) |
 |------|------------------|------------------------------|
+| Session overview | `get_overview_context` | — |
 | NL / domain “where is auth?” | `concept_search` → `semantic_search` | Grep |
 | Exact symbol name | `search_code` / `find_function` | Grep |
 | Read hit | `get_context` | Read |
@@ -59,8 +60,10 @@ User asks about codebase
 
 ## Prefer-order (FR-SURF-02)
 
+- Overview: `get_overview_context` → optional `load_layer` → `get_architecture` (not `load_layer(L0)` alone)
 - Search: `concept_search` → `semantic_search` → `search_code`
 - Semantic context: `semantic_search` → `kg_semantic_context` → `kg_context`
+- Environment: `env=` on search / `kg_*` (hard-removed: `search_by_environment`)
 - File context: `get_context` (default); `ctx_read` for compression modes
 
 ## Canonical skill

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -2,6 +2,8 @@
 
 LeanKG exposes a Model Context Protocol (MCP) server that AI tools can connect to.
 
+**Tool prefer-order:** See [MCP tools](mcp-tools.md) — overview (`get_overview_context`), search (`concept_search` → `semantic_search` → `search_code`), environment (`env=` on search/`kg_*`). Hard-removed: `wake_up`, `search_by_environment`, and others listed there (~81 tools with embeddings).
+
 ## Automated Setup (Recommended)
 
 Use the install script to install and configure MCP for your AI tool:

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2,17 +2,17 @@
 
 LeanKG exposes a comprehensive set of MCP tools for AI tools to query the knowledge graph.
 
-Live registry size is **~84** tools (`tools/list`). Prefer-order and redundancy status:
+Live registry size is **~81** tools with embeddings (`tools/list`; ~79 without). Prefer-order and redundancy status:
 
 | Prefer-order | Tools |
 |--------------|-------|
+| Overview | `get_overview_context` → optional `load_layer` → `get_architecture` (not `load_layer(L0)` alone) |
 | Search | `concept_search` → `semantic_search` → `search_code` |
 | Semantic context | `semantic_search` → `kg_semantic_context` → `kg_context` |
-| Overview | `get_overview_context` (not `wake_up`; not `load_layer(L0)` alone) |
+| Environment filter | `env=` on search / `kg_*` tools |
 | File context | `get_context` (skill default); `ctx_read` for compression modes |
 
-**Soft-deprecated (still registered):** `wake_up`, `search_by_environment` — see [redundancy impact report](reports/mcp-tool-redundancy-impact-2026-07-20.md).  
-**Hard-removed:** `mcp_hello`, `mcp_impact`, `get_doc_for_file`.  
+**Hard-removed:** `mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment` — see [redundancy impact report](reports/mcp-tool-redundancy-impact-2026-07-20.md).  
 **Machine-checked matrix:** `tests/redundant_tools_matrix.rs` (every tool classified).
 
 ## Core Tools
@@ -46,6 +46,7 @@ Live registry size is **~84** tools (`tools/list`). Prefer-order and redundancy 
 
 | Tool | Description |
 |------|-------------|
+| `get_overview_context` | Session-start L0+L1 overview (replaces removed `wake_up`) |
 | `get_context` | Get AI context for file (minimal, token-optimized) |
 | `get_tested_by` | Get test coverage for a function/file |
 | `find_large_functions` | Find oversized functions by line count |
@@ -157,10 +158,6 @@ Behavior notes:
 - If the reranker fails to load, the tool silently falls back to ANN-order top-N (Q4 option A). `diagnostics.reranker = "fallback_ann"` surfaces this.
 - If the embedding index is older than the last `index` run, `diagnostics.embeddings_stale = true` (still serves, just warns).
 - Worktree scratch copies (`.worktrees/`, `.claude/worktrees/`, `.opencode/worktrees/`) are filtered out by default to avoid duplicate-noise results.
-
-## Auto-Indexing
-
-When the MCP server starts with an existing LeanKG project, it checks if the index is stale (by comparing git HEAD commit time vs database file modification time). If stale, it automatically runs incremental indexing to ensure AI tools have up-to-date context.
 
 ## Auto-Indexing
 

--- a/docs/prd-task-tracker.json
+++ b/docs/prd-task-tracker.json
@@ -1,26 +1,40 @@
 {
-  "generated": "2026-07-21",
+  "generated": "2026-07-21T14:00:00+07:00",
   "source": "docs/prd.md",
   "counts": {
-    "DONE": 375,
-    "PARTIAL": 13,
-    "PENDING": 25,
-    "NOT_DONE": 61,
-    "WONT_DO": 3,
-    "OPEN": 1
+    "total": 496,
+    "by_status": {
+      "NOT_DONE": 68,
+      "PENDING": 28,
+      "PARTIAL": 13,
+      "OPEN": 1,
+      "DONE": 383,
+      "WONT_DO": 3
+    },
+    "open_work": 110,
+    "open_by_focus": {
+      "P2": 77,
+      "P1": 23,
+      "P3": 10
+    },
+    "by_kind": {
+      "FR": 257,
+      "Release": 63,
+      "User Story": 176
+    }
   },
   "tasks": [
     {
       "id": "FR-B05",
       "kind": "FR",
       "title": "Benchmark harness vs CBM (50-edge samples)",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "NOT_DONE",
-      "notes": "[ ]",
+      "notes": "[ ] 2026-07-21 priority reorder: CBM harness after packaging; not blocking adoption",
       "section": "5.10 CBM Structural Parity Requirements (merged)",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
@@ -29,50 +43,50 @@
       "title": "Single-repo projects treated as single service \u2014 root double-click loads everything",
       "priority": "Must Have",
       "status": "NOT_DONE",
-      "notes": "[ ]",
+      "notes": "[ ] 2026-07-21 priority reorder: Wave 4 UI correctness after packaging",
       "section": "5.7 Massive Graph UI (DONE)",
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 0
+      "ve_suborder": 10
     },
     {
       "id": "REL-032",
       "kind": "Release",
       "title": "Swift / Vue / Svelte / SQL DDL \u2014 extractors present ('swift.rs' / 'sfc.rs' / 'sql.rs') but **not wired** into \u2026",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "NOT_DONE",
-      "notes": "8.3 v3.6 Roll-up (Current: v0.17.9) - ST\u2026",
+      "notes": "8.3 v3.6 Roll-up (Current: v0.17.9) - ST\u2026 2026-07-21 priority reorder: Language breadth not ROI; extractors exist, index-walk later",
       "section": "8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
       "id": "REL-040",
       "kind": "Release",
       "title": "REST API auth wiring + mutation endpoints (mutation endpoints still partial)",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "NOT_DONE",
-      "notes": "8.3 v3.6 Roll-up (Current: v0.17.9) - ST\u2026",
+      "notes": "8.3 v3.6 Roll-up (Current: v0.17.9) - ST\u2026 2026-07-21 priority reorder: REST mutation polish; not agent-cost lever",
       "section": "8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
       "id": "REL-041",
       "kind": "Release",
       "title": "3D graph UI Track E ('graph-ui/'; keep 2D 'ui/')",
-      "priority": "Must Have",
+      "priority": "Could Have",
       "status": "NOT_DONE",
-      "notes": "8.3 v3.6 Roll-up (Current: v0.17.9) - ST\u2026",
+      "notes": "8.3 v3.6 Roll-up (Current: v0.17.9) - ST\u2026 2026-07-21 priority reorder: Track E 3D is aspirational; ui-v2 is company explorer",
       "section": "8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P3",
+      "focus_rank": 3,
       "ve_suborder": 0
     },
     {
@@ -98,7 +112,7 @@
       "section": "5.9 Graphify-Inspired Features",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 2,
+      "ve_suborder": 4,
       "focus_rank": 1
     },
     {
@@ -111,7 +125,7 @@
       "section": "5.9 Graphify-Inspired Features",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 3,
+      "ve_suborder": 5,
       "focus_rank": 1
     },
     {
@@ -125,7 +139,7 @@
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 4
+      "ve_suborder": 6
     },
     {
       "id": "FR-GF-08",
@@ -138,7 +152,7 @@
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 4
+      "ve_suborder": 6
     },
     {
       "id": "FR-GF-09",
@@ -151,7 +165,7 @@
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 4
+      "ve_suborder": 6
     },
     {
       "id": "REL-043",
@@ -164,7 +178,7 @@
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 4
+      "ve_suborder": 6
     },
     {
       "id": "FR-GF-13",
@@ -177,7 +191,7 @@
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 5
+      "ve_suborder": 7
     },
     {
       "id": "FR-GF-21",
@@ -189,7 +203,7 @@
       "section": "5.9 Graphify-Inspired Features",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 6,
+      "ve_suborder": 8,
       "focus_rank": 1
     },
     {
@@ -202,7 +216,7 @@
       "section": "5.19 UI v2 Graph Explorer",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 7,
+      "ve_suborder": 9,
       "focus_rank": 1
     },
     {
@@ -215,7 +229,7 @@
       "section": "5.19 UI v2 Graph Explorer",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 8,
+      "ve_suborder": 2,
       "focus_rank": 1
     },
     {
@@ -228,7 +242,7 @@
       "section": "5.19 UI v2 Graph Explorer",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 8,
+      "ve_suborder": 2,
       "focus_rank": 1
     },
     {
@@ -237,11 +251,11 @@
       "title": "Automate/document ontology sync for concepts + workflows YAML",
       "priority": "Should Have",
       "status": "NOT_DONE",
-      "notes": "P1 docs/automation; runtime auto-update is US-ONT-PROC-01 / FR-ONT-PROC-* P0 (v3.7.9)",
+      "notes": "P1 docs/automation; runtime auto-update is US-ONT-PROC-01 / FR-ONT-PROC-* P0 (v3.7.9) 2026-07-21 priority reorder: Runtime auto-update DONE (FR-ONT-PROC); remainder is docs",
       "section": "5.10 CBM Structural Parity Requirements (merged)",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
@@ -807,39 +821,39 @@
       "id": "US-CBM-A1",
       "kind": "User Story",
       "title": "Correct MCP 'project' routing (multi-mount \u2260 wrong RocksDB project)",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "PENDING",
-      "notes": "PENDING (ops; freepeak\u2260be historically)",
+      "notes": "PENDING (ops; freepeak\u2260be historically) 2026-07-21 priority reorder: Multi-mount routing reliability; after adoption packaging",
       "section": "3.11 CBM Structural Parity Stories (US-CBM) \u2014 merged from 'p\u2026",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
       "id": "US-CBM-A4",
       "kind": "User Story",
       "title": "Moat smoke (ontology + routing) gates Phase 1 \u201cdone\u201d",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "PENDING",
-      "notes": "PENDING",
+      "notes": "PENDING 2026-07-21 priority reorder: Moat smoke gate; after packaging",
       "section": "3.11 CBM Structural Parity Stories (US-CBM) \u2014 merged from 'p\u2026",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
       "id": "US-CBM-D3",
       "kind": "User Story",
       "title": "Re-evaluate dual-run after typed-resolve Phase",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "PENDING",
-      "notes": "PENDING",
+      "notes": "PENDING 2026-07-21 priority reorder: Depends on typed-resolve phase",
       "section": "3.11 CBM Structural Parity Stories (US-CBM) \u2014 merged from 'p\u2026",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
@@ -852,7 +866,7 @@
       "section": "3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17)",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 2,
+      "ve_suborder": 4,
       "focus_rank": 1
     },
     {
@@ -865,7 +879,7 @@
       "section": "3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17)",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 3,
+      "ve_suborder": 5,
       "focus_rank": 1
     },
     {
@@ -878,7 +892,7 @@
       "section": "3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17)",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 6,
+      "ve_suborder": 8,
       "focus_rank": 1
     },
     {
@@ -891,7 +905,7 @@
       "section": "3.17 UI v2 \u2014 GitNexus Shell Adapted (US-UI2)",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 7,
+      "ve_suborder": 9,
       "focus_rank": 1
     },
     {
@@ -904,7 +918,7 @@
       "section": "3.17 UI v2 \u2014 GitNexus Shell Adapted (US-UI2)",
       "prd_line": null,
       "focus": "P1",
-      "ve_suborder": 8,
+      "ve_suborder": 2,
       "focus_rank": 1
     },
     {
@@ -1132,26 +1146,26 @@
       "id": "US-08",
       "kind": "User Story",
       "title": "Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP)",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "PARTIAL",
-      "notes": "PARTIAL \u2014 Go/TS/Python/Rust/Java/Kotlin (+Dart/XML/TF/CI) indexed; C++/C#/Ruby/P\u2026",
+      "notes": "PARTIAL \u2014 Go/TS/Python/Rust/Java/Kotlin (+Dart/XML/TF/CI) indexed; C++/C#/Ruby/P\u2026 2026-07-21 priority reorder: Core langs production; remainder is breadth",
       "section": "3.1 Core MVP Stories (US-01 to US-18)",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
       "id": "US-CBM-A2",
       "kind": "User Story",
       "title": "Ontology online ('kg_ontology_status', 'concept_search' non-empty after sync)",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "PARTIAL",
-      "notes": "PARTIAL (tools exist; sync/activation ops-dependent)",
+      "notes": "PARTIAL (tools exist; sync/activation ops-dependent) 2026-07-21 priority reorder: Ontology online largely works post ont-proc; residual smoke",
       "section": "3.11 CBM Structural Parity Stories (US-CBM) \u2014 merged from 'p\u2026",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
@@ -1160,37 +1174,37 @@
       "title": "Single-repo projects expand fully on service double-click (no multi-level drilling)",
       "priority": "Must Have",
       "status": "PARTIAL",
-      "notes": "PARTIAL (expand-service called, FR-MG-03 still pending)",
+      "notes": "PARTIAL (expand-service called, FR-MG-03 still pending) 2026-07-21 priority reorder: Wave 4 UI correctness after packaging",
       "section": "3.8 Massive Graph Stories (US-MG-01 to US-MG-05)",
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 0
+      "ve_suborder": 10
     },
     {
       "id": "US-MP-02",
       "kind": "User Story",
       "title": "Layered Context Loading (L0-L3) \u2014 explicit token budgets per layer: L0 identity (~50 tok), L1 critical facts (\u2026",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "PARTIAL",
-      "notes": "PARTIAL ('wake_up' returns L0+L1; 'load_layer' MCP tool registered but minimal)",
+      "notes": "PARTIAL ('wake_up' returns L0+L1; 'load_layer' MCP tool registered but minimal) 2026-07-21 priority reorder: L0-L3 partial; polish after adoption",
       "section": "3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08)",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
       "id": "US-MP-08",
       "kind": "User Story",
       "title": "Folder Structure as Graph Edges \u2014 directories as first-class 'directory' nodes with 'contains' edges (dir\u2192dir,\u2026",
-      "priority": "Must Have",
+      "priority": "Should Have",
       "status": "PARTIAL",
-      "notes": "PARTIAL \u2014 'generate_physical_structure' creates 'directory' / 'File' / 'Project'\u2026",
+      "notes": "PARTIAL \u2014 'generate_physical_structure' creates 'directory' / 'File' / 'Project'\u2026 2026-07-21 priority reorder: Directory edges partial; polish after adoption",
       "section": "3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08)",
       "prd_line": null,
-      "focus": "P1",
-      "focus_rank": 1,
+      "focus": "P2",
+      "focus_rank": 2,
       "ve_suborder": 0
     },
     {
@@ -1230,7 +1244,7 @@
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 4
+      "ve_suborder": 6
     },
     {
       "id": "US-GF-06",
@@ -1243,7 +1257,7 @@
       "prd_line": null,
       "focus": "P1",
       "focus_rank": 1,
-      "ve_suborder": 5
+      "ve_suborder": 7
     },
     {
       "id": "US-LANG-02",
@@ -6223,6 +6237,240 @@
       "focus": "P1",
       "focus_rank": 1,
       "ve_suborder": 0
+    },
+    {
+      "id": "US-SURF-06",
+      "kind": "User Story",
+      "title": "Hard-delete soft-deprecated MCP tools (wake_up, search_by_environment) after grace",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "3.16 MCP Tool Surface Rationalization (US-SURF) \u2014 v3.7.12",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "US-SURF-07",
+      "kind": "User Story",
+      "title": "After tool shrink: sync skills, rules, guidelines, and install/setup to reduced roster",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "3.16 MCP Tool Surface Rationalization (US-SURF) \u2014 v3.7.12",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "FR-SURF-07",
+      "kind": "FR",
+      "title": "Hard-delete wake_up from ToolRegistry + handlers; matrix AlreadyRemoved; smoke MUTATING list cleaned",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "5.18 MCP Tool Surface Rationalization (v3.7.12)",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "FR-SURF-08",
+      "kind": "FR",
+      "title": "Hard-delete search_by_environment; callers use env= on search_code/semantic_search/concept_search/kg_*",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "5.18 MCP Tool Surface Rationalization (v3.7.12)",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "FR-SURF-09",
+      "kind": "FR",
+      "title": "Sync repo guidelines: AGENTS.md, CLAUDE.md, docs/mcp-tools.md, mcp-setup.md, agentic-instructions.md, cli-reference \u2014 no deleted tool names as preferred",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "5.18 MCP Tool Surface Rationalization (v3.7.12)",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "FR-SURF-10",
+      "kind": "FR",
+      "title": "Sync using-leankg skill + leankg-first / mandatory-workflow-loop / skill-auto-invoke rules to post-shrink prefer-order (path\u00b7explain\u00b7query)",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "5.18 MCP Tool Surface Rationalization (v3.7.12)",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "FR-SURF-11",
+      "kind": "FR",
+      "title": "Sync install/setup: scripts/install.sh, mcp-smoke-tools.py, cursor/opencode/claude plugin manifests \u2014 drop deleted tools from lists",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "5.18 MCP Tool Surface Rationalization (v3.7.12)",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "REL-062",
+      "kind": "Release",
+      "title": "Evidence: list_tools before/after hard-delete + grep-clean skills/rules/docs/setup of deleted tool names",
+      "priority": "Must Have",
+      "status": "DONE",
+      "notes": "DONE 2026-07-21 \u2014 Wave 1a hard-delete wake_up + search_by_environment; agent surface synced (REL-062)",
+      "section": "5.18 MCP Tool Surface Rationalization (v3.7.12)",
+      "prd_line": 0,
+      "focus": "P1",
+      "focus_rank": 1,
+      "ve_suborder": 3
+    },
+    {
+      "id": "FR-DOCJOIN-01",
+      "kind": "FR",
+      "title": "Resolve markdown code refs to indexed file-level CodeElement keys on write",
+      "priority": "Must Have",
+      "status": "NOT_DONE",
+      "notes": "[ ] 2026-07-21 review: bare-path targets miss qualified/file keys; resolve longest path match; AMBIGUOUS/drop if unresolved",
+      "section": "5.22 Doc\u2194Code Join Quality (v3.7.13)",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 91
+    },
+    {
+      "id": "FR-DOCJOIN-02",
+      "kind": "FR",
+      "title": "Normalize doc/file path aliases on get_files_for_doc and find_related_docs",
+      "priority": "Must Have",
+      "status": "NOT_DONE",
+      "notes": "[ ] Canonical docs/\u2026 keys; try README.md \u2194 docs/README.md \u2194 ./docs/\u2026; hint tried aliases on miss; no all_elements()",
+      "section": "5.22 Doc\u2194Code Join Quality (v3.7.13)",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 90
+    },
+    {
+      "id": "FR-DOCJOIN-03",
+      "kind": "FR",
+      "title": "Persist references edge context snippet + EXTRACTED confidence metadata",
+      "priority": "Must Have",
+      "status": "NOT_DONE",
+      "notes": "[ ] metadata.context \u2264100 chars; align with FR-GF-07 when available",
+      "section": "5.22 Doc\u2194Code Join Quality (v3.7.13)",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 92
+    },
+    {
+      "id": "FR-DOCJOIN-04",
+      "kind": "FR",
+      "title": "Unit + TempDir integration tests for doc\u2194code join round-trip",
+      "priority": "Must Have",
+      "status": "NOT_DONE",
+      "notes": "[ ] normalize/resolve tables; index+index_docs \u2192 get_files_for_doc + find_related_docs non-empty",
+      "section": "5.22 Doc\u2194Code Join Quality (v3.7.13)",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 93
+    },
+    {
+      "id": "FR-DOCJOIN-05",
+      "kind": "FR",
+      "title": "Sync mcp-tools / AGENTS / using-leankg prefer-order for annotations vs markdown edges",
+      "priority": "Should Have",
+      "status": "NOT_DONE",
+      "notes": "[ ] FR IDs \u2192 search_by_requirement/get_traceability; markdown tools after mcp_index_docs with docs/\u2026 paths",
+      "section": "5.22 Doc\u2194Code Join Quality (v3.7.13)",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 95
+    },
+    {
+      "id": "FR-DOCJOIN-06",
+      "kind": "FR",
+      "title": "Optional best-effort upgrade of file::symbol mentions to unique function/class keys",
+      "priority": "Could Have",
+      "status": "NOT_DONE",
+      "notes": "[ ] Only when unique in index; otherwise leave file-level",
+      "section": "5.22 Doc\u2194Code Join Quality (v3.7.13)",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 96
+    },
+    {
+      "id": "REL-063",
+      "kind": "Release",
+      "title": "Evidence: fixture + live MCP smoke for doc\u2194code join quality (docs/reports/)",
+      "priority": "Must Have",
+      "status": "NOT_DONE",
+      "notes": "[ ] Non-empty round-trip on /workspace after mcp_index_docs; note RocksDB LOCK if mount unavailable",
+      "section": "5.22 Doc\u2194Code Join Quality (v3.7.13)",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 94
+    },
+    {
+      "id": "US-DOCJOIN-01",
+      "kind": "User Story",
+      "title": "Markdown documented_by/references attach to same keys as code index",
+      "priority": "Must Have",
+      "status": "PENDING",
+      "notes": "[ ] ACs in prd.md \u00a73.19; depends FR-DOCJOIN-01/03/04",
+      "section": "3.19 Doc\u2194Code Join Quality (US-DOCJOIN) \u2014 v3.7.13",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 91
+    },
+    {
+      "id": "US-DOCJOIN-02",
+      "kind": "User Story",
+      "title": "Doc query tools accept human path aliases for indexed docs/\u2026 keys",
+      "priority": "Must Have",
+      "status": "PENDING",
+      "notes": "[ ] ACs in prd.md \u00a73.19; depends FR-DOCJOIN-02",
+      "section": "3.19 Doc\u2194Code Join Quality (US-DOCJOIN) \u2014 v3.7.13",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 90
+    },
+    {
+      "id": "US-DOCJOIN-03",
+      "kind": "User Story",
+      "title": "Prefer-order + authoring practices for annotations vs markdown edges",
+      "priority": "Should Have",
+      "status": "PENDING",
+      "notes": "[ ] ACs in prd.md \u00a73.19; depends FR-DOCJOIN-05",
+      "section": "3.19 Doc\u2194Code Join Quality (US-DOCJOIN) \u2014 v3.7.13",
+      "prd_line": null,
+      "focus": "P2",
+      "focus_rank": 2,
+      "ve_suborder": 95
     }
   ],
   "meta": {
@@ -6232,29 +6480,85 @@
     "update_rule": "Edit this file (and JSON) when closing work. Link new IDs from PRD narrative sections.",
     "sort": "status(NOT_DONE\u2192PENDING\u2192PARTIAL\u2192OPEN\u2192DONE\u2192WONT_DO) \u2192 focus(P0..P3) \u2192 MoSCoW \u2192 ve_suborder \u2192 id",
     "focus_legend": {
-      "P0": "CLOSED \u2014 procedural ontology auto-update (see smoke report); next open work is P1 company adoption",
-      "P1": "CURRENT next \u2014 company adoption / Graphify packaging (US-COST / US-GF-*)",
-      "P2": "Should Have",
-      "P3": "Could Have / aspirational OPEN"
+      "P0": "CLOSED \u2014 procedural ontology auto-update",
+      "P1": "NOW \u2014 company adoption waves 0\u20134 including Wave 1a MCP surface cleanup",
+      "P2": "Next \u2014 reliability, semantic UX, install breadth, CBM leftovers",
+      "P3": "Backlog \u2014 Track E 3D, FR-SURF-06 doc merge, aspirational OPEN"
     },
-    "updated": "2026-07-21-v3.7.9-ont-proc-auto-done",
-    "sync_note": "v3.7.9 P0 procedural ontology auto-update CLOSED (US-ONT-PROC-01 / FR-ONT-PROC-* / REL-059); company adoption remains P1",
+    "updated": "2026-07-21 \u2014 v3.7.13 DOCJOIN P2 join-quality backlog added",
+    "sync_note": "P2 DOCJOIN after Wave 1a; FR-51-56 remain DONE; FR-SURF-06 stays P3",
     "company_adoption_order": [
       "US-COST-01",
+      "US-UI2-07",
+      "US-SURF-06",
+      "US-SURF-07",
       "US-GF-14",
       "US-GF-17",
       "US-GF-04",
       "US-GF-06",
       "US-GF-13",
       "US-UI2-06",
-      "US-UI2-07"
+      "US-MG-02"
     ],
-    "p0_current": [
-      "US-ONT-PROC-01",
-      "FR-ONT-PROC-01",
-      "FR-ONT-PROC-02",
-      "FR-ONT-PROC-03",
-      "REL-059"
+    "p0_current": [],
+    "implementation_waves": {
+      "0_closeouts": [
+        "US-COST-01",
+        "FR-COST-01",
+        "REL-058",
+        "US-UI2-07",
+        "FR-UI2-09",
+        "REL-057"
+      ],
+      "1a_mcp_surface_cleanup": [
+        "US-SURF-06",
+        "US-SURF-07",
+        "FR-SURF-07",
+        "FR-SURF-08",
+        "FR-SURF-09",
+        "FR-SURF-10",
+        "FR-SURF-11",
+        "REL-062"
+      ],
+      "1b_agent_cost_narrative": [
+        "US-GF-14",
+        "FR-GF-22"
+      ],
+      "1c_always_on_hooks": [
+        "US-GF-17",
+        "FR-GF-24"
+      ],
+      "2_trust_artifacts": [
+        "US-GF-04",
+        "FR-GF-07",
+        "FR-GF-08",
+        "FR-GF-09",
+        "REL-043",
+        "US-GF-06",
+        "FR-GF-13",
+        "US-GF-13",
+        "FR-GF-21"
+      ],
+      "3_human_nl": [
+        "US-UI2-06",
+        "FR-UI2-08"
+      ],
+      "4_ui_correctness": [
+        "US-MG-02",
+        "FR-MG-03"
+      ]
+    },
+    "p2_docjoin": [
+      "FR-DOCJOIN-01",
+      "FR-DOCJOIN-02",
+      "FR-DOCJOIN-03",
+      "FR-DOCJOIN-04",
+      "FR-DOCJOIN-05",
+      "FR-DOCJOIN-06",
+      "REL-063",
+      "US-DOCJOIN-01",
+      "US-DOCJOIN-02",
+      "US-DOCJOIN-03"
     ]
   }
 }

--- a/docs/prd-task-tracker.md
+++ b/docs/prd-task-tracker.md
@@ -1,12 +1,13 @@
 # LeanKG PRD Task Tracker (Single Session)
 
-**Last synced:** 2026-07-21 — PR #92 merge: UI v2 load-more + folder sidebar (`US-UI2-10..12` / `FR-UI2-12..14` / `REL-060..061`); main P0 ont-proc-auto **DONE** (`REL-059`).
+**Last synced:** 2026-07-21 — Wave **1a** MCP hard-delete (`wake_up`, `search_by_environment`) + agent-surface sync **DONE** (REL-062).
 **This file is the SoT for task inventory + status.**  
-**PRD narrative / ACs / HLD:** [`docs/prd.md`](prd.md) §3.18 / §5.21  
+**PRD narrative / ACs / HLD:** [`docs/prd.md`](prd.md) §1.1 / §3.16 / §3.19 / §5.18 / §5.22  
 
-> **Agent rule:** Work **P0 first**, then P1 → P2 → P3.  
+> **Agent rule:** Work **P0 first**, then P1 waves → P2 → P3.  
 > **P0:** Procedural ontology auto-update — **DONE**.  
-> **P1 CURRENT:** Company ROI + Graphify packaging (§1.1).  
+> **P1 CURRENT:** Company adoption waves — **Wave 1a = redundant MCP tool cleanup + agent-surface sync**.  
+> **P2 follow-on:** Doc↔code join quality (§3.19 / §5.22) — do **not** interrupt Wave 1a.  
 > Open `prd.md` only for design narrative and acceptance criteria.
 
 ---
@@ -16,9 +17,9 @@
 | Focus | Meaning | When to work |
 |------:|---------|--------------|
 | **P0** | Procedural ontology auto-update | **DONE** |
-| **P1** | Company adoption / Graphify packaging + ROI | **NOW** |
-| **P2** | Should Have | Next |
-| **P3** | Could Have / aspirational `OPEN` | Backlog |
+| **P1** | Company adoption waves 0–4 (incl. MCP surface) | **NOW** |
+| **P2** | Reliability / semantic UX / CBM leftovers | Next |
+| **P3** | Track E 3D / doc-tool merge / aspirational | Backlog |
 
 ## Status legend
 
@@ -37,27 +38,27 @@
 
 | Metric | Count |
 |--------|------:|
-| **Total tracked** | **478** |
-| NOT_DONE | 61 |
-| PENDING | 25 |
+| **Total tracked** | **496** |
+| NOT_DONE | 74 |
+| PENDING | 30 |
 | PARTIAL | 13 |
 | OPEN | 1 |
 | DONE | 375 |
 | WONT_DO | 3 |
-| Open work | **100** |
+| Open work | **118** |
 
 | Open by Focus | Count |
 |---------------|------:|
 | P0 | 0 |
-| P1 | 35 |
-| P2 | 56 |
-| P3 | 9 |
+| P1 | 31 |
+| P2 | 77 |
+| P3 | 10 |
 
 | Kind | Count |
 |------|------:|
-| FR | 243 |
-| Release | 59 |
-| User Story | 168 |
+| FR | 257 |
+| Release | 63 |
+| User Story | 176 |
 
 ---
 
@@ -75,37 +76,98 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 
 ---
 
-## Company adoption queue (P1 — CURRENT)
+## Company adoption — implementation waves (P1 — CURRENT)
 
-| # | ID | Why (cost / efficiency) |
-|--:|----|-------------------------|
-| 1 | `US-COST-01` / `FR-COST-01` / `REL-058` | Manager one-pager: LeanKG vs grep + vs Graphify ([brief](reports/leankg-vs-graphify-company-roi-2026-07-21.md)) |
-| 2 | `US-GF-14` / `FR-GF-22` | Three verbs first → agents pick cheap tools |
-| 3 | `US-GF-17` / `FR-GF-24` | Always-on install/hooks → **primary token-cost lever** |
-| 4 | `US-GF-04` / `FR-GF-07..09` / `REL-043` | Honest edges → trust & adoption |
-| 5 | `US-GF-06` / `FR-GF-13` | Auto GRAPH_REPORT.md → onboarding without 85-tool wall |
-| 6 | `US-GF-13` / `FR-GF-21` | HTML export → shareable PR/CI artifact |
-| 7 | `US-UI2-06` / `FR-UI2-08` | NL Query FAB → humans use same cheap verb |
-| 8 | `US-UI2-07` / `FR-UI2-09` / `REL-057` | ui-v2 cutover → one company explorer |
+> Sort within P1 by `ve_suborder` (wave). Implement **in order**.
+
+| Wave | Goal | IDs (implement) | Why |
+|-----:|------|-----------------|-----|
+| **0a** | Publish ROI | `US-COST-01` / `FR-COST-01` / `REL-058` | Brief exists; link README |
+| **0b** | ui-v2 cutover closeout | `US-UI2-07` / `FR-UI2-09` / `REL-057` | Embed present; finish evidence |
+| **1a** | **MCP redundant-tool cleanup + agent surface sync** | `US-SURF-06..07` / `FR-SURF-07..11` / `REL-062` | Hard-delete `wake_up` + `search_by_environment`; sync skills/rules/guidelines/setup |
+| **1b** | Three-verb narrative | `US-GF-14` / `FR-GF-22` | Agents pick cheap tools on **shrunk** roster |
+| **1c** | Always-on hooks | `US-GF-17` / `FR-GF-24` | Primary token-cost lever (install what skills say) |
+| **2a** | Honest edges | `US-GF-04` / `FR-GF-07..09` / `REL-043` | Trust = adoption |
+| **2b** | Auto GRAPH_REPORT | `US-GF-06` / `FR-GF-13` | Onboarding without tool wall |
+| **2c** | HTML export | `US-GF-13` / `FR-GF-21` | Shareable PR/CI artifact |
+| **3** | NL Query FAB | `US-UI2-06` / `FR-UI2-08` | Humans use same cheap verb |
+| **4** | Single-repo expand | `US-MG-02` / `FR-MG-03` | UI correctness |
+
+### Wave 1a detail (MCP surface)
+
+| ID | Status | Intent |
+|----|--------|--------|
+| `US-SURF-06` | DONE | Hard-delete soft-deprecated tools after grace |
+| `US-SURF-07` | DONE | Sync skills / rules / guidelines / setup after shrink |
+| `FR-SURF-07` | DONE | Hard-delete `wake_up` |
+| `FR-SURF-08` | DONE | Hard-delete `search_by_environment` |
+| `FR-SURF-09` | DONE | Sync AGENTS / CLAUDE / mcp-tools / mcp-setup / agentic-instructions |
+| `FR-SURF-10` | DONE | Sync `using-leankg` skill + Cursor/Claude rules |
+| `FR-SURF-11` | DONE | Sync install.sh / smoke / plugin manifests |
+| `REL-062` | DONE | Evidence report + `redundant_tools_matrix` green |
+
+Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool-redundancy-impact-2026-07-20.md). Already removed: `mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`. Soft-deprecated → hard-delete now: `wake_up`, `search_by_environment`.
+
+**Known UI follow-up (not a new FR yet):** expand `path=src` path-prefix vs regex — see deep-test report.
+
+### Demoted out of P1 (do not do now)
+
+| ID | New focus | Reason |
+|----|-----------|--------|
+| `REL-041` | P3 | Track E 3D; ui-v2 is the company explorer |
+| `REL-032` | P2 | Language breadth; extractors exist |
+| `REL-040` | P2 | REST mutation polish |
+| `FR-B05` | P2 | CBM benchmark harness |
+| `FR-A02` | P2 | Runtime sync DONE via ont-proc; docs leftover |
+| `US-CBM-A1/A2/A4`, `US-CBM-D3` | P2 | Moat/routing residual after packaging |
+| `US-08`, `US-MP-02`, `US-MP-08` | P2 | PARTIAL polish; core value already shipped |
+| `FR-SURF-06` / `US-SURF-05` | P3 | Doc tree/structure merge — mega-safe first; after hard-deletes + preferably after DOCJOIN path normalize |
+| `US-DOCJOIN-*` / `FR-DOCJOIN-*` / `REL-063` | P2 | Doc↔code join quality — structure mapping DONE; fix key join + aliases (after Wave 1a) |
 
 ---
 
-## Active session — open work (sorted by status, then priority)
+## P2 — Doc↔code join quality (after Wave 1a)
+
+> Narrative + ACs + implement/test practices: [`prd.md`](prd.md) §3.19 / §5.22.  
+> **Baseline DONE:** FR-51–56 / US-10 / REL-017–018 (structure mapping). This queue is **join quality**.
+
+| # | ID | Status | Intent |
+|--:|----|--------|--------|
+| 1 | `FR-DOCJOIN-02` | NOT_DONE | Normalize `doc`/`file` aliases on query tools (read-path quick win) |
+| 2 | `US-DOCJOIN-02` | PENDING | Human paths resolve to indexed `docs/…` keys |
+| 3 | `FR-DOCJOIN-01` | NOT_DONE | Resolve markdown refs to indexed file keys on write |
+| 4 | `US-DOCJOIN-01` | PENDING | `documented_by` / `references` join to code index keys |
+| 5 | `FR-DOCJOIN-03` | NOT_DONE | Edge `context` + EXTRACTED confidence metadata |
+| 6 | `FR-DOCJOIN-04` | NOT_DONE | Unit + TempDir integration join tests |
+| 7 | `REL-063` | NOT_DONE | Live MCP smoke report under `docs/reports/` |
+| 8 | `FR-DOCJOIN-05` | NOT_DONE | Sync prefer-order / authoring in mcp-tools + skills |
+| 9 | `US-DOCJOIN-03` | PENDING | Prefer annotations for FR IDs; extractable markdown refs |
+| 10 | `FR-DOCJOIN-06` | NOT_DONE | Could: best-effort `file::symbol` upgrade when unique |
+
+**Implement order (best practice):** FR-DOCJOIN-02 → 01 → 03 → 04 / REL-063 → 05 / US-DOCJOIN-03 → 06. See PRD §5.22 test matrix.
+
+---
+
+## Active session — open work (sorted by status, then wave)
 
 > **Sort:** `NOT_DONE` → `PENDING` → `PARTIAL` → `OPEN`, then focus P0→P3, then MoSCoW, then `ve_suborder`, then id.
 >
+> **2026-07-21 — v3.7.13:** P2 DOCJOIN join-quality backlog added (does not reopen FR-51–56).  
+> **2026-07-21 — v3.7.12:** Wave 1a MCP surface cleanup added.  
+> **2026-07-21 — v3.7.11:** Priority reorder.  
 > **2026-07-21 — v3.7.9 P0 CLOSED:** Procedural ontology auto-update.
->
-> **2026-07-21 — v3.7.8:** Graphify packaging / company ROI (P1 CURRENT).
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
-| **P1** | `FR-B05` | FR | **NOT_DONE** | Must Have | Benchmark harness vs CBM (50-edge samples) | 5.10 CBM Structural Parity Requirements (merged) |
-| **P1** | `FR-MG-03` | FR | **NOT_DONE** | Must Have | Single-repo projects treated as single service — root double-click loads everything | 5.7 Massive Graph UI (DONE) |
-| **P1** | `REL-032` | Release | **NOT_DONE** | Must Have | Swift / Vue / Svelte / SQL DDL — extractors present ('swift.rs' / 'sfc.rs' / 'sql.rs') but… | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
-| **P1** | `REL-040` | Release | **NOT_DONE** | Must Have | REST API auth wiring + mutation endpoints (mutation endpoints still partial) | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
-| **P1** | `REL-041` | Release | **NOT_DONE** | Must Have | 3D graph UI Track E ('graph-ui/'; keep 2D 'ui/') | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `REL-058` | Release | **NOT_DONE** | Must Have | Manager ROI brief checked into docs/reports/ and linked from README competitive section | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `FR-UI2-09` | FR | **NOT_DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
+| **P1** | `REL-057` | Release | **NOT_DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
+| **P1** | `FR-SURF-07` | FR | **DONE** | Must Have | Hard-delete wake_up from ToolRegistry + handlers; matrix AlreadyRemoved; smoke MUTATING li… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-08` | FR | **DONE** | Must Have | Hard-delete search_by_environment; callers use env= on search_code/semantic_search/concept… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-09` | FR | **DONE** | Must Have | Sync repo guidelines: AGENTS.md, CLAUDE.md, docs/mcp-tools.md, mcp-setup.md, agentic-instr… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-10` | FR | **DONE** | Must Have | Sync using-leankg skill + leankg-first / mandatory-workflow-loop / skill-auto-invoke rules… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-11` | FR | **DONE** | Must Have | Sync install/setup: scripts/install.sh, mcp-smoke-tools.py, cursor/opencode/claude plugin … | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `REL-062` | Release | **DONE** | Must Have | Evidence: list_tools before/after hard-delete + grep-clean skills/rules/docs/setup of dele… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
 | **P1** | `FR-GF-22` | FR | **NOT_DONE** | Must Have | README / AGENTS / using-leankg skill lead with path · explain · query; demote full tool wa… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-24` | FR | **NOT_DONE** | Must Have | Always-on graph-first rules/hooks: nudge before grep/Read; optional strict first-Read redi… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-07` | FR | **NOT_DONE** | Must Have | Relationship metadata field 'confidence_label' ∈ {EXTRACTED, INFERRED, AMBIGUOUS} written … | 5.9 Graphify-Inspired Features |
@@ -115,13 +177,20 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P1** | `FR-GF-13` | FR | **NOT_DONE** | Must Have | Auto-generate '.leankg/GRAPH_REPORT.md' on every index (CLI 'leankg report' / MCP 'get_gra… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-21` | FR | **NOT_DONE** | Must Have | CLI/MCP export html — single-file bounded subgraph/community; document node budget | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-UI2-08` | FR | **NOT_DONE** | Must Have | Query FAB dual-mode: NL → query_graph; Advanced → raw Cozo POST /api/query | 5.19 UI v2 Graph Explorer |
-| **P1** | `FR-UI2-09` | FR | **NOT_DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
-| **P1** | `REL-057` | Release | **NOT_DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
-| **P1** | `FR-A02` | FR | **NOT_DONE** | Should Have | Automate/document ontology sync for concepts + workflows YAML | 5.10 CBM Structural Parity Requirements (merged) |
+| **P1** | `FR-MG-03` | FR | **NOT_DONE** | Must Have | Single-repo projects treated as single service — root double-click loads everything | 5.7 Massive Graph UI (DONE) |
+| **P2** | `FR-DOCJOIN-02` | FR | **NOT_DONE** | Must Have | Normalize doc/file path aliases on get_files_for_doc and find_related_docs | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-01` | FR | **NOT_DONE** | Must Have | Resolve markdown code refs to indexed file-level CodeElement keys on write | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-03` | FR | **NOT_DONE** | Must Have | Persist references edge context snippet + EXTRACTED confidence metadata | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-04` | FR | **NOT_DONE** | Must Have | Unit + TempDir integration tests for doc↔code join round-trip | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `REL-063` | Release | **NOT_DONE** | Must Have | Evidence: fixture + live MCP smoke for doc↔code join quality (docs/reports/) | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-05` | FR | **NOT_DONE** | Should Have | Sync mcp-tools / AGENTS / using-leankg prefer-order for annotations vs markdown edges | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-06` | FR | **NOT_DONE** | Could Have | Optional best-effort upgrade of file::symbol mentions to unique function/class keys | 5.22 Doc↔Code Join Quality (v3.7.13) |
 | **P2** | `FR-A01` | FR | **NOT_DONE** | Should Have | MCP 'project' resolves to correct RocksDB project for multi-mount setups | 5.10 CBM Structural Parity Requirements (merged) |
+| **P2** | `FR-A02` | FR | **NOT_DONE** | Should Have | Automate/document ontology sync for concepts + workflows YAML | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-A03` | FR | **NOT_DONE** | Should Have | Verify ontology/knowledge tools after sync | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-A04` | FR | **NOT_DONE** | Should Have | Index per 'leankg.yaml'; expose counts | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-A06` | FR | **NOT_DONE** | Should Have | Smoke: ontology + routing must pass before Phase 1 “fully done” | 5.10 CBM Structural Parity Requirements (merged) |
+| **P2** | `FR-B05` | FR | **NOT_DONE** | Should Have | Benchmark harness vs CBM (50-edge samples) | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B06` | FR | **NOT_DONE** | Should Have | Python + Rust typed resolve (Could) — infra works; LSP server default wiring PENDING | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B13` | FR | **NOT_DONE** | Should Have | Extend 'service_calls' beyond k8s DNS regex (Should) | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B16` | FR | **NOT_DONE** | Should Have | Runtime trace ingestion (Could) | 5.10 CBM Structural Parity Requirements (merged) |
@@ -159,47 +228,55 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P2** | `FR-SEM-03` | FR | **NOT_DONE** | Should Have | MCP HTTP resilience for long read-only semantic tools (retry docs + keep-alive / stale-lis… | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P2** | `FR-UI2-10` | FR | **NOT_DONE** | Should Have | Cluster legend + show/hide filters wired to /api/graph/clusters | 5.19 UI v2 Graph Explorer |
 | **P2** | `FR-UI2-11` | FR | **NOT_DONE** | Should Have | Port incidents / env / conflicts panels from legacy ui/ into ui-v2 | 5.19 UI v2 Graph Explorer |
+| **P2** | `REL-032` | Release | **NOT_DONE** | Should Have | Swift / Vue / Svelte / SQL DDL — extractors present ('swift.rs' / 'sfc.rs' / 'sql.rs') but… | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
+| **P2** | `REL-040` | Release | **NOT_DONE** | Should Have | REST API auth wiring + mutation endpoints (mutation endpoints still partial) | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P3** | `FR-SEM-05` | FR | **NOT_DONE** | Could Have | Optional file-diversity / MMR post-filter after HNSW+rerank (top-k not ≥70% one file) | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P3** | `FR-SURF-06` | FR | **NOT_DONE** | Could Have | Mega-safe get_doc_structure/tree; optional merge format tree\|list after safety | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
-| **P1** | `US-CBM-A1` | User Story | **PENDING** | Must Have | Correct MCP 'project' routing (multi-mount ≠ wrong RocksDB project) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-A4` | User Story | **PENDING** | Must Have | Moat smoke (ontology + routing) gates Phase 1 “done” | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-D3` | User Story | **PENDING** | Must Have | Re-evaluate dual-run after typed-resolve Phase | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-GF-14` | User Story | **PENDING** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-17` | User Story | **PENDING** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-13` | User Story | **PENDING** | Must Have | Shareable single-file HTML graph export (leankg export html, bounded subgraph/community) | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-UI2-06` | User Story | **PENDING** | Must Have | Query FAB NL mode calls query_graph (raw Cozo remains advanced) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
+| **P3** | `REL-041` | Release | **NOT_DONE** | Could Have | 3D graph UI Track E ('graph-ui/'; keep 2D 'ui/') | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `US-UI2-07` | User Story | **PENDING** | Must Have | ui-v2 production cutover: embed into src/embed/ / Docker serve; become default explorer | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
-| **P2** | `US-CBM-B12` | User Story | **PENDING** | Should Have | ≥10 'run_raw_query' recipes in skills/docs | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-C3` | User Story | **PENDING** | Should Have | Selective language expansion with quality tiers | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E1` | User Story | **PENDING** | Should Have | New 3D graph UI ('graph-ui/') with WebGL galaxy + Bloom (keep existing 2D 'ui/') | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E2` | User Story | **PENDING** | Should Have | Server-computed 3D layout in Rust + 'get_graph_layout' / '/api/graph' | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E3` | User Story | **PENDING** | Should Have | Adaptive rendering (InstancedMesh &lt;75k; point sprites above) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E4` | User Story | **PENDING** | Should Have | Node detail + edge-type filter panels | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-GF-15` | User Story | **PENDING** | Should Have | Expand assistant install matrix (Cursor/Claude/Codex/…) toward Graphify-style one-command … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-GF-16` | User Story | **PENDING** | Should Have | Productize reflect / query-outcome loop as default skill guidance | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-MP-03` | User Story | **PENDING** | Should Have | Conversation/Decision Mining — import Claude/ChatGPT/Slack transcripts; auto-extract decis… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P2** | `US-SEM-01` | User Story | **PENDING** | Should Have | Honest token accounting on truncated MCP payloads (delivered vs _token_budget.actual) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
-| **P2** | `US-SEM-02` | User Story | **PENDING** | Should Have | Adequate per-tool budgets for concept_search / kg_semantic_context (not default 1000) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
-| **P2** | `US-SEM-03` | User Story | **PENDING** | Should Have | Resilient MCP HTTP for long semantic calls (transient socket drop retry) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
+| **P1** | `US-SURF-06` | User Story | **DONE** | Must Have | Hard-delete soft-deprecated MCP tools (wake_up, search_by_environment) after grace | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
+| **P1** | `US-SURF-07` | User Story | **DONE** | Must Have | After tool shrink: sync skills, rules, guidelines, and install/setup to reduced roster | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
+| **P2** | `US-DOCJOIN-02` | User Story | **PENDING** | Must Have | Doc query tools accept human path aliases for indexed docs/… keys | 3.19 Doc↔Code Join Quality (US-DOCJOIN) — v3.7.13 |
+| **P2** | `US-DOCJOIN-01` | User Story | **PENDING** | Must Have | Markdown documented_by/references attach to same keys as code index | 3.19 Doc↔Code Join Quality (US-DOCJOIN) — v3.7.13 |
+| **P2** | `US-DOCJOIN-03` | User Story | **PENDING** | Should Have | Prefer-order + authoring practices for annotations vs markdown edges | 3.19 Doc↔Code Join Quality (US-DOCJOIN) — v3.7.13 |
+| **P1** | `US-GF-14` | User Story | **PENDING** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-17` | User Story | **PENDING** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-13` | User Story | **PENDING** | Must Have | Shareable single-file HTML graph export (leankg export html, bounded subgraph/community) | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-UI2-06` | User Story | **PENDING** | Must Have | Query FAB NL mode calls query_graph (raw Cozo remains advanced) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
+| **P2** | `US-CBM-A1` | User Story | **PENDING** | Should Have | Correct MCP 'project' routing (multi-mount ≠ wrong RocksDB project) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-A4` | User Story | **PENDING** | Should Have | Moat smoke (ontology + routing) gates Phase 1 “done” | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-B12` | User Story | **PENDING** | Should Have | ≥10 'run_raw_query' recipes in skills/docs | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-C3` | User Story | **PENDING** | Should Have | Selective language expansion with quality tiers | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-D3` | User Story | **PENDING** | Should Have | Re-evaluate dual-run after typed-resolve Phase | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E1` | User Story | **PENDING** | Should Have | New 3D graph UI ('graph-ui/') with WebGL galaxy + Bloom (keep existing 2D 'ui/') | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E2` | User Story | **PENDING** | Should Have | Server-computed 3D layout in Rust + 'get_graph_layout' / '/api/graph' | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E3` | User Story | **PENDING** | Should Have | Adaptive rendering (InstancedMesh &lt;75k; point sprites above) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E4` | User Story | **PENDING** | Should Have | Node detail + edge-type filter panels | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-GF-15` | User Story | **PENDING** | Should Have | Expand assistant install matrix (Cursor/Claude/Codex/…) toward Graphify-style one-command … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P2** | `US-GF-16` | User Story | **PENDING** | Should Have | Productize reflect / query-outcome loop as default skill guidance | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P2** | `US-MP-03` | User Story | **PENDING** | Should Have | Conversation/Decision Mining — import Claude/ChatGPT/Slack transcripts; auto-extract decis… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `US-SEM-01` | User Story | **PENDING** | Should Have | Honest token accounting on truncated MCP payloads (delivered vs _token_budget.actual) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
+| **P2** | `US-SEM-02` | User Story | **PENDING** | Should Have | Adequate per-tool budgets for concept_search / kg_semantic_context (not default 1000) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
+| **P2** | `US-SEM-03` | User Story | **PENDING** | Should Have | Resilient MCP HTTP for long semantic calls (transient socket drop retry) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
 | **P2** | `US-UI2-08` | User Story | **PENDING** | Should Have | Community/cluster legend with show-hide filters (Graphify sidebar parity) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
 | **P2** | `US-UI2-09` | User Story | **PENDING** | Should Have | Port legacy ops panels (incidents / env / conflicts) into ui-v2 | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
-| **P3** | `US-CBM-C5` | User Story | **PENDING** | Could Have | Windows build + smoke | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P3** | `US-SEM-04` | User Story | **PENDING** | Could Have | Semantic hit diversity across files (MMR / file-diversity post-filter) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
-| **P3** | `US-SURF-05` | User Story | **PENDING** | Could Have | Optional unify get_doc_tree + get_doc_structure (mega-safe first) | 3.16 MCP Tool Surface Rationalization (US-SURF) —  |
-| **P1** | `US-08` | User Story | **PARTIAL** | Must Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |
-| **P1** | `US-CBM-A2` | User Story | **PARTIAL** | Must Have | Ontology online ('kg_ontology_status', 'concept_search' non-empty after sync) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-MG-02` | User Story | **PARTIAL** | Must Have | Single-repo projects expand fully on service double-click (no multi-level drilling) | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
-| **P1** | `US-MP-02` | User Story | **PARTIAL** | Must Have | Layered Context Loading (L0-L3) — explicit token budgets per layer: L0 identity (~50 tok),… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P1** | `US-MP-08` | User Story | **PARTIAL** | Must Have | Folder Structure as Graph Edges — directories as first-class 'directory' nodes with 'conta… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
+| **P3** | `US-CBM-C5` | User Story | **PENDING** | Could Have | Windows build + smoke | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P3** | `US-SEM-04` | User Story | **PENDING** | Could Have | Semantic hit diversity across files (MMR / file-diversity post-filter) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
+| **P3** | `US-SURF-05` | User Story | **PENDING** | Could Have | Optional unify get_doc_tree + get_doc_structure (mega-safe first) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
 | **P1** | `FR-COST-01` | FR | **PARTIAL** | Must Have | Publish ROI brief: token/tool-call floors, multi-repo Docker TCO, mega-graph + ops differe… | 5.20 Company cost / competitive ROI (v3.7.8) |
 | **P1** | `US-COST-01` | User Story | **PARTIAL** | Must Have | Manager ROI brief: why LeanKG reduces AI agent cost vs grep/cat and vs Graphify at company… | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `US-GF-04` | User Story | **PARTIAL** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-06` | User Story | **PARTIAL** | Must Have | Generate 'GRAPH_REPORT.md': god nodes, surprising cross-module links, suggested questions,… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-LANG-02` | User Story | **PARTIAL** | Should Have | Swift parser (tree-sitter-swift) with regex entity extraction | 3.7 Additional Language Stories (US-LANG-01 to US- |
-| **P3** | `US-GF-10` | User Story | **PARTIAL** | Could Have | Expand language extractors toward Graphify breadth (Vue/Svelte, Scala, Lua, Zig, shell, Ap… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P3** | `US-GF-12` | User Story | **PARTIAL** | Could Have | Live SQL / Postgres schema introspection into the same graph (tables, FKs, views ↔ app cod… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P3** | `US-GN-08` | User Story | **PARTIAL** | Could Have | MCP Resources for overview context | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P3** | `FR-EMBED-R4` | FR | **OPEN** | Could Have | (open / aspirational): Cold functions-only &lt;20 min on ~371k on reference M2 Pro 10c. **… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
+| **P1** | `US-GF-04` | User Story | **PARTIAL** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-GF-06` | User Story | **PARTIAL** | Must Have | Generate 'GRAPH_REPORT.md': god nodes, surprising cross-module links, suggested questions,… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-MG-02` | User Story | **PARTIAL** | Must Have | Single-repo projects expand fully on service double-click (no multi-level drilling) | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
+| **P2** | `US-08` | User Story | **PARTIAL** | Should Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |
+| **P2** | `US-CBM-A2` | User Story | **PARTIAL** | Should Have | Ontology online ('kg_ontology_status', 'concept_search' non-empty after sync) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-LANG-02` | User Story | **PARTIAL** | Should Have | Swift parser (tree-sitter-swift) with regex entity extraction | 3.7 Additional Language Stories (US-LANG-01 to US-LANG-03) |
+| **P2** | `US-MP-02` | User Story | **PARTIAL** | Should Have | Layered Context Loading (L0-L3) — explicit token budgets per layer: L0 identity (~50 tok),… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `US-MP-08` | User Story | **PARTIAL** | Should Have | Folder Structure as Graph Edges — directories as first-class 'directory' nodes with 'conta… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P3** | `US-GF-10` | User Story | **PARTIAL** | Could Have | Expand language extractors toward Graphify breadth (Vue/Svelte, Scala, Lua, Zig, shell, Ap… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P3** | `US-GF-12` | User Story | **PARTIAL** | Could Have | Live SQL / Postgres schema introspection into the same graph (tables, FKs, views ↔ app cod… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P3** | `US-GN-08` | User Story | **PARTIAL** | Could Have | MCP Resources for overview context | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P3** | `FR-EMBED-R4` | FR | **OPEN** | Could Have | (open / aspirational): Cold functions-only &lt;20 min on ~371k on reference M2 Pro 10c. **… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
 
 ---
 
@@ -207,12 +284,15 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
-| **P1** | `FR-B05` | FR | **NOT_DONE** | Must Have | Benchmark harness vs CBM (50-edge samples) | 5.10 CBM Structural Parity Requirements (merged) |
-| **P1** | `FR-MG-03` | FR | **NOT_DONE** | Must Have | Single-repo projects treated as single service — root double-click loads everything | 5.7 Massive Graph UI (DONE) |
-| **P1** | `REL-032` | Release | **NOT_DONE** | Must Have | Swift / Vue / Svelte / SQL DDL — extractors present ('swift.rs' / 'sfc.rs' / 'sql.rs') but… | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
-| **P1** | `REL-040` | Release | **NOT_DONE** | Must Have | REST API auth wiring + mutation endpoints (mutation endpoints still partial) | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
-| **P1** | `REL-041` | Release | **NOT_DONE** | Must Have | 3D graph UI Track E ('graph-ui/'; keep 2D 'ui/') | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `REL-058` | Release | **NOT_DONE** | Must Have | Manager ROI brief checked into docs/reports/ and linked from README competitive section | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `FR-UI2-09` | FR | **NOT_DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
+| **P1** | `REL-057` | Release | **NOT_DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
+| **P1** | `FR-SURF-07` | FR | **DONE** | Must Have | Hard-delete wake_up from ToolRegistry + handlers; matrix AlreadyRemoved; smoke MUTATING li… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-08` | FR | **DONE** | Must Have | Hard-delete search_by_environment; callers use env= on search_code/semantic_search/concept… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-09` | FR | **DONE** | Must Have | Sync repo guidelines: AGENTS.md, CLAUDE.md, docs/mcp-tools.md, mcp-setup.md, agentic-instr… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-10` | FR | **DONE** | Must Have | Sync using-leankg skill + leankg-first / mandatory-workflow-loop / skill-auto-invoke rules… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `FR-SURF-11` | FR | **DONE** | Must Have | Sync install/setup: scripts/install.sh, mcp-smoke-tools.py, cursor/opencode/claude plugin … | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
+| **P1** | `REL-062` | Release | **DONE** | Must Have | Evidence: list_tools before/after hard-delete + grep-clean skills/rules/docs/setup of dele… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
 | **P1** | `FR-GF-22` | FR | **NOT_DONE** | Must Have | README / AGENTS / using-leankg skill lead with path · explain · query; demote full tool wa… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-24` | FR | **NOT_DONE** | Must Have | Always-on graph-first rules/hooks: nudge before grep/Read; optional strict first-Read redi… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-07` | FR | **NOT_DONE** | Must Have | Relationship metadata field 'confidence_label' ∈ {EXTRACTED, INFERRED, AMBIGUOUS} written … | 5.9 Graphify-Inspired Features |
@@ -222,13 +302,23 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P1** | `FR-GF-13` | FR | **NOT_DONE** | Must Have | Auto-generate '.leankg/GRAPH_REPORT.md' on every index (CLI 'leankg report' / MCP 'get_gra… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-21` | FR | **NOT_DONE** | Must Have | CLI/MCP export html — single-file bounded subgraph/community; document node budget | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-UI2-08` | FR | **NOT_DONE** | Must Have | Query FAB dual-mode: NL → query_graph; Advanced → raw Cozo POST /api/query | 5.19 UI v2 Graph Explorer |
-| **P1** | `FR-UI2-09` | FR | **NOT_DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
-| **P1** | `REL-057` | Release | **NOT_DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
-| **P1** | `FR-A02` | FR | **NOT_DONE** | Should Have | Automate/document ontology sync for concepts + workflows YAML | 5.10 CBM Structural Parity Requirements (merged) |
+| **P1** | `FR-MG-03` | FR | **NOT_DONE** | Must Have | Single-repo projects treated as single service — root double-click loads everything | 5.7 Massive Graph UI (DONE) |
+| **P2** | `FR-DOCJOIN-02` | FR | **NOT_DONE** | Must Have | Normalize doc/file path aliases on get_files_for_doc and find_related_docs | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-01` | FR | **NOT_DONE** | Must Have | Resolve markdown code refs to indexed file-level CodeElement keys on write | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-03` | FR | **NOT_DONE** | Must Have | Persist references edge context snippet + EXTRACTED confidence metadata | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-04` | FR | **NOT_DONE** | Must Have | Unit + TempDir integration tests for doc↔code join round-trip | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `REL-063` | Release | **NOT_DONE** | Must Have | Evidence: fixture + live MCP smoke for doc↔code join quality (docs/reports/) | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-05` | FR | **NOT_DONE** | Should Have | Sync mcp-tools / AGENTS / using-leankg prefer-order for annotations vs markdown edges | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `FR-DOCJOIN-06` | FR | **NOT_DONE** | Could Have | Optional best-effort upgrade of file::symbol mentions to unique function/class keys | 5.22 Doc↔Code Join Quality (v3.7.13) |
+| **P2** | `US-DOCJOIN-02` | User Story | **PENDING** | Must Have | Doc query tools accept human path aliases for indexed docs/… keys | 3.19 Doc↔Code Join Quality (US-DOCJOIN) — v3.7.13 |
+| **P2** | `US-DOCJOIN-01` | User Story | **PENDING** | Must Have | Markdown documented_by/references attach to same keys as code index | 3.19 Doc↔Code Join Quality (US-DOCJOIN) — v3.7.13 |
+| **P2** | `US-DOCJOIN-03` | User Story | **PENDING** | Should Have | Prefer-order + authoring practices for annotations vs markdown edges | 3.19 Doc↔Code Join Quality (US-DOCJOIN) — v3.7.13 |
 | **P2** | `FR-A01` | FR | **NOT_DONE** | Should Have | MCP 'project' resolves to correct RocksDB project for multi-mount setups | 5.10 CBM Structural Parity Requirements (merged) |
+| **P2** | `FR-A02` | FR | **NOT_DONE** | Should Have | Automate/document ontology sync for concepts + workflows YAML | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-A03` | FR | **NOT_DONE** | Should Have | Verify ontology/knowledge tools after sync | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-A04` | FR | **NOT_DONE** | Should Have | Index per 'leankg.yaml'; expose counts | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-A06` | FR | **NOT_DONE** | Should Have | Smoke: ontology + routing must pass before Phase 1 “fully done” | 5.10 CBM Structural Parity Requirements (merged) |
+| **P2** | `FR-B05` | FR | **NOT_DONE** | Should Have | Benchmark harness vs CBM (50-edge samples) | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B06` | FR | **NOT_DONE** | Should Have | Python + Rust typed resolve (Could) — infra works; LSP server default wiring PENDING | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B13` | FR | **NOT_DONE** | Should Have | Extend 'service_calls' beyond k8s DNS regex (Should) | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B16` | FR | **NOT_DONE** | Should Have | Runtime trace ingestion (Could) | 5.10 CBM Structural Parity Requirements (merged) |
@@ -266,51 +356,56 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P2** | `FR-SEM-03` | FR | **NOT_DONE** | Should Have | MCP HTTP resilience for long read-only semantic tools (retry docs + keep-alive / stale-lis… | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P2** | `FR-UI2-10` | FR | **NOT_DONE** | Should Have | Cluster legend + show/hide filters wired to /api/graph/clusters | 5.19 UI v2 Graph Explorer |
 | **P2** | `FR-UI2-11` | FR | **NOT_DONE** | Should Have | Port incidents / env / conflicts panels from legacy ui/ into ui-v2 | 5.19 UI v2 Graph Explorer |
+| **P2** | `REL-032` | Release | **NOT_DONE** | Should Have | Swift / Vue / Svelte / SQL DDL — extractors present ('swift.rs' / 'sfc.rs' / 'sql.rs') but… | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
+| **P2** | `REL-040` | Release | **NOT_DONE** | Should Have | REST API auth wiring + mutation endpoints (mutation endpoints still partial) | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P3** | `FR-SEM-05` | FR | **NOT_DONE** | Could Have | Optional file-diversity / MMR post-filter after HNSW+rerank (top-k not ≥70% one file) | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P3** | `FR-SURF-06` | FR | **NOT_DONE** | Could Have | Mega-safe get_doc_structure/tree; optional merge format tree\|list after safety | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
-| **P1** | `US-CBM-A1` | User Story | **PENDING** | Must Have | Correct MCP 'project' routing (multi-mount ≠ wrong RocksDB project) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-A4` | User Story | **PENDING** | Must Have | Moat smoke (ontology + routing) gates Phase 1 “done” | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-D3` | User Story | **PENDING** | Must Have | Re-evaluate dual-run after typed-resolve Phase | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-GF-14` | User Story | **PENDING** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-17` | User Story | **PENDING** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-13` | User Story | **PENDING** | Must Have | Shareable single-file HTML graph export (leankg export html, bounded subgraph/community) | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-UI2-06` | User Story | **PENDING** | Must Have | Query FAB NL mode calls query_graph (raw Cozo remains advanced) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
+| **P3** | `REL-041` | Release | **NOT_DONE** | Could Have | 3D graph UI Track E ('graph-ui/'; keep 2D 'ui/') | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `US-UI2-07` | User Story | **PENDING** | Must Have | ui-v2 production cutover: embed into src/embed/ / Docker serve; become default explorer | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
-| **P2** | `US-CBM-B12` | User Story | **PENDING** | Should Have | ≥10 'run_raw_query' recipes in skills/docs | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-C3` | User Story | **PENDING** | Should Have | Selective language expansion with quality tiers | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E1` | User Story | **PENDING** | Should Have | New 3D graph UI ('graph-ui/') with WebGL galaxy + Bloom (keep existing 2D 'ui/') | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E2` | User Story | **PENDING** | Should Have | Server-computed 3D layout in Rust + 'get_graph_layout' / '/api/graph' | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E3` | User Story | **PENDING** | Should Have | Adaptive rendering (InstancedMesh &lt;75k; point sprites above) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-E4` | User Story | **PENDING** | Should Have | Node detail + edge-type filter panels | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-GF-15` | User Story | **PENDING** | Should Have | Expand assistant install matrix (Cursor/Claude/Codex/…) toward Graphify-style one-command … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-GF-16` | User Story | **PENDING** | Should Have | Productize reflect / query-outcome loop as default skill guidance | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-MP-03` | User Story | **PENDING** | Should Have | Conversation/Decision Mining — import Claude/ChatGPT/Slack transcripts; auto-extract decis… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P2** | `US-SEM-01` | User Story | **PENDING** | Should Have | Honest token accounting on truncated MCP payloads (delivered vs _token_budget.actual) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
-| **P2** | `US-SEM-02` | User Story | **PENDING** | Should Have | Adequate per-tool budgets for concept_search / kg_semantic_context (not default 1000) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
-| **P2** | `US-SEM-03` | User Story | **PENDING** | Should Have | Resilient MCP HTTP for long semantic calls (transient socket drop retry) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
+| **P1** | `US-SURF-06` | User Story | **DONE** | Must Have | Hard-delete soft-deprecated MCP tools (wake_up, search_by_environment) after grace | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
+| **P1** | `US-SURF-07` | User Story | **DONE** | Must Have | After tool shrink: sync skills, rules, guidelines, and install/setup to reduced roster | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
+| **P1** | `US-GF-14` | User Story | **PENDING** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-17` | User Story | **PENDING** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-13` | User Story | **PENDING** | Must Have | Shareable single-file HTML graph export (leankg export html, bounded subgraph/community) | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-UI2-06` | User Story | **PENDING** | Must Have | Query FAB NL mode calls query_graph (raw Cozo remains advanced) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
+| **P2** | `US-CBM-A1` | User Story | **PENDING** | Should Have | Correct MCP 'project' routing (multi-mount ≠ wrong RocksDB project) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-A4` | User Story | **PENDING** | Should Have | Moat smoke (ontology + routing) gates Phase 1 “done” | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-B12` | User Story | **PENDING** | Should Have | ≥10 'run_raw_query' recipes in skills/docs | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-C3` | User Story | **PENDING** | Should Have | Selective language expansion with quality tiers | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-D3` | User Story | **PENDING** | Should Have | Re-evaluate dual-run after typed-resolve Phase | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E1` | User Story | **PENDING** | Should Have | New 3D graph UI ('graph-ui/') with WebGL galaxy + Bloom (keep existing 2D 'ui/') | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E2` | User Story | **PENDING** | Should Have | Server-computed 3D layout in Rust + 'get_graph_layout' / '/api/graph' | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E3` | User Story | **PENDING** | Should Have | Adaptive rendering (InstancedMesh &lt;75k; point sprites above) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-E4` | User Story | **PENDING** | Should Have | Node detail + edge-type filter panels | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-GF-15` | User Story | **PENDING** | Should Have | Expand assistant install matrix (Cursor/Claude/Codex/…) toward Graphify-style one-command … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P2** | `US-GF-16` | User Story | **PENDING** | Should Have | Productize reflect / query-outcome loop as default skill guidance | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P2** | `US-MP-03` | User Story | **PENDING** | Should Have | Conversation/Decision Mining — import Claude/ChatGPT/Slack transcripts; auto-extract decis… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `US-SEM-01` | User Story | **PENDING** | Should Have | Honest token accounting on truncated MCP payloads (delivered vs _token_budget.actual) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
+| **P2** | `US-SEM-02` | User Story | **PENDING** | Should Have | Adequate per-tool budgets for concept_search / kg_semantic_context (not default 1000) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
+| **P2** | `US-SEM-03` | User Story | **PENDING** | Should Have | Resilient MCP HTTP for long semantic calls (transient socket drop retry) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
 | **P2** | `US-UI2-08` | User Story | **PENDING** | Should Have | Community/cluster legend with show-hide filters (Graphify sidebar parity) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
 | **P2** | `US-UI2-09` | User Story | **PENDING** | Should Have | Port legacy ops panels (incidents / env / conflicts) into ui-v2 | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
-| **P3** | `US-CBM-C5` | User Story | **PENDING** | Could Have | Windows build + smoke | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P3** | `US-SEM-04` | User Story | **PENDING** | Could Have | Semantic hit diversity across files (MMR / file-diversity post-filter) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
-| **P3** | `US-SURF-05` | User Story | **PENDING** | Could Have | Optional unify get_doc_tree + get_doc_structure (mega-safe first) | 3.16 MCP Tool Surface Rationalization (US-SURF) —  |
-| **P1** | `US-08` | User Story | **PARTIAL** | Must Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |
-| **P1** | `US-CBM-A2` | User Story | **PARTIAL** | Must Have | Ontology online ('kg_ontology_status', 'concept_search' non-empty after sync) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-MG-02` | User Story | **PARTIAL** | Must Have | Single-repo projects expand fully on service double-click (no multi-level drilling) | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
-| **P1** | `US-MP-02` | User Story | **PARTIAL** | Must Have | Layered Context Loading (L0-L3) — explicit token budgets per layer: L0 identity (~50 tok),… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P1** | `US-MP-08` | User Story | **PARTIAL** | Must Have | Folder Structure as Graph Edges — directories as first-class 'directory' nodes with 'conta… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
+| **P3** | `US-CBM-C5` | User Story | **PENDING** | Could Have | Windows build + smoke | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P3** | `US-SEM-04` | User Story | **PENDING** | Could Have | Semantic hit diversity across files (MMR / file-diversity post-filter) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
+| **P3** | `US-SURF-05` | User Story | **PENDING** | Could Have | Optional unify get_doc_tree + get_doc_structure (mega-safe first) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
 | **P1** | `FR-COST-01` | FR | **PARTIAL** | Must Have | Publish ROI brief: token/tool-call floors, multi-repo Docker TCO, mega-graph + ops differe… | 5.20 Company cost / competitive ROI (v3.7.8) |
 | **P1** | `US-COST-01` | User Story | **PARTIAL** | Must Have | Manager ROI brief: why LeanKG reduces AI agent cost vs grep/cat and vs Graphify at company… | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `US-GF-04` | User Story | **PARTIAL** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-06` | User Story | **PARTIAL** | Must Have | Generate 'GRAPH_REPORT.md': god nodes, surprising cross-module links, suggested questions,… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-LANG-02` | User Story | **PARTIAL** | Should Have | Swift parser (tree-sitter-swift) with regex entity extraction | 3.7 Additional Language Stories (US-LANG-01 to US- |
-| **P3** | `US-GF-10` | User Story | **PARTIAL** | Could Have | Expand language extractors toward Graphify breadth (Vue/Svelte, Scala, Lua, Zig, shell, Ap… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P3** | `US-GF-12` | User Story | **PARTIAL** | Could Have | Live SQL / Postgres schema introspection into the same graph (tables, FKs, views ↔ app cod… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P3** | `US-GN-08` | User Story | **PARTIAL** | Could Have | MCP Resources for overview context | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P3** | `FR-EMBED-R4` | FR | **OPEN** | Could Have | (open / aspirational): Cold functions-only &lt;20 min on ~371k on reference M2 Pro 10c. **… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P0** | `FR-HNSW-E` | FR | **DONE** | Must Have | Incremental embed filter (foundation) — PARTIAL: day-2 resume/HNSW no-op/stale-blast track… | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) + |
+| **P1** | `US-GF-04` | User Story | **PARTIAL** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-GF-06` | User Story | **PARTIAL** | Must Have | Generate 'GRAPH_REPORT.md': god nodes, surprising cross-module links, suggested questions,… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-MG-02` | User Story | **PARTIAL** | Must Have | Single-repo projects expand fully on service double-click (no multi-level drilling) | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
+| **P2** | `US-08` | User Story | **PARTIAL** | Should Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |
+| **P2** | `US-CBM-A2` | User Story | **PARTIAL** | Should Have | Ontology online ('kg_ontology_status', 'concept_search' non-empty after sync) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-LANG-02` | User Story | **PARTIAL** | Should Have | Swift parser (tree-sitter-swift) with regex entity extraction | 3.7 Additional Language Stories (US-LANG-01 to US-LANG-03) |
+| **P2** | `US-MP-02` | User Story | **PARTIAL** | Should Have | Layered Context Loading (L0-L3) — explicit token budgets per layer: L0 identity (~50 tok),… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `US-MP-08` | User Story | **PARTIAL** | Should Have | Folder Structure as Graph Edges — directories as first-class 'directory' nodes with 'conta… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P3** | `US-GF-10` | User Story | **PARTIAL** | Could Have | Expand language extractors toward Graphify breadth (Vue/Svelte, Scala, Lua, Zig, shell, Ap… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P3** | `US-GF-12` | User Story | **PARTIAL** | Could Have | Live SQL / Postgres schema introspection into the same graph (tables, FKs, views ↔ app cod… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P3** | `US-GN-08` | User Story | **PARTIAL** | Could Have | MCP Resources for overview context | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P3** | `FR-EMBED-R4` | FR | **OPEN** | Could Have | (open / aspirational): Cold functions-only &lt;20 min on ~371k on reference M2 Pro 10c. **… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P0** | `FR-HNSW-E` | FR | **DONE** | Must Have | Incremental embed filter (foundation) — PARTIAL: day-2 resume/HNSW no-op/stale-blast track… | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) + 5.12 |
 | **P0** | `US-MG-TOOL-01` | User Story | **DONE** | Must Have | Mega-safe concept_search / query_graph / get_clusters serve | 3.14 / US-MG-TOOL-01 |
 | **P0** | `US-ONT-PROC-01` | User Story | **DONE** | Must Have | Procedural ontology auto-update while using LeanKG (YAML watch + index hook; no manual syn… | 3.18 Procedural Ontology Auto-Update (US-ONT-PROC) |
-| **P0** | `US-SEM-06` | User Story | **DONE** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — |
+| **P0** | `US-SEM-06` | User Story | **DONE** | Must Have | Mega-graph HNSW semantic_search / kg_semantic_context must not OOM MCP | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
 | **P0** | `FR-ONT-MEGA-01` | FR | **DONE** | Must Have | Mega-safe concept_search keyed code_ref + typed name fallback | 5.15 |
 | **P0** | `FR-ONT-PROC-01` | FR | **DONE** | Must Have | Watch ontology/workflows.yaml + concepts.yaml during mcp-http/serve; debounce idempotent s… | 5.21 Procedural ontology auto-update (v3.7.9) |
 | **P0** | `FR-SEM-07` | FR | **DONE** | Must Have | Mega-safe HNSW path: no unbounded all_elements(); ANN + paginated/keyed hydration; MCP sta… | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
@@ -324,38 +419,38 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P0** | `US-EMBED-03` | User Story | **DONE** | Must Have | Zero-dirty embed does not drop/rebuild HNSW | 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 |
 | **P0** | `REL-059` | Release | **DONE** | Must Have | Live smoke: edit workflows.yaml → kg_trace_workflow updates without restart; boot respects… | 5.21 Procedural ontology auto-update (v3.7.9) |
 | **P0** | `US-EMBED-04` | User Story | **DONE** | Must Have | Docker MCP/boot/setup embed resumes existing RocksDB data; cold/fresh only when no embed d… | 3.15 Day-2 Embed Resume (US-EMBED) — v3.7.2 |
-| **P0** | `US-VE-01` | User Story | **DONE** | Must Have | As a local developer on Apple Silicon (≤16GB RAM), I want idle LeanKG MCP RSS **&lt; 150MB… | 3.13 Optimized Local-First Vector Graph Engine (US |
-| **P0** | `US-VE-02` | User Story | **DONE** | Must Have | As an AI agent, I want code chunks + dependency JSON in **&lt; 100ms P95**, so tool loops … | 3.13 Optimized Local-First Vector Graph Engine (US |
-| **P0** | `US-VE-03` | User Story | **DONE** | Must Have | As a platform engineer, I want 'LocalEngine' vs 'CloudEngine' selected via env/config (Rus… | 3.13 Optimized Local-First Vector Graph Engine (US |
-| **P0** | `US-VE-04` | User Story | **DONE** | Must Have | As a query runtime, I want SQ8/INT8 vectors fully in RAM with dynamic SIMD (NEON / AVX2 / … | 3.13 Optimized Local-First Vector Graph Engine (US |
-| **P0** | `US-VE-05` | User Story | **DONE** | Must Have | As a storage owner on a 256GB SSD, I want mmap disabled + Zstd RocksDB + append/fsync dual… | 3.13 Optimized Local-First Vector Graph Engine (US |
-| **P0** | `US-VE-07` | User Story | **DONE** | Must Have | As a QA engineer, I want dual-write crash, SIMD differential, GC concurrency, and engine-f… | 3.13 Optimized Local-First Vector Graph Engine (US |
-| **P0** | `US-VE-08` | User Story | **DONE** | Must Have | As a product owner, I want Kilo/OpenCode A/B (≥100 tasks) showing ≥60% token cut, ≥80% too… | 3.13 Optimized Local-First Vector Graph Engine (US |
+| **P0** | `US-VE-01` | User Story | **DONE** | Must Have | As a local developer on Apple Silicon (≤16GB RAM), I want idle LeanKG MCP RSS **&lt; 150MB… | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
+| **P0** | `US-VE-02` | User Story | **DONE** | Must Have | As an AI agent, I want code chunks + dependency JSON in **&lt; 100ms P95**, so tool loops … | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
+| **P0** | `US-VE-03` | User Story | **DONE** | Must Have | As a platform engineer, I want 'LocalEngine' vs 'CloudEngine' selected via env/config (Rus… | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
+| **P0** | `US-VE-04` | User Story | **DONE** | Must Have | As a query runtime, I want SQ8/INT8 vectors fully in RAM with dynamic SIMD (NEON / AVX2 / … | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
+| **P0** | `US-VE-05` | User Story | **DONE** | Must Have | As a storage owner on a 256GB SSD, I want mmap disabled + Zstd RocksDB + append/fsync dual… | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
+| **P0** | `US-VE-07` | User Story | **DONE** | Must Have | As a QA engineer, I want dual-write crash, SIMD differential, GC concurrency, and engine-f… | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
+| **P0** | `US-VE-08` | User Story | **DONE** | Must Have | As a product owner, I want Kilo/OpenCode A/B (≥100 tasks) showing ≥60% token cut, ≥80% too… | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
 | **P0** | `FR-EMBED-RESUME-01` | FR | **DONE** | Must Have | Standalone embed --wait loads RocksDB embedding_state; unchanged second run skips fresh (e… | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) |
-| **P0** | `FR-VE-ABS` | FR | **DONE** | Must Have | Storage abstraction via Rust traits + **static enum dispatch** ('LocalEngine' / 'CloudEngi… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-FS-DW` | FR | **DONE** | Must Have | Safe dual-write order: **Append Flat File → 'fsync' → Commit offsets to RocksDB/TiKV → Upd… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-FS-REC` | FR | **DONE** | Must Have | Crash after Flat File write but before RocksDB commit → clean recovery, **no dangling poin… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-HNSW` | FR | **DONE** | Must Have | HNSW 'selectNeighborsHeuristic' with low **M ∈ [12, 16]**; raise 'efConstruction' to prote… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-RT-MEM` | FR | **DONE** | Must Have | Auto-tune RocksDB block cache from cgroups / 'sysinfo' available RAM (2GB survival → cloud… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-RT-SIMD` | FR | **DONE** | Must Have | Runtime SIMD dispatch ('is_x86_feature_detected!' / 'is_aarch64_feature_detected!') → AVX-… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-RT-THREADS` | FR | **DONE** | Must Have | Dynamic 'rayon' pool — leave **2 cores free** for OS/IDE on Local; utilize full machine on… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-T1` | FR | **DONE** | Must Have | **Tier 1 — Graph topology** in RocksDB (Local) / TiKV (Cloud): metadata, AST refs, HNSW ad… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-T2` | FR | **DONE** | Must Have | **Tier 2 — Quantized vectors** as an in-memory SQ8/INT8 array (100% RAM). All hot ANN dist… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-T3` | FR | **DONE** | Must Have | **Tier 3 — Raw payload** flat binary file: original FP32 vectors + source/chunk payload. R… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
+| **P0** | `FR-VE-ABS` | FR | **DONE** | Must Have | Storage abstraction via Rust traits + **static enum dispatch** ('LocalEngine' / 'CloudEngi… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-FS-DW` | FR | **DONE** | Must Have | Safe dual-write order: **Append Flat File → 'fsync' → Commit offsets to RocksDB/TiKV → Upd… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-FS-REC` | FR | **DONE** | Must Have | Crash after Flat File write but before RocksDB commit → clean recovery, **no dangling poin… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-HNSW` | FR | **DONE** | Must Have | HNSW 'selectNeighborsHeuristic' with low **M ∈ [12, 16]**; raise 'efConstruction' to prote… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-RT-MEM` | FR | **DONE** | Must Have | Auto-tune RocksDB block cache from cgroups / 'sysinfo' available RAM (2GB survival → cloud… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-RT-SIMD` | FR | **DONE** | Must Have | Runtime SIMD dispatch ('is_x86_feature_detected!' / 'is_aarch64_feature_detected!') → AVX-… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-RT-THREADS` | FR | **DONE** | Must Have | Dynamic 'rayon' pool — leave **2 cores free** for OS/IDE on Local; utilize full machine on… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-T1` | FR | **DONE** | Must Have | **Tier 1 — Graph topology** in RocksDB (Local) / TiKV (Cloud): metadata, AST refs, HNSW ad… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-T2` | FR | **DONE** | Must Have | **Tier 2 — Quantized vectors** as an in-memory SQ8/INT8 array (100% RAM). All hot ANN dist… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-T3` | FR | **DONE** | Must Have | **Tier 3 — Raw payload** flat binary file: original FP32 vectors + source/chunk payload. R… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
 | **P0** | `FR-EMBED-RESUME-02` | FR | **DONE** | Must Have | Skip HNSW drop+recreate when to_embed empty and orphan set empty; fast no-op exit | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) |
 | **P0** | `FR-EMBED-RESUME-03` | FR | **DONE** | Must Have | Mid-run durability: committed fresh rows survive kill/restart; next run dirty-only | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) |
 | **P0** | `FR-EMBED-RESUME-04` | FR | **DONE** | Must Have | Indexer marks stale only for content_hash-changed QNs; no stale-all on no-op full index | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) |
 | **P0** | `FR-EMBED-RESUME-05` | FR | **DONE** | Must Have | Day-2 SLA evidence: unchanged mega-graph second pass near-zero ONNX; wall time << cold | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) |
 | **P0** | `FR-EMBED-RESUME-06` | FR | **DONE** | Must Have | All Docker embed-on paths share resume-if-data / cold-if-empty; never wipe on enable (BACK… | 5.16 Day-2 Embed Resume / Resource Gate (v3.7.2) |
-| **P0** | `FR-VE-TEST-DW` | FR | **DONE** | Must Have | Dual-write crash simulation unit/integration test (assert recovery). | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-TEST-FACTORY` | FR | **DONE** | Must Have | Env injection selects LocalEngine vs CloudEngine correctly. | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-TEST-GC` | FR | **DONE** | Must Have | 10k update/delete fragment → background GC + concurrent reads → integrity OK, reads never … | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-TEST-SIMD` | FR | **DONE** | Must Have | Differential test: NEON / AVX2 / scalar on same mock set; abs error **&lt; 1e-6**. | 5.14 Optimized Local-First Vector Graph Engine (v3 |
+| **P0** | `FR-VE-TEST-DW` | FR | **DONE** | Must Have | Dual-write crash simulation unit/integration test (assert recovery). | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-TEST-FACTORY` | FR | **DONE** | Must Have | Env injection selects LocalEngine vs CloudEngine correctly. | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-TEST-GC` | FR | **DONE** | Must Have | 10k update/delete fragment → background GC + concurrent reads → integrity OK, reads never … | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-TEST-SIMD` | FR | **DONE** | Must Have | Differential test: NEON / AVX2 / scalar on same mock set; abs error **&lt; 1e-6**. | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
 | **P0** | `REL-052` | Release | **DONE** | Must Have | v3.7.2 embed-resume gate: day-2 proven for standalone embed --wait AND Docker MCP embed-on… | 8.5 v3.7.2 Embed Resume Gate |
-| **P0** | `FR-VE-BENCH-IO` | FR | **DONE** | Must Have | Prove ≥ **80%** reduction in page faults / disk reads vs legacy mmap architecture. | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-BENCH-OOM` | FR | **DONE** | Must Have | Simulated **2GB cgroup** — heap/RSS monitored; **must not** OOM-kill. | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-BENCH-Q` | FR | **DONE** | Must Have | 'cargo bench' — 1 query vs **1,000,000** SQ8 chunks, Local mode P95 **&lt; 50ms**. | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-BENCH-RECALL` | FR | **DONE** | Must Have | Recall **&gt; 90%** at 'efSearch=50' vs FP32 brute-force. | 5.14 Optimized Local-First Vector Graph Engine (v3 |
+| **P0** | `FR-VE-BENCH-IO` | FR | **DONE** | Must Have | Prove ≥ **80%** reduction in page faults / disk reads vs legacy mmap architecture. | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-BENCH-OOM` | FR | **DONE** | Must Have | Simulated **2GB cgroup** — heap/RSS monitored; **must not** OOM-kill. | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-BENCH-Q` | FR | **DONE** | Must Have | 'cargo bench' — 1 query vs **1,000,000** SQ8 chunks, Local mode P95 **&lt; 50ms**. | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-BENCH-RECALL` | FR | **DONE** | Must Have | Recall **&gt; 90%** at 'efSearch=50' vs FP32 brute-force. | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
 | **P0** | `REL-044` | Release | **DONE** | Must Have | 3-tier LocalEngine implemented (FR-VE-T1..T3 + FR-VE-ABS) | 8.4 v3.7 Vector Engine Gate (COMPLETE on PR #80) |
 | **P0** | `REL-045` | Release | **DONE** | Must Have | Dynamic SIMD + memory + thread auto-tune (FR-VE-RT-*) | 8.4 v3.7 Vector Engine Gate (COMPLETE on PR #80) |
 | **P0** | `REL-046` | Release | **DONE** | Must Have | Dual-write + crash recovery + GC (FR-VE-FS-*) | 8.4 v3.7 Vector Engine Gate (COMPLETE on PR #80) |
@@ -363,17 +458,17 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P0** | `REL-048` | Release | **DONE** | Must Have | Benches: &lt;50ms P95 @ 1M SQ8; ≥80% I/O reduction vs mmap; recall &gt;90% @ ef=50; 2GB cg… | 8.4 v3.7 Vector Engine Gate (COMPLETE on PR #80) |
 | **P0** | `REL-049` | Release | **DONE** | Must Have | Agent A/B: ≥60% tokens, ≥80% tool calls, ≥2× faster, success ≥ baseline (FR-VE-BENCH-AB) | 8.4 v3.7 Vector Engine Gate (COMPLETE on PR #80) |
 | **P0** | `REL-050` | Release | **DONE** | Must Have | Idle MCP RSS &lt; 150MB; time-to-context P95 &lt; 100ms | 8.4 v3.7 Vector Engine Gate (COMPLETE on PR #80) |
-| **P0** | `FR-VE-BENCH-AB` | FR | **DONE** | Must Have | Agent A/B ('run_kilo_ab_final.sh' or existing harness), ≥100 tasks: | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-GATE` | FR | **DONE** | Must Have | Default Local switch only when FR-VE-TEST-* + FR-VE-BENCH-Q/IO/RECALL/OOM pass and FR-VE-B… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `FR-VE-FS-GC` | FR | **DONE** | Should Have | Zero-downtime GC via shadow paging + micro-lock delta sync; trigger when fragmentation **&… | 5.14 Optimized Local-First Vector Graph Engine (v3 |
-| **P0** | `US-VE-06` | User Story | **DONE** | Should Have | As an operator, I want zero-downtime GC (shadow paging + micro-lock delta sync when fragme… | 3.13 Optimized Local-First Vector Graph Engine (US |
+| **P0** | `FR-VE-BENCH-AB` | FR | **DONE** | Must Have | Agent A/B ('run_kilo_ab_final.sh' or existing harness), ≥100 tasks: | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-GATE` | FR | **DONE** | Must Have | Default Local switch only when FR-VE-TEST-* + FR-VE-BENCH-Q/IO/RECALL/OOM pass and FR-VE-B… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `FR-VE-FS-GC` | FR | **DONE** | Should Have | Zero-downtime GC via shadow paging + micro-lock delta sync; trigger when fragmentation **&… | 5.14 Optimized Local-First Vector Graph Engine (v3.7.0) |
+| **P0** | `US-VE-06` | User Story | **DONE** | Should Have | As an operator, I want zero-downtime GC (shadow paging + micro-lock delta sync when fragme… | 3.13 Optimized Local-First Vector Graph Engine (US-VE) — v3.… |
 | **P1** | `FR-B03` | FR | **DONE** | Must Have | LSP bridge infrastructure for Go (could read 'gopls' textDocument/definition/references) —… | 5.10 CBM Structural Parity Requirements (merged) |
 | **P1** | `FR-B04` | FR | **DONE** | Must Have | LSP bridge infrastructure for TS/TSX — DONE infra; actual 'typed' edge production PENDING | 5.10 CBM Structural Parity Requirements (merged) |
 | **P1** | `FR-CL-MEGA-01` | FR | **DONE** | Must Have | Mega get_clusters serves precomputed cluster_id from DB | 5.15 |
-| **P1** | `FR-LSP-A` | FR | **DONE** | Must Have | LeanKG-native Hybrid LSP tier — an **in-process, no-spawn type resolver** for Go / TypeScr… | 5.13 LSP Adoption Track from CBM (moved from forme |
-| **P1** | `FR-LSP-B` | FR | **DONE** | Must Have | Prefab 'lsp:' block — 'leankg init --with-lsp' writes a default block listing 'gopls' / 't… | 5.13 LSP Adoption Track from CBM (moved from forme |
-| **P1** | `FR-LSP-C` | FR | **DONE** | Must Have | Wire 'resolve_with_lsp' results into the indexer — when 'typed_resolve=go,ts' (or 'all') i… | 5.13 LSP Adoption Track from CBM (moved from forme |
-| **P1** | `FR-LSP-D` | FR | **DONE** | Must Have | Cross-file type registry shared across files in the same project (mirror 'internal/cbm/lsp… | 5.13 LSP Adoption Track from CBM (moved from forme |
+| **P1** | `FR-LSP-A` | FR | **DONE** | Must Have | LeanKG-native Hybrid LSP tier — an **in-process, no-spawn type resolver** for Go / TypeScr… | 5.13 LSP Adoption Track from CBM (moved from former 5.12; de… |
+| **P1** | `FR-LSP-B` | FR | **DONE** | Must Have | Prefab 'lsp:' block — 'leankg init --with-lsp' writes a default block listing 'gopls' / 't… | 5.13 LSP Adoption Track from CBM (moved from former 5.12; de… |
+| **P1** | `FR-LSP-C` | FR | **DONE** | Must Have | Wire 'resolve_with_lsp' results into the indexer — when 'typed_resolve=go,ts' (or 'all') i… | 5.13 LSP Adoption Track from CBM (moved from former 5.12; de… |
+| **P1** | `FR-LSP-D` | FR | **DONE** | Must Have | Cross-file type registry shared across files in the same project (mirror 'internal/cbm/lsp… | 5.13 LSP Adoption Track from CBM (moved from former 5.12; de… |
 | **P1** | `FR-SURF-01` | FR | **DONE** | Must Have | Fix semantic_search schema: dual-path HNSW+rerank OR ontology-first (not ANN-only) | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
 | **P1** | `FR-SURF-02` | FR | **DONE** | Must Have | Prefer-order one-liners on concept_search / search_code / semantic_search / kg_semantic_co… | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
 | **P1** | `FR-SURF-03` | FR | **DONE** | Must Have | Delete mcp_hello, mcp_impact, get_doc_for_file; update redundant_tools_matrix.rs | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
@@ -384,6 +479,9 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P1** | `FR-UI2-05` | FR | **DONE** | Must Have | Preserve US-MG-03/04 filter defaults | 5.19 UI v2 |
 | **P1** | `FR-UI2-06` | FR | **DONE** | Must Have | decideSkipGraph mega-graph gate + Load anyway | 5.19 UI v2 |
 | **P1** | `FR-UI2-07` | FR | **DONE** | Must Have | Vitest + Playwright Phase-1 parity matrix | 5.19 UI v2 |
+| **P1** | `FR-UI2-12` | FR | **DONE** | Must Have | expandService replace-graph + CodePanel file gate + directory /api/file error | 5.19 UI v2 |
+| **P1** | `FR-UI2-13` | FR | **DONE** | Must Have | expand-service pagination + Load more merge (+200) into kg | 5.19 UI v2 |
+| **P1** | `FR-UI2-14` | FR | **DONE** | Must Have | Explore sidebar hierarchical Folders & files + session tree across Overview | 5.19 UI v2 |
 | **P1** | `REL-001` | Release | **DONE** | Must Have | Code indexing works for 10 languages | 8.1 MVP (v1.x) - COMPLETED |
 | **P1** | `REL-002` | Release | **DONE** | Must Have | Dependency graph builds correctly with 10 relationship types | 8.1 MVP (v1.x) - COMPLETED |
 | **P1** | `REL-003` | Release | **DONE** | Must Have | CLI commands functional (28+ commands) | 8.1 MVP (v1.x) - COMPLETED |
@@ -424,6 +522,8 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P1** | `REL-039` | Release | **DONE** | Must Have | Default LSP server bootstrap (FR-LSP-B / FR-B09 fanout — gopls + tsserver + pyright + dart… | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `REL-042` | Release | **DONE** | Must Have | US-GF-03 NL scoped subgraph ('query_graph') | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `REL-056` | Release | **DONE** | Must Have | ui-v2 GitNexus shell parity report | 5.19 UI v2 |
+| **P1** | `REL-060` | Release | **DONE** | Must Have | ui-v2 Service/Folder expand replace-graph + no /api/file 400 | 5.19 UI v2 |
+| **P1** | `REL-061` | Release | **DONE** | Must Have | ui-v2 expand Load more merge pagination + sidebar tree | 5.19 UI v2 |
 | **P1** | `US-01` | User Story | **DONE** | Must Have | Auto-index codebase so AI tools have accurate context | 3.1 Core MVP Stories (US-01 to US-18) |
 | **P1** | `US-02` | User Story | **DONE** | Must Have | Generate and update documentation automatically | 3.1 Core MVP Stories (US-01 to US-18) |
 | **P1** | `US-03` | User Story | **DONE** | Must Have | Map business logic to code for AI understanding | 3.1 Core MVP Stories (US-01 to US-18) |
@@ -441,62 +541,57 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P1** | `US-AB-01` | User Story | **DONE** | Must Have | OpenCode token parsing for benchmark comparison | 3.4 AB Testing Stories (US-AB-01 to US-AB-05) |
 | **P1** | `US-AB-02` | User Story | **DONE** | Must Have | Context correctness validation (precision/recall/F1) | 3.4 AB Testing Stories (US-AB-01 to US-AB-05) |
 | **P1** | `US-AB-03` | User Story | **DONE** | Must Have | CozoDB data store correctness tests | 3.4 AB Testing Stories (US-AB-01 to US-AB-05) |
-| **P1** | `US-CBM-A3` | User Story | **DONE** | Must Have | Default call-edge resolution on index for Go/TS | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-B1` | User Story | **DONE** | Must Have | Typed call resolution Go + TypeScript MVP ('resolution_method=typed') | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-B10` | User Story | **DONE** | Must Have | Feature flag 'typed_resolve=off\/go,ts\/all' | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-B11` | User Story | **DONE** | Must Have | Architecture/schema honor token budgets / truncation | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-B2` | User Story | **DONE** | Must Have | HTTP Route nodes + 'http_calls' edges (≥2 Go + ≥2 TS frameworks) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-B3` | User Story | **DONE** | Must Have | 'get_architecture' single-call overview | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-B4` | User Story | **DONE** | Must Have | 'get_graph_schema' label/edge counts | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-B9` | User Story | **DONE** | Must Have | Call 'resolution_method' + numeric 'confidence' on edges | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-C1` | User Story | **DONE** | Must Have | Docker image: embeddings / semantic tools OOTB (Cozo HNSW) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-D1` | User Story | **DONE** | Must Have | Skills remain LeanKG-first; optional CBM escape hatch only | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-CBM-D2` | User Story | **DONE** | Must Have | Do not auto-install CBM into default '.mcp.json' | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P1** | `US-GF-01` | User Story | **DONE** | Must Have | Shortest path between two symbols/concepts ('leankg path A B' + MCP 'shortest_path') | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-02` | User Story | **DONE** | Must Have | Explain a node: source location, community/cluster, degree, labeled neighbors | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-03` | User Story | **DONE** | Must Have | Natural-language scoped subgraph query ('query_graph "what connects auth to DB?"') | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GF-05` | User Story | **DONE** | Must Have | God-node / hub ranking exposed via CLI + MCP (top-degree concepts; exclude utility super-h… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P1** | `US-GN-01` | User Story | **DONE** | Must Have | Impact analysis with confidence scores and severity classifications | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P1** | `US-GN-02` | User Story | **DONE** | Must Have | Pre-commit 'detect_changes' tool | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P1** | `US-INF-01` | User Story | **DONE** | Must Have | Git pre-commit hook with critical file blocking | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
+| **P1** | `US-CBM-A3` | User Story | **DONE** | Must Have | Default call-edge resolution on index for Go/TS | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-B1` | User Story | **DONE** | Must Have | Typed call resolution Go + TypeScript MVP ('resolution_method=typed') | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-B10` | User Story | **DONE** | Must Have | Feature flag 'typed_resolve=off\/go,ts\/all' | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-B11` | User Story | **DONE** | Must Have | Architecture/schema honor token budgets / truncation | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-B2` | User Story | **DONE** | Must Have | HTTP Route nodes + 'http_calls' edges (≥2 Go + ≥2 TS frameworks) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-B3` | User Story | **DONE** | Must Have | 'get_architecture' single-call overview | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-B4` | User Story | **DONE** | Must Have | 'get_graph_schema' label/edge counts | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-B9` | User Story | **DONE** | Must Have | Call 'resolution_method' + numeric 'confidence' on edges | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-C1` | User Story | **DONE** | Must Have | Docker image: embeddings / semantic tools OOTB (Cozo HNSW) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-D1` | User Story | **DONE** | Must Have | Skills remain LeanKG-first; optional CBM escape hatch only | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-CBM-D2` | User Story | **DONE** | Must Have | Do not auto-install CBM into default '.mcp.json' | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P1** | `US-GF-01` | User Story | **DONE** | Must Have | Shortest path between two symbols/concepts ('leankg path A B' + MCP 'shortest_path') | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-GF-02` | User Story | **DONE** | Must Have | Explain a node: source location, community/cluster, degree, labeled neighbors | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-GF-03` | User Story | **DONE** | Must Have | Natural-language scoped subgraph query ('query_graph "what connects auth to DB?"') | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-GF-05` | User Story | **DONE** | Must Have | God-node / hub ranking exposed via CLI + MCP (top-degree concepts; exclude utility super-h… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `US-GN-01` | User Story | **DONE** | Must Have | Impact analysis with confidence scores and severity classifications | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P1** | `US-GN-02` | User Story | **DONE** | Must Have | Pre-commit 'detect_changes' tool | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P1** | `US-INF-01` | User Story | **DONE** | Must Have | Git pre-commit hook with critical file blocking | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
 | **P1** | `US-MG-01` | User Story | **DONE** | Must Have | Double-click Service node loads ALL elements and edges in one shot | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
 | **P1** | `US-MG-03` | User Story | **DONE** | Must Have | Filter UI always shows ALL node type toggles regardless of loaded data | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
 | **P1** | `US-MG-04` | User Story | **DONE** | Must Have | Default visible filters: Service, Folder, File, Function ON; rest OFF | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
 | **P1** | `US-MG-05` | User Story | **DONE** | Must Have | Expand-service API optimized: targeted DB query instead of full scan | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
-| **P1** | `US-MP-01` | User Story | **DONE** | Must Have | Temporal Knowledge Graph — relationships have valid_from/valid_to; historical queries ("wh… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P1** | `US-RTK-01` | User Story | **DONE** | Must Have | LeanKGCompressor for internal command compression | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P1** | `US-RTK-02` | User Story | **DONE** | Must Have | CargoTestCompressor with failures-only mode (85%+ savings) | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P1** | `US-RTK-03` | User Story | **DONE** | Must Have | GitDiffCompressor with stats extraction (70%+ savings) | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P1** | `US-RTK-05` | User Story | **DONE** | Must Have | 8 read modes: adaptive, full, map, signatures, diff, aggressive, entropy, lines | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P1** | `US-RTK-07` | User Story | **DONE** | Must Have | ResponseCompressor for MCP JSON responses | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P1** | `US-RTK-08` | User Story | **DONE** | Must Have | Compress impact_radius, call_graph, search_code responses | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P1** | `US-SURF-01` | User Story | **DONE** | Must Have | Agents know which search/semantic tool to call first (prefer-order in schemas) | 3.16 MCP Tool Surface Rationalization (US-SURF) —  |
-| **P1** | `US-SURF-02` | User Story | **DONE** | Must Have | Remove zero-value / superseded MCP tools (mcp_hello, mcp_impact, get_doc_for_file) | 3.16 MCP Tool Surface Rationalization (US-SURF) —  |
+| **P1** | `US-MP-01` | User Story | **DONE** | Must Have | Temporal Knowledge Graph — relationships have valid_from/valid_to; historical queries ("wh… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P1** | `US-RTK-01` | User Story | **DONE** | Must Have | LeanKGCompressor for internal command compression | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P1** | `US-RTK-02` | User Story | **DONE** | Must Have | CargoTestCompressor with failures-only mode (85%+ savings) | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P1** | `US-RTK-03` | User Story | **DONE** | Must Have | GitDiffCompressor with stats extraction (70%+ savings) | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P1** | `US-RTK-05` | User Story | **DONE** | Must Have | 8 read modes: adaptive, full, map, signatures, diff, aggressive, entropy, lines | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P1** | `US-RTK-07` | User Story | **DONE** | Must Have | ResponseCompressor for MCP JSON responses | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P1** | `US-RTK-08` | User Story | **DONE** | Must Have | Compress impact_radius, call_graph, search_code responses | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P1** | `US-SURF-01` | User Story | **DONE** | Must Have | Agents know which search/semantic tool to call first (prefer-order in schemas) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
+| **P1** | `US-SURF-02` | User Story | **DONE** | Must Have | Remove zero-value / superseded MCP tools (mcp_hello, mcp_impact, get_doc_for_file) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
 | **P1** | `US-TOON-01` | User Story | **DONE** | Must Have | MCP tool responses use TOON format for ~40% token reduction vs JSON | 3.9 TOON Format Stories (US-TOON-01) |
 | **P1** | `US-UI2-01` | User Story | **DONE** | Must Have | Explore graph in Force/Tree/Circles via ui-v2 + leankg serve | 3.17 UI v2 |
 | **P1** | `US-UI2-02` | User Story | **DONE** | Must Have | File tree + type/edge filters (US-MG-04 defaults) | 3.17 UI v2 |
 | **P1** | `US-UI2-03` | User Story | **DONE** | Must Have | Node select opens /api/file code panel | 3.17 UI v2 |
 | **P1** | `US-UI2-04` | User Story | **DONE** | Must Have | Server search + QueryFAB /api/query | 3.17 UI v2 |
 | **P1** | `US-UI2-05` | User Story | **DONE** | Must Have | Mega-graph skip + Load graph anyway | 3.17 UI v2 |
-| **P1** | `US-UI2-10` | User Story | **DONE** | Must Have | Double-click Service/Folder replace-graph expand | 3.17 UI v2 |
-| **P1** | `US-UI2-11` | User Story | **DONE** | Must Have | Load more (+200) merges expand pages into current graph | 3.17 UI v2 |
-| **P1** | `US-UI2-12` | User Story | **DONE** | Must Have | Hierarchical Folders & files sidebar + session tree | 3.17 UI v2 |
-| **P1** | `FR-UI2-12` | FR | **DONE** | Must Have | expandService replace-graph + CodePanel file gate | 5.19 UI v2 |
-| **P1** | `FR-UI2-13` | FR | **DONE** | Must Have | expand pagination + Load more merge (+200) | 5.19 UI v2 |
-| **P1** | `FR-UI2-14` | FR | **DONE** | Must Have | Explore sidebar hierarchical Folders & files | 5.19 UI v2 |
-| **P1** | `REL-060` | Release | **DONE** | Must Have | Service/Folder expand replace-graph + no /api/file 400 | 5.19 UI v2 |
-| **P1** | `REL-061` | Release | **DONE** | Must Have | expand Load more merge pagination + sidebar tree | 5.19 UI v2 |
-| **P1** | `US-V2-01` | User Story | **DONE** | Must Have | Environment namespacing ('local' / 'staging' / 'production' / 'upcoming') on nodes/edges; … | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P1** | `US-V2-02` | User Story | **DONE** | Must Have | Incident knowledge layer — contribute/query incidents linked to services | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P1** | `US-V2-03` | User Story | **DONE** | Must Have | Enhanced service context (deps, incidents, env) in one MCP call | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P1** | `US-V2-04` | User Story | **DONE** | Must Have | Surface environment conflicts before promote/push | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P1** | `US-V2-05` | User Story | **DONE** | Must Have | Team/knowledge contribution via MCP ('add_knowledge', annotations) | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P1** | `US-V2-07` | User Story | **DONE** | Must Have | Token budget enforcement on MCP responses | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P1** | `US-V2-10` | User Story | **DONE** | Must Have | Multi-repo / shared RocksDB HTTP backend for teams | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
+| **P1** | `US-UI2-10` | User Story | **DONE** | Must Have | Double-click Service/Folder replaces canvas with expand-service subgraph | 3.17 UI v2 |
+| **P1** | `US-UI2-11` | User Story | **DONE** | Must Have | Load more expand pages merge into current graph (500 then +200) | 3.17 UI v2 |
+| **P1** | `US-UI2-12` | User Story | **DONE** | Must Have | Explore sidebar hierarchical Folders & files with session retention | 3.17 UI v2 |
+| **P1** | `US-V2-01` | User Story | **DONE** | Must Have | Environment namespacing ('local' / 'staging' / 'production' / 'upcoming') on nodes/edges; … | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P1** | `US-V2-02` | User Story | **DONE** | Must Have | Incident knowledge layer — contribute/query incidents linked to services | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P1** | `US-V2-03` | User Story | **DONE** | Must Have | Enhanced service context (deps, incidents, env) in one MCP call | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P1** | `US-V2-04` | User Story | **DONE** | Must Have | Surface environment conflicts before promote/push | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P1** | `US-V2-05` | User Story | **DONE** | Must Have | Team/knowledge contribution via MCP ('add_knowledge', annotations) | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P1** | `US-V2-07` | User Story | **DONE** | Must Have | Token budget enforcement on MCP responses | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P1** | `US-V2-10` | User Story | **DONE** | Must Have | Multi-repo / shared RocksDB HTTP backend for teams | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
 | **P1** | `US-SEM-05` | User Story | **DONE** | Must Have | Exclude UI-bundle / benchmark noise from semantic seeds (embed/assets + src/benchmark gate… | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) |
 | **P1** | `FR-SEM-06` | FR | **DONE** | Must Have | Path filter: always drop embed/assets/; query-gate src/benchmark/ unless query contains be… | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
-| **P1** | `FR-MG-AUTO-01` | FR | **DONE** | Must Have | LEANKG_SKIP_FRESHNESS_CHECK=1 skips MCP auto-index; document mega-graph 6g/3g/cpus6 + AUTO… | 5.17 Mega-graph MCP auto-index + embed ops (v3.7.3 |
-| **P1** | `FR-OPS-EMBED-CPU` | FR | **DONE** | Must Have | Compose envelope: cpus 6, mem_reservation 3g; MCP mem_limit 6g; embed mem_limit 10g | 5.17 Mega-graph MCP auto-index + embed ops (v3.7.3 |
+| **P1** | `FR-MG-AUTO-01` | FR | **DONE** | Must Have | LEANKG_SKIP_FRESHNESS_CHECK=1 skips MCP auto-index; document mega-graph 6g/3g/cpus6 + AUTO… | 5.17 Mega-graph MCP auto-index + embed ops (v3.7.3) |
+| **P1** | `FR-OPS-EMBED-CPU` | FR | **DONE** | Must Have | Compose envelope: cpus 6, mem_reservation 3g; MCP mem_limit 6g; embed mem_limit 10g | 5.17 Mega-graph MCP auto-index + embed ops (v3.7.3) |
 | **P2** | `FR-01 to FR-07` | FR | **DONE** | Should Have | Code Indexing and Dependency Graph | 5.1 Core Features (DONE) |
 | **P2** | `FR-08 to FR-12` | FR | **DONE** | Should Have | Auto Documentation Generation | 5.1 Core Features (DONE) |
 | **P2** | `FR-13 to FR-16` | FR | **DONE** | Should Have | Business Logic to Code Mapping | 5.1 Core Features (DONE) |
@@ -536,15 +631,15 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P2** | `FR-B31` | FR | **DONE** | Should Have | 'find_clones' MCP + 'leankg clones' CLI ('55e6e72') — same-file Jaccard only after FR-HNSW… | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B32` | FR | **DONE** | Should Have | Cross-repo edges across registry ('ab16c9b') | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-B33` | FR | **DONE** | Should Have | Cross-repo summary in tool or architecture ('ab16c9b', surfaced via 'find_cross_repo_simil… | 5.10 CBM Structural Parity Requirements (merged) |
-| **P2** | `FR-BENCH-HNSW` | FR | **DONE** | Should Have | Semantic recall smoke — 'tests/hnsw_recall_e2e.rs' (synthetic 384-d vectors + brute-force … | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
+| **P2** | `FR-BENCH-HNSW` | FR | **DONE** | Should Have | Semantic recall smoke — 'tests/hnsw_recall_e2e.rs' (synthetic 384-d vectors + brute-force … | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
 | **P2** | `FR-C01` | FR | **DONE** | Should Have | Docker embeddings OOTB (Must — alias FR-HNSW-C; Dockerfiles '--features embeddings' + 'ent… | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-C03` | FR | **DONE** | Should Have | Hot-path cache — DONE ('836f0a3') | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-D01` | FR | **DONE** | Should Have | Skills remain LeanKG-first | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-D02` | FR | **DONE** | Should Have | Documented CBM escape hatch when confidence low / lang unsupported (Should — documented as… | 5.10 CBM Structural Parity Requirements (merged) |
 | **P2** | `FR-D03` | FR | **DONE** | Should Have | No auto-install CBM into default '.mcp.json' | 5.10 CBM Structural Parity Requirements (merged) |
-| **P2** | `FR-EMBED-R1` | FR | **DONE** | Should Have | MCP / Docker boot must not wait on cold embed. 'LEANKG_EMBED_ON_BOOT=0'; in-process backgr… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P2** | `FR-EMBED-R2` | FR | **DONE** | Should Have | Parallel embed pipeline — N ONNX workers + single writer; 'import_relations' bulk path; op… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P2** | `FR-EMBED-R3` | FR | **DONE** | Should Have | Document measured ceilings — e2e ~170 vec/sec / ~36 min cold on ~371k; writer-only ~100k+ … | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
+| **P2** | `FR-EMBED-R1` | FR | **DONE** | Should Have | MCP / Docker boot must not wait on cold embed. 'LEANKG_EMBED_ON_BOOT=0'; in-process backgr… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P2** | `FR-EMBED-R2` | FR | **DONE** | Should Have | Parallel embed pipeline — N ONNX workers + single writer; 'import_relations' bulk path; op… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P2** | `FR-EMBED-R3` | FR | **DONE** | Should Have | Document measured ceilings — e2e ~170 vec/sec / ~36 min cold on ~371k; writer-only ~100k+ … | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
 | **P2** | `FR-GF-01` | FR | **DONE** | Should Have | MCP tool 'shortest_path(source, target, max_hops?)' returns ordered hops with relation + '… | 5.9 Graphify-Inspired Features |
 | **P2** | `FR-GF-02` | FR | **DONE** | Should Have | CLI 'leankg path <a> <b>' wrapping FR-GF-01 | 5.9 Graphify-Inspired Features |
 | **P2** | `FR-GF-03` | FR | **DONE** | Should Have | MCP tool 'explain_node(name_or_qn)' — definition, cluster, degree, neighbors | 5.9 Graphify-Inspired Features |
@@ -563,10 +658,10 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P2** | `FR-GN-08 to FR-GN-12` | FR | **DONE** | Should Have | Multi-Repo Global Registry | 5.2 GitNexus Enhancements (DONE) |
 | **P2** | `FR-GN-13 to FR-GN-17` | FR | **DONE** | Should Have | Community Detection and Cluster-Grouped Search | 5.2 GitNexus Enhancements (DONE) |
 | **P2** | `FR-GN-18 to FR-GN-19` | FR | **DONE** | Should Have | Enhanced 360-Degree Context Tool | 5.2 GitNexus Enhancements (DONE) |
-| **P2** | `FR-HNSW-B` | FR | **DONE** | Should Have | Sole **canonical shipped** ANN path (until FR-VE-GATE) = Cozo '::hnsw' on 'embedding_vecto… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P2** | `FR-HNSW-C` | FR | **DONE** | Should Have | (= FR-C01 / US-CBM-C1): Docker / RocksDB image builds with '--features embeddings'. Prefer… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P2** | `FR-HNSW-D` | FR | **DONE** | Should Have | Default agent discovery path — NL query → embed → HNSW top-k → optional rerank → graph tra… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P2** | `FR-HNSW-F` | FR | **DONE** | Should Have | Mega-graph HNSW ops — expose/document 'ef' / 'm' / page 'limit'+'offset'; keep RSS under e… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
+| **P2** | `FR-HNSW-B` | FR | **DONE** | Should Have | Sole **canonical shipped** ANN path (until FR-VE-GATE) = Cozo '::hnsw' on 'embedding_vecto… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P2** | `FR-HNSW-C` | FR | **DONE** | Should Have | (= FR-C01 / US-CBM-C1): Docker / RocksDB image builds with '--features embeddings'. Prefer… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P2** | `FR-HNSW-D` | FR | **DONE** | Should Have | Default agent discovery path — NL query → embed → HNSW top-k → optional rerank → graph tra… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P2** | `FR-HNSW-F` | FR | **DONE** | Should Have | Mega-graph HNSW ops — expose/document 'ef' / 'm' / page 'limit'+'offset'; keep RSS under e… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
 | **P2** | `FR-INF-01` | FR | **DONE** | Should Have | Git pre-commit hook with critical file blocking | 5.5 Infrastructure Features (DONE) |
 | **P2** | `FR-INF-02` | FR | **DONE** | Should Have | Git post-commit hook triggers 'leankg index --incremental' | 5.5 Infrastructure Features (DONE) |
 | **P2** | `FR-INF-03` | FR | **DONE** | Should Have | Git post-checkout hook triggers reindex on branch switch | 5.5 Infrastructure Features (DONE) |
@@ -613,19 +708,19 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P2** | `FR-SEM-04` | FR | **DONE** | Should Have | Formal live MCP semantic smoke checklist (Docker project=/workspace) as release complement… | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P2** | `FR-SURF-04` | FR | **DONE** | Should Have | Soft-deprecate wake_up → get_overview_context (not load_layer L0 alone) | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
 | **P2** | `FR-SURF-05` | FR | **DONE** | Should Have | Soft-deprecate search_by_environment; point to env= on primary search/kg tools | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
-| **P2** | `FR-UPD-01` | FR | **DONE** | Should Have | 'leankg update' from GitHub releases | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-01` | FR | **DONE** | Should Have | 'env' field on elements/relationships; default 'local' | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-02` | FR | **DONE** | Should Have | Incident data model + CLI/MCP contribute & query | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-03` | FR | **DONE** | Should Have | 'get_service_context' with env + incident summary | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-04` | FR | **DONE** | Should Have | 'find_env_conflicts' with risk levels | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-05` | FR | **DONE** | Should Have | Knowledge contribution ('add_knowledge' / annotations) | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-06` | FR | **DONE** | Should Have | 'semantic_search' (embeddings feature-flagged) | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-07` | FR | **DONE** | Should Have | Per-tool token budgets / TOON compression | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-08` | FR | **DONE** | Should Have | Vacuum scheduler ('LEANKG_VACUUM_INTERVAL_HOURS'; RocksDB no-op) | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-09` | FR | **DONE** | Should Have | 'kg_self_test' MCP + HTTP startup WARN (non-gating) | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-10` | FR | **DONE** | Should Have | Multi-project RocksDB HTTP deploy + registry | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-11` | FR | **DONE** | Should Have | CI/CD auto-graph update on release (< 3 min freshness) — GitHub Actions workflow ('eb3d331… | 5.11 Team Infrastructure / v2 Requirements (merged |
-| **P2** | `FR-V2-12` | FR | **DONE** | Should Have | 'get_team_map' ownership/on-call tool ('3368b5f') | 5.11 Team Infrastructure / v2 Requirements (merged |
+| **P2** | `FR-UPD-01` | FR | **DONE** | Should Have | 'leankg update' from GitHub releases | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-01` | FR | **DONE** | Should Have | 'env' field on elements/relationships; default 'local' | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-02` | FR | **DONE** | Should Have | Incident data model + CLI/MCP contribute & query | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-03` | FR | **DONE** | Should Have | 'get_service_context' with env + incident summary | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-04` | FR | **DONE** | Should Have | 'find_env_conflicts' with risk levels | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-05` | FR | **DONE** | Should Have | Knowledge contribution ('add_knowledge' / annotations) | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-06` | FR | **DONE** | Should Have | 'semantic_search' (embeddings feature-flagged) | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-07` | FR | **DONE** | Should Have | Per-tool token budgets / TOON compression | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-08` | FR | **DONE** | Should Have | Vacuum scheduler ('LEANKG_VACUUM_INTERVAL_HOURS'; RocksDB no-op) | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-09` | FR | **DONE** | Should Have | 'kg_self_test' MCP + HTTP startup WARN (non-gating) | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-10` | FR | **DONE** | Should Have | Multi-project RocksDB HTTP deploy + registry | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-11` | FR | **DONE** | Should Have | CI/CD auto-graph update on release (< 3 min freshness) — GitHub Actions workflow ('eb3d331… | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
+| **P2** | `FR-V2-12` | FR | **DONE** | Should Have | 'get_team_map' ownership/on-call tool ('3368b5f') | 5.11 Team Infrastructure / v2 Requirements (merged from 'prd… |
 | **P2** | `REL-051` | Release | **DONE** | Should Have | Live semantic MCP smoke executed (or waived with reason) alongside embeddings cargo suite | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P2** | `REL-053` | Release | **DONE** | Should Have | Release note: MCP tool surface shrink after FR-SURF-03 (list_tools before/after) | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
 | **P2** | `US-07` | User Story | **DONE** | Should Have | Lightweight Web UI for graph visualization | 3.1 Core MVP Stories (US-01 to US-18) |
@@ -642,57 +737,46 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 | **P2** | `US-27` | User Story | **DONE** | Should Have | MCP tool definition quality improvements | 3.2 v2.0 Enhancement Stories (US-19 to US-27) |
 | **P2** | `US-AB-04` | User Story | **DONE** | Should Have | Token savings summary report with overall verdict | 3.4 AB Testing Stories (US-AB-01 to US-AB-05) |
 | **P2** | `US-AB-05` | User Story | **DONE** | Should Have | Prompt YAML format with 'expected_files' field for ground truth | 3.4 AB Testing Stories (US-AB-01 to US-AB-05) |
-| **P2** | `US-CBM-B5` | User Story | **DONE** | Should Have | Dead code detection ('find_dead_code') | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-B6` | User Story | **DONE** | Should Have | Event channel edges (EMITS / LISTENS_ON) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-B8` | User Story | **DONE** | Should Have | Cross-repo edges on multi-repo registry | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-CBM-C2` | User Story | **DONE** | Should Have | Query hot-path cache (search/schema/architecture/find_function) | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P2** | `US-GF-07` | User Story | **DONE** | Should Have | Extract rationale nodes from '# WHY:' / '# NOTE:' / '# HACK:' / '# FIXME:' / '# XXX:' comm… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-GF-08` | User Story | **DONE** | Should Have | PR impact dashboard: graph-aware PR review, community overlap / merge-order risk | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-GF-09` | User Story | **DONE** | Should Have | Work-memory reflect loop: record Q&A outcomes; aggregate lessons that bias future query ra… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P2** | `US-GN-03` | User Story | **DONE** | Should Have | Multi-repo global registry | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P2** | `US-GN-04` | User Story | **DONE** | Should Have | Cluster-grouped search results | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P2** | `US-GN-05` | User Story | **DONE** | Should Have | Auto-detect functional clusters | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P2** | `US-GN-06` | User Story | **DONE** | Should Have | 360-degree context view in single tool call | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P2** | `US-INF-02` | User Story | **DONE** | Should Have | Git post-commit hook with auto-incremental reindex | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-INF-03` | User Story | **DONE** | Should Have | Git post-checkout hook with branch-switch reindex | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-INF-04` | User Story | **DONE** | Should Have | GitWatcher for continuous index freshness | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-INF-05` | User Story | **DONE** | Should Have | Context metrics tracking with schema (18 fields) | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-INF-06` | User Story | **DONE** | Should Have | REST API server with health/status/search endpoints | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-INF-07` | User Story | **DONE** | Should Have | API key management with Argon2 hashing | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-INF-09` | User Story | **DONE** | Should Have | Graph export to HTML, SVG, GraphML, Neo4j formats | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-INF-10` | User Story | **DONE** | Should Have | Smart orchestrator with intent parsing and persistent cache | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P2** | `US-LANG-01` | User Story | **DONE** | Should Have | Dart parser (tree-sitter-dart) with getter/setter/enum extraction | 3.7 Additional Language Stories (US-LANG-01 to US- |
-| **P2** | `US-MP-04` | User Story | **DONE** | Should Have | Specialist Agent Contexts — define agent personas (reviewer, architect, ops) each with a f… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P2** | `US-MP-05` | User Story | **DONE** | Should Have | Contradiction & Staleness Detection — detect when stored context contradicts current code … | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P2** | `US-MP-07` | User Story | **DONE** | Should Have | Wake-up Context Protocol — standardized 'wake_up' MCP tool that loads ~170 tokens of criti… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P2** | `US-RTK-04` | User Story | **DONE** | Should Have | ShellCompressor extended with leankg-specific patterns | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P2** | `US-RTK-06` | User Story | **DONE** | Should Have | Entropy analysis (Shannon, Jaccard, Kolmogorov) | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P2** | `US-RTK-09` | User Story | **DONE** | Should Have | 'compress_response' parameter on graph tools | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P2** | `US-RTK-10` | User Story | **DONE** | Should Have | '--compress' CLI flag for shell command output | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-1 |
-| **P2** | `US-SURF-03` | User Story | **DONE** | Should Have | Soft-deprecate wake_up in favor of get_overview_context (not load_layer L0 alone) | 3.16 MCP Tool Surface Rationalization (US-SURF) —  |
-| **P2** | `US-SURF-04` | User Story | **DONE** | Should Have | Soft-deprecate search_by_environment (use env= on primary search/kg tools) | 3.16 MCP Tool Surface Rationalization (US-SURF) —  |
-| **P2** | `US-UPD-01` | User Story | **DONE** | Should Have | 'leankg update' installs latest GitHub release binary | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P2** | `US-V2-06` | User Story | **DONE** | Should Have | Semantic search natural language → graph nodes | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P2** | `US-V2-08` | User Story | **DONE** | Should Have | Scheduled DB vacuum on long-lived MCP servers | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P2** | `US-V2-09` | User Story | **DONE** | Should Have | Ontology 'kg_self_test' + HTTP startup self-test WARN | 3.12 Team Knowledge Infrastructure (US-V2) — merge |
-| **P3** | `US-CBM-B7` | User Story | **DONE** | Could Have | Clone / near-duplicate detection ('find_clones', 'similar_to') | 3.11 CBM Structural Parity Stories (US-CBM) — merg |
-| **P3** | `US-GF-11` | User Story | **DONE** | Could Have | Portable graph snapshot export + optional git merge driver for team-committed graph artifa… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF- |
-| **P3** | `US-GN-07` | User Story | **DONE** | Could Have | Cluster-level SKILL.md generation | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P3** | `US-GN-09` | User Story | **DONE** | Could Have | Repository wiki generation | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-G |
-| **P3** | `US-INF-08` | User Story | **DONE** | Could Have | Wiki generation from code structure | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10 |
-| **P3** | `US-LANG-03` | User Story | **DONE** | Could Have | XML parser (tree-sitter-xml) with child-elements + attributes | 3.7 Additional Language Stories (US-LANG-01 to US- |
-| **P3** | `US-MP-06` | User Story | **DONE** | Could Have | Cross-Domain Tunnels — auto-link clusters across projects/modules that share the same doma… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP- |
-| **P2** | `FR-BENCH-A` | FR | **WONT_DO** | Should Have | CBM clone quality head-to-head — **Won't Do** (v3.6.2) | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P2** | `FR-HNSW-A` | FR | **WONT_DO** | Should Have | Remove custom MinHash/LSH — delete 'src/minhash.rs', drop 'mod minhash' from 'lib.rs' / 'm… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-| **P2** | `FR-LSH-A..F` | FR | **WONT_DO** | Should Have | AST MinHash / bucket guards / signature K env — **Won't Do** (v3.6.2) | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) |
-
----
-
-## Sync notes
-
-- **2026-07-21 v3.7.9 DONE:** P0 procedural ontology auto-update closed — evidence [`reports/ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-smoke-2026-07-21.md). Company adoption is **P1 CURRENT**.
-- **2026-07-21 v3.7.9-ont-proc-auto:** Introduced P0 ONT-PROC tasks.
-- **2026-07-21 v3.7.8-graphify-ui:** Company ROI + Graphify packaging backlog.
-- Machine mirror: [`prd-task-tracker.json`](prd-task-tracker.json).
-
-*Regenerated: 2026-07-21 — v3.7.9-ont-proc-auto DONE.*
+| **P2** | `US-CBM-B5` | User Story | **DONE** | Should Have | Dead code detection ('find_dead_code') | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-B6` | User Story | **DONE** | Should Have | Event channel edges (EMITS / LISTENS_ON) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-B8` | User Story | **DONE** | Should Have | Cross-repo edges on multi-repo registry | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-CBM-C2` | User Story | **DONE** | Should Have | Query hot-path cache (search/schema/architecture/find_function) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P2** | `US-GF-07` | User Story | **DONE** | Should Have | Extract rationale nodes from '# WHY:' / '# NOTE:' / '# HACK:' / '# FIXME:' / '# XXX:' comm… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P2** | `US-GF-08` | User Story | **DONE** | Should Have | PR impact dashboard: graph-aware PR review, community overlap / merge-order risk | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P2** | `US-GF-09` | User Story | **DONE** | Should Have | Work-memory reflect loop: record Q&A outcomes; aggregate lessons that bias future query ra… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P2** | `US-GN-03` | User Story | **DONE** | Should Have | Multi-repo global registry | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P2** | `US-GN-04` | User Story | **DONE** | Should Have | Cluster-grouped search results | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P2** | `US-GN-05` | User Story | **DONE** | Should Have | Auto-detect functional clusters | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P2** | `US-GN-06` | User Story | **DONE** | Should Have | 360-degree context view in single tool call | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P2** | `US-INF-02` | User Story | **DONE** | Should Have | Git post-commit hook with auto-incremental reindex | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-INF-03` | User Story | **DONE** | Should Have | Git post-checkout hook with branch-switch reindex | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-INF-04` | User Story | **DONE** | Should Have | GitWatcher for continuous index freshness | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-INF-05` | User Story | **DONE** | Should Have | Context metrics tracking with schema (18 fields) | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-INF-06` | User Story | **DONE** | Should Have | REST API server with health/status/search endpoints | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-INF-07` | User Story | **DONE** | Should Have | API key management with Argon2 hashing | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-INF-09` | User Story | **DONE** | Should Have | Graph export to HTML, SVG, GraphML, Neo4j formats | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-INF-10` | User Story | **DONE** | Should Have | Smart orchestrator with intent parsing and persistent cache | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P2** | `US-LANG-01` | User Story | **DONE** | Should Have | Dart parser (tree-sitter-dart) with getter/setter/enum extraction | 3.7 Additional Language Stories (US-LANG-01 to US-LANG-03) |
+| **P2** | `US-MP-04` | User Story | **DONE** | Should Have | Specialist Agent Contexts — define agent personas (reviewer, architect, ops) each with a f… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `US-MP-05` | User Story | **DONE** | Should Have | Contradiction & Staleness Detection — detect when stored context contradicts current code … | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `US-MP-07` | User Story | **DONE** | Should Have | Wake-up Context Protocol — standardized 'wake_up' MCP tool that loads ~170 tokens of criti… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `US-RTK-04` | User Story | **DONE** | Should Have | ShellCompressor extended with leankg-specific patterns | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P2** | `US-RTK-06` | User Story | **DONE** | Should Have | Entropy analysis (Shannon, Jaccard, Kolmogorov) | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P2** | `US-RTK-09` | User Story | **DONE** | Should Have | 'compress_response' parameter on graph tools | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P2** | `US-RTK-10` | User Story | **DONE** | Should Have | '--compress' CLI flag for shell command output | 3.5 RTK Compression Stories (US-RTK-01 to US-RTK-15) |
+| **P2** | `US-SURF-03` | User Story | **DONE** | Should Have | Soft-deprecate wake_up in favor of get_overview_context (not load_layer L0 alone) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
+| **P2** | `US-SURF-04` | User Story | **DONE** | Should Have | Soft-deprecate search_by_environment (use env= on primary search/kg tools) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
+| **P2** | `US-UPD-01` | User Story | **DONE** | Should Have | 'leankg update' installs latest GitHub release binary | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P2** | `US-V2-06` | User Story | **DONE** | Should Have | Semantic search natural language → graph nodes | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P2** | `US-V2-08` | User Story | **DONE** | Should Have | Scheduled DB vacuum on long-lived MCP servers | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P2** | `US-V2-09` | User Story | **DONE** | Should Have | Ontology 'kg_self_test' + HTTP startup self-test WARN | 3.12 Team Knowledge Infrastructure (US-V2) — merged from 'pr… |
+| **P3** | `US-CBM-B7` | User Story | **DONE** | Could Have | Clone / near-duplicate detection ('find_clones', 'similar_to') | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
+| **P3** | `US-GF-11` | User Story | **DONE** | Could Have | Portable graph snapshot export + optional git merge driver for team-committed graph artifa… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P3** | `US-GN-07` | User Story | **DONE** | Could Have | Cluster-level SKILL.md generation | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P3** | `US-GN-09` | User Story | **DONE** | Could Have | Repository wiki generation | 3.3 GitNexus Enhancement Stories (US-GN-01 to US-GN-09) |
+| **P3** | `US-INF-08` | User Story | **DONE** | Could Have | Wiki generation from code structure | 3.6 Infrastructure Stories (US-INF-01 to US-INF-10) |
+| **P3** | `US-LANG-03` | User Story | **DONE** | Could Have | XML parser (tree-sitter-xml) with child-elements + attributes | 3.7 Additional Language Stories (US-LANG-01 to US-LANG-03) |
+| **P3** | `US-MP-06` | User Story | **DONE** | Could Have | Cross-Domain Tunnels — auto-link clusters across projects/modules that share the same doma… | 3.9 MemPalace-Inspired Stories (US-MP-01 to US-MP-08) |
+| **P2** | `FR-BENCH-A` | FR | **WONT_DO** | Should Have | CBM clone quality head-to-head — **Won't Do** (v3.6.2) | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P2** | `FR-HNSW-A` | FR | **WONT_DO** | Should Have | Remove custom MinHash/LSH — delete 'src/minhash.rs', drop 'mod minhash' from 'lib.rs' / 'm… | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |
+| **P2** | `FR-LSH-A..F` | FR | **WONT_DO** | Should Have | AST MinHash / bucket guards / signature K env — **Won't Do** (v3.6.2) | 5.12 Semantic ANN — CozoDB HNSW expansion (v3.6.2) + embed r… |

--- a/docs/reports/rel-062-mcp-surf-hard-delete-2026-07-21.md
+++ b/docs/reports/rel-062-mcp-surf-hard-delete-2026-07-21.md
@@ -1,0 +1,66 @@
+# REL-062: MCP Wave 1a hard-delete evidence
+
+**Date:** 2026-07-21  
+**Branch:** `feature/mcp-surf-hard-delete`  
+**Tracker:** `US-SURF-06`, `US-SURF-07`, `FR-SURF-07`..`FR-SURF-11`, `REL-062`
+
+## Summary
+
+Hard-deleted MCP tools `wake_up` and `search_by_environment` from `ToolRegistry` and handlers. Kept internal `GraphEngine::wake_up_summary()` for `get_overview_context`. Synced agent-facing docs, install hooks, smoke lists, and plugin manifests to the reduced prefer-order.
+
+## `tools/list` delta
+
+| Surface | Count | `wake_up` | `search_by_environment` | `get_overview_context` |
+|---------|------:|-----------|-------------------------|------------------------|
+| Docker MCP `:9699` (pre-redeploy, 2026-07-21) | 84 | present | present | present |
+| Worktree binary `mcp-http :9700` (post-change) | 82 | **absent** | **absent** | present |
+
+Delta: **−2** registered tools. Docker `:9699` requires image/binary redeploy to pick up the new registry.
+
+## Live checks (worktree `target/release/leankg mcp-http --port 9700`)
+
+```text
+tools/list → wake_up ABSENT, search_by_environment ABSENT, get_overview_context OK
+tools/call wake_up → unknown-tool / error (not in registry)
+tools/call get_overview_context → success
+```
+
+## Unit / matrix tests
+
+```bash
+cargo test --release --test redundant_tools_matrix
+cargo test --release --test redundant_tools_matrix --features embeddings
+cargo test --release --test mcp_tools_redundancy_tests
+cargo test --release -p leankg --lib mcp::tools
+```
+
+All green in worktree on 2026-07-21.
+
+## Grep-clean agent surfaces (preferred refs)
+
+Checked paths from Wave 1a plan; only **hard-removed** list mentions remain:
+
+```bash
+rg -n 'wake_up|search_by_environment|mcp_hello|mcp_impact|get_doc_for_file|find_clones' \
+  AGENTS.md CLAUDE.md docs/mcp-tools.md docs/agentic-instructions.md \
+  instructions/using-leankg scripts/install.sh scripts/mcp-smoke-tools.py \
+  .cursor-plugin .opencode .claude-plugin
+```
+
+No preferred-call guidance for deleted tools outside explicit forbidden / hard-removed sections.
+
+## Prefer-order (canonical post–Wave 1a)
+
+| Chain | Tools |
+|-------|-------|
+| Overview | `get_overview_context` → optional `load_layer` → `get_architecture` |
+| Search | `concept_search` → `semantic_search` → `search_code` |
+| Env | `env=` on search / `kg_*` |
+| File context | `get_context` |
+
+**Hard-removed set:** `mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`
+
+## Smoke / install
+
+- `scripts/mcp-smoke-tools.py`: removed `wake_up` from `MUTATING`, `search_by_environment` from `MEGA_GRAPH_HEAVY`
+- `scripts/install.sh`: `forbidden_actions` + prefer-order hooks updated (overview + `env=`)

--- a/instructions/using-leankg/SKILL.md
+++ b/instructions/using-leankg/SKILL.md
@@ -39,6 +39,13 @@ Do **not** pass a Mac host path (e.g. `/Users/.../leankg`) as `project` against 
 
 ### Prefer-order (discover → exact)
 
+**Session start (overview):**
+```
+get_overview_context(project=…)  # L0+L1 summary — not load_layer(L0) alone
+→ optional load_layer for progressive budgets
+→ get_architecture for deep single-call overview
+```
+
 Natural-language / domain questions:
 
 ```
@@ -76,6 +83,12 @@ mcp_status → find_function / query_file → get_context → impact/deps tools
 | Imports / dependents | `get_dependencies` / `get_dependents` |
 | Tests | `get_tested_by` |
 | NL subgraph | `query_graph` (frontier-local; mega-safe) |
+| Session overview | `get_overview_context` |
+| Environment filter | `env=` on `search_code` / `semantic_search` / `concept_search` / `kg_*` |
+
+### Hard-removed tools (do not call)
+
+`mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`
 
 ### If mcp_status is not ready (but HTTP health was OK)
 

--- a/leankg-bootstrap.md
+++ b/leankg-bootstrap.md
@@ -21,7 +21,8 @@ LeanKG provides these MCP tools for codebase navigation and analysis:
 | `get_call_graph` | Get function call chains |
 | `find_large_functions` | Find oversized functions |
 | `get_tested_by` | Get test coverage for a function/file |
-| `get_doc_for_file` | Get documentation for a file |
+| `get_overview_context` | Session-start L0+L1 overview |
+| `find_related_docs` | Find documentation related to a code change |
 | `get_traceability` | Get full traceability chain |
 | `get_code_tree` | Get codebase structure |
 | `get_doc_tree` | Get documentation tree |

--- a/ontology/workflows.yaml
+++ b/ontology/workflows.yaml
@@ -431,8 +431,8 @@ workflows:
       - id: tag_environment
         name: Tag with Environment
         code_refs:
-          - src/mcp/handler.rs::search_by_environment
           - src/mcp/handler.rs::promote_environment
+          - src/mcp/handler.rs::get_service_context
         failure_modes:
           - environment_mismatch
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -501,6 +501,7 @@ const ROUTING_BLOCK = `
   Gate: curl -sf http://localhost:9699/health — if fail, use Grep/Glob/Read (no LeanKG).
 
   Prefer-order (HTTP healthy):
+  0. get_overview_context(project=…) — session start; not load_layer(L0) alone
   1. mcp_status(project=…) — container path e.g. /workspace for Docker
   2. DISCOVER: concept_search → semantic_search → search_code / find_function
   3. EXACT: get_context / get_impact_radius / get_dependencies / get_dependents
@@ -508,13 +509,14 @@ const ROUTING_BLOCK = `
   5. DOCS: get_traceability / find_related_docs / get_files_for_doc
   6. TESTING: get_tested_by / detect_changes
   7. ORCHESTRATE: orchestrate(intent) when unsure which tool
+  8. ENV: env= on search/kg_* (never search_by_environment — removed)
 </tool_selection_hierarchy>
 
 <forbidden_actions>
   - Do NOT call LeanKG when :9699 health failed
   - Do NOT pass host Mac paths as project= against Docker MCP (use /workspace)
   - Do NOT use Grep for code search when LeanKG is healthy and returns hits
-  - Do NOT call removed tools (get_doc_for_file, mcp_hello, mcp_impact)
+  - Do NOT call removed tools (get_doc_for_file, mcp_hello, mcp_impact, find_clones, wake_up, search_by_environment)
 </forbidden_actions>
 `;
 
@@ -878,7 +880,7 @@ function buildSessionContext(input) {
   - Do NOT call LeanKG when :9699 health failed
   - Do NOT pass host Mac paths as project= against Docker MCP
   - Do NOT use Grep when LeanKG is healthy and returns hits
-  - Do NOT call removed tools (get_doc_for_file, mcp_hello, mcp_impact)
+  - Do NOT call removed tools (get_doc_for_file, mcp_hello, mcp_impact, find_clones, wake_up, search_by_environment)
 </forbidden_actions>
 
 <project_context>
@@ -1504,10 +1506,14 @@ curl -sf --max-time 2 http://localhost:9699/health
 
 ### When HTTP is healthy
 
+0. `get_overview_context(project=…)` — session start (not `load_layer(L0)` alone)
 1. `mcp_status(project=…)` — Docker: container mount (`/workspace`), not a host Mac path
 2. Prefer-order discover: `concept_search` → `semantic_search` → `search_code` / `find_function`
 3. Exact follow-up: `get_context` / `get_impact_radius` / `get_dependencies` / `get_dependents` / `get_tested_by`
-4. If LeanKG returns empty → fall back to Grep/Glob/Read
+4. Environment filter: `env=` on search / `kg_*` (never `search_by_environment` — removed)
+5. If LeanKG returns empty → fall back to Grep/Glob/Read
+
+See [MCP tools reference](mcp-tools.md) for the full prefer-order and hard-removed tool list (~81 tools with embeddings).
 
 | Instead of | Use LeanKG (HTTP up only) |
 |------------|---------------------------|

--- a/scripts/mcp-smoke-tools.py
+++ b/scripts/mcp-smoke-tools.py
@@ -42,7 +42,6 @@ MUTATING = {
     "agent_diary_write",
     "report_query_outcome",
     "export_graph_snapshot",
-    "wake_up",
 }
 
 # Full-graph / heavy tools — safe on small projects; skip on mega-graphs unless opted in.
@@ -70,7 +69,6 @@ MEGA_GRAPH_HEAVY = {
     "load_layer",
     "temporal_query",
     "timeline",
-    "search_by_environment",
     "search_by_requirement",
     "query_incidents",
     "find_env_conflicts",

--- a/src/benchmark/unified.rs
+++ b/src/benchmark/unified.rs
@@ -295,7 +295,7 @@ fn get_cases() -> Vec<CaseDef> {
             id: "C8",
             category: "overview",
             complexity: "complex",
-            tool: "wake_up",
+            tool: "get_overview_context",
             query: "project overview",
         },
     ]
@@ -522,12 +522,15 @@ fn run_leankg(
                 n,
             )
         }
-        "wake_up" => {
+        "get_overview_context" => {
+            let l0 = graph.identity_context("project").unwrap_or_default();
+            let l1 = graph.critical_facts_context().unwrap_or_default();
             let summary = graph
                 .wake_up_summary()
                 .unwrap_or_else(|e| format!("error: {}", e));
-            let n = summary.lines().count();
-            ("wake_up_summary()".to_string(), summary, n)
+            let output = format!("{}\n{}\n{}", l0, l1, summary);
+            let n = output.lines().count();
+            ("get_overview_context()".to_string(), output, n)
         }
         _ => (String::new(), format!("unknown tool: {}", cd.tool), 0),
     };
@@ -587,7 +590,7 @@ fn manual_cmd(cd: &CaseDef) -> String {
         "concept_search" => format!("grep -rn --include='*.rs' -l -i '{}' src/ | wc -l", cd.query.replace(" ", ".*")),
         "kg_context" => format!("grep -rn --include='*.rs' -l -i '{}' src/ docs/ 2>/dev/null | wc -l", cd.query.replace(" ", ".*")),
         "ontology_status" => "grep -rn --include='*.rs' 'concept' src/ontology/ | wc -l".to_string(),
-        "wake_up" => "find src -name '*.rs' | head -20 && echo '---' && find src -name '*.rs' | wc -l".to_string(),
+        "get_overview_context" => "find src -name '*.rs' | head -20 && echo '---' && find src -name '*.rs' | wc -l".to_string(),
         _ => format!("echo 'unknown tool: {}'", cd.tool),
     }
 }
@@ -595,7 +598,7 @@ fn manual_cmd(cd: &CaseDef) -> String {
 fn count_results(cd: &CaseDef, stdout: &str) -> usize {
     let trimmed = stdout.trim();
     match cd.tool {
-        "get_context" | "wake_up" => trimmed.lines().count(),
+        "get_context" | "get_overview_context" => trimmed.lines().count(),
         _ => trimmed.parse::<usize>().unwrap_or(0),
     }
 }

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -281,7 +281,6 @@ impl ToolHandler {
             "concept_search" => self.concept_search(arguments),
             "search_annotations" => self.search_annotations(arguments),
             "semantic_search" => self.semantic_search(arguments),
-            "wake_up" => self.wake_up(arguments),
             "generate_doc" => self.generate_doc(arguments),
             "find_large_functions" => self.find_large_functions(arguments),
             "get_tested_by" => self.get_tested_by(arguments),
@@ -309,7 +308,6 @@ impl ToolHandler {
             "link_element" => self.link_element_tool(arguments),
             "add_documentation" => self.add_documentation(arguments),
             // Versioning tools
-            "search_by_environment" => self.search_by_environment(arguments),
             "get_upcoming_changes" => self.get_upcoming_changes(arguments),
             "promote_environment" => self.promote_environment(arguments),
             // Incident and environment tools
@@ -1656,7 +1654,7 @@ impl ToolHandler {
         }))
     }
 
-    /// US-GN-08: Aggregate wake_up + L0 identity + L1 critical facts
+    /// US-GN-08: Aggregate L0 identity + L1 critical facts + project summary
     /// into a single resource-like MCP response that an agent can
     /// consume at session start. Equivalent to MCP Resources for
     /// overview context (leankg-mcp doesn't currently expose the
@@ -3320,37 +3318,6 @@ impl ToolHandler {
     // Version/Branch Tagging Tools
     // ========================================================================
 
-    fn search_by_environment(&self, args: &Value) -> Result<Value, String> {
-        let environment = args["environment"].as_str().ok_or("Missing environment")?;
-        let limit = args["limit"].as_u64().unwrap_or(20).min(50) as usize;
-
-        let knowledge =
-            db::get_knowledge_by_environment(self.graph_engine.db(), environment, limit)
-                .map_err(|e| format!("Failed to search by environment: {}", e))?;
-
-        let results: Vec<Value> = knowledge
-            .iter()
-            .map(|e| {
-                json!({
-                    "id": e.id,
-                    "knowledge_type": e.knowledge_type,
-                    "title": e.title,
-                    "content_preview": truncate_str(&e.content, 200),
-                    "branch": e.branch,
-                    "author": e.author,
-                    "environment": e.environment,
-                    "created_at": e.created_at
-                })
-            })
-            .collect();
-
-        Ok(json!({
-            "environment": environment,
-            "results": results,
-            "count": results.len()
-        }))
-    }
-
     fn get_upcoming_changes(&self, args: &Value) -> Result<Value, String> {
         let limit = args["limit"].as_u64().unwrap_or(20).min(50) as usize;
         let branch_filter = args["branch"].as_str();
@@ -3797,37 +3764,6 @@ impl ToolHandler {
         }
 
         Ok(response)
-    }
-
-    fn wake_up(&self, args: &Value) -> Result<Value, String> {
-        let project_path = args["project"].as_str().unwrap_or(".");
-        let cache_path = std::path::Path::new(project_path)
-            .join(".leankg")
-            .join("wake_up.txt");
-
-        if let Ok(cached) = std::fs::read_to_string(&cache_path) {
-            if !cached.trim().is_empty() {
-                return Ok(json!({
-                    "context": cached,
-                    "source": "cache",
-                }));
-            }
-        }
-
-        let summary = self
-            .graph_engine
-            .wake_up_summary()
-            .unwrap_or_else(|e| format!("LeanKG project (context generation error: {})", e));
-
-        if let Some(parent) = cache_path.parent() {
-            let _ = std::fs::create_dir_all(parent);
-        }
-        let _ = std::fs::write(&cache_path, &summary);
-
-        Ok(json!({
-            "context": summary,
-            "source": "generated",
-        }))
     }
 
     /// FR-B20: Get architecture overview.

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -246,7 +246,7 @@ impl ToolRegistry {
             },
             ToolDefinition {
                 name: "get_overview_context".to_string(),
-                description: "US-GN-08: Return the project overview context (identity, critical facts, recent hotspots) as a single MCP-callable resource. Acts as an MCP-Resources-style agent context shortcut for wake_up + L0/L1 layers.".to_string(),
+                description: "US-GN-08: Session-start overview (L0 identity + L1 critical facts + project summary). Prefer over load_layer(L0) alone. Replaces removed wake_up tool.".to_string(),
                 input_schema: json!({
                     "type": "object",
                     "properties": {
@@ -873,20 +873,6 @@ impl ToolRegistry {
 
             // Version/Branch Tagging Tools
             ToolDefinition {
-                name: "search_by_environment".to_string(),
-                description: "DEPRECATED (FR-SURF-05): prefer env= on search_code / semantic_search / concept_search / kg_* tools. Still searches code elements and knowledge filtered by environment (production, staging, dev, upcoming, local).".to_string(),
-                input_schema: json!({
-                    "type": "object",
-                    "properties": {
-                                                "environment": {"type": "string", "enum": ["production", "staging", "dev", "upcoming", "local"], "description": "Environment to filter by (use 'local' for default-indexed code)"},
-                        "query": {"type": "string", "description": "Optional: search query to further filter results"},
-                        "limit": {"type": "integer", "description": "Max results (default: 20)"},
-                        "project": {"type": "string", "description": "Optional: project path"}
-                    },
-                    "required": ["environment"]
-                }),
-            },
-            ToolDefinition {
                 name: "get_upcoming_changes".to_string(),
                 description: "Get knowledge entries and code elements tagged as 'upcoming' (feature branch changes not yet in main). Shows what's coming in the next release.".to_string(),
                 input_schema: json!({
@@ -965,17 +951,6 @@ impl ToolRegistry {
                         "project": {"type": "string", "description": "Optional: project path"}
                     },
                     "required": ["query"]
-                }),
-            },
-            ToolDefinition {
-                name: "wake_up".to_string(),
-                description: "DEPRECATED (FR-SURF-04): prefer get_overview_context (L0+L1 style overview). Do not replace with load_layer(L0) alone — wake_up is L0+L1 (~170 tok). Still loads cached project identity + critical facts from .leankg/wake_up.txt.".to_string(),
-                input_schema: json!({
-                    "type": "object",
-                    "properties": {
-                        "project": {"type": "string", "description": "Optional: project path"}
-                    },
-                    "required": []
                 }),
             },
 
@@ -1160,7 +1135,14 @@ mod tests {
         assert!(names.contains(&"find_related_docs"));
         assert!(names.contains(&"query_graph"));
         assert!(names.contains(&"shortest_path"));
-        for removed in ["mcp_hello", "mcp_impact", "get_doc_for_file"] {
+        for removed in [
+            "mcp_hello",
+            "mcp_impact",
+            "get_doc_for_file",
+            "find_clones",
+            "wake_up",
+            "search_by_environment",
+        ] {
             assert!(
                 !names.contains(&removed),
                 "removed tool `{removed}` must not be registered"

--- a/tests/mcp_tools_redundancy_tests.rs
+++ b/tests/mcp_tools_redundancy_tests.rs
@@ -25,9 +25,9 @@
 //! get_upcoming_changes, kg_concept_map, kg_context, kg_ontology_status,
 //! kg_self_test, kg_semantic_context, kg_trace_workflow, link_element,
 //! load_layer, promote_environment, query_incidents, report_query_outcome,
-//! resolve_with_lsp, search_annotations, search_by_environment,
+//! resolve_with_lsp, search_annotations,
 //! search_knowledge, semantic_search, shortest_path, temporal_query,
-//! timeline, update_knowledge, wake_up, query_graph
+//! timeline, update_knowledge, query_graph
 
 use leankg::db::schema::{init_db, run_script, CozoDb};
 use leankg::graph::GraphEngine;
@@ -155,7 +155,6 @@ fn every_tested_tool_is_registered() {
         "report_query_outcome",
         "resolve_with_lsp",
         "search_annotations",
-        "search_by_environment",
         "search_knowledge",
         "semantic_search",
         "shortest_path",
@@ -163,7 +162,6 @@ fn every_tested_tool_is_registered() {
         "temporal_query",
         "timeline",
         "update_knowledge",
-        "wake_up",
     ];
     for name in required {
         // `kg_semantic_context` is `#[cfg(feature = "embeddings")]`-gated; only
@@ -527,13 +525,6 @@ mod graph_features {
     }
 
     #[tokio::test(flavor = "multi_thread")]
-    async fn wake_up_returns_project_summary() {
-        let (handler, _tmp) = make_handler().await;
-        let resp = call(&handler, "wake_up", json!({})).await.expect("wake_up");
-        assert!(!resp.to_string().is_empty());
-    }
-
-    #[tokio::test(flavor = "multi_thread")]
     async fn load_layer_returns_layer_payload() {
         let (handler, _tmp) = make_handler().await;
         let resp = call(&handler, "load_layer", json!({}))
@@ -839,19 +830,6 @@ mod ontology {
 
 mod environment {
     use super::*;
-
-    #[tokio::test(flavor = "multi_thread")]
-    async fn search_by_environment_filters() {
-        let (handler, _tmp) = make_handler().await;
-        let resp = call(
-            &handler,
-            "search_by_environment",
-            json!({"environment": "local"}),
-        )
-        .await
-        .expect("search_by_environment");
-        assert!(!resp.to_string().is_empty());
-    }
 
     #[tokio::test(flavor = "multi_thread")]
     async fn get_upcoming_changes_returns_payload() {

--- a/tests/redundant_tools_matrix.rs
+++ b/tests/redundant_tools_matrix.rs
@@ -2,7 +2,7 @@
 //!
 //! Every registered tool must appear exactly once in [`TOOL_CLASSIFICATION`].
 //! Overlap relationships live in [`OVERLAP_TABLE`] (documentation + keep-both).
-//! Soft-deprecated tools remain registered; hard-removed tools are asserted absent.
+//! Soft-deprecated tools are hard-removed in FR-SURF-07/08 (2026-07-21).
 //!
 //! Report: `docs/reports/mcp-tool-redundancy-impact-2026-07-20.md`
 //!
@@ -21,8 +21,6 @@ enum Kind {
     Complementary,
     /// Same shape, different domain (e.g. Android nav) — keep both.
     DomainSpecific,
-    /// Soft-deprecated; still registered; prefer replacement (FR-SURF-04/05).
-    SoftDeprecated,
 }
 
 struct ClassEntry {
@@ -41,22 +39,18 @@ struct OverlapEntry {
     note: &'static str,
 }
 
-/// Tools hard-removed (FR-SURF-03 + find_clones hard-delete 2026-07-20).
-const REMOVED_TOOLS: &[&str] = &["mcp_hello", "mcp_impact", "get_doc_for_file", "find_clones"];
+/// Tools hard-removed (FR-SURF-03 + find_clones + FR-SURF-07/08 hard-delete 2026-07-21).
+const REMOVED_TOOLS: &[&str] = &[
+    "mcp_hello",
+    "mcp_impact",
+    "get_doc_for_file",
+    "find_clones",
+    "wake_up",
+    "search_by_environment",
+];
 
 /// Full inventory — must match `ToolRegistry::list_tools()` exactly (one row each).
 const TOOL_CLASSIFICATION: &[ClassEntry] = &[
-    // --- Soft-deprecated (FR-SURF-04 / FR-SURF-05) ---
-    ClassEntry {
-        name: "wake_up",
-        kind: Kind::SoftDeprecated,
-        note: "Prefer get_overview_context (L0+L1). Do not use load_layer(L0) alone.",
-    },
-    ClassEntry {
-        name: "search_by_environment",
-        kind: Kind::SoftDeprecated,
-        note: "Prefer env= on search_code / semantic_search / concept_search / kg_*.",
-    },
     // --- Ops bootstrap ---
     ClassEntry {
         name: "mcp_init",
@@ -158,6 +152,11 @@ const TOOL_CLASSIFICATION: &[ClassEntry] = &[
         note: "Ontology coverage diagnostics.",
     },
     ClassEntry {
+        name: "ontology_control",
+        kind: Kind::KeepUnique,
+        note: "FR-ONT-PROC-03 admin sync/status for ontology YAML.",
+    },
+    ClassEntry {
         name: "kg_self_test",
         kind: Kind::KeepUnique,
         note: "Ontology tool smoke; replaces removed mcp_hello.",
@@ -191,12 +190,12 @@ const TOOL_CLASSIFICATION: &[ClassEntry] = &[
     ClassEntry {
         name: "get_overview_context",
         kind: Kind::Complementary,
-        note: "L0+L1 overview; preferred over wake_up.",
+        note: "L0+L1 overview; session-start prefer-order entry.",
     },
     ClassEntry {
         name: "load_layer",
         kind: Kind::Complementary,
-        note: "Progressive L0–L3 layers; not a full wake_up replacement alone.",
+        note: "Progressive L0–L3 layers; not a full overview replacement alone.",
     },
     ClassEntry {
         name: "get_architecture",
@@ -506,16 +505,15 @@ const OVERLAP_TABLE: &[OverlapEntry] = &[
             "search_annotations",
             "search_knowledge",
             "search_by_requirement",
-            "search_by_environment",
         ],
         kind: Kind::DomainSpecific,
         note: "Prefer-order: concept_search → semantic_search → search_code; others entity-scoped.",
     },
     OverlapEntry {
         primary: "get_architecture",
-        related: &["get_overview_context", "wake_up", "load_layer"],
+        related: &["get_overview_context", "load_layer"],
         kind: Kind::Complementary,
-        note: "Deep arch vs overview vs deprecated wake_up vs progressive layers.",
+        note: "Deep arch vs overview vs progressive layers.",
     },
     OverlapEntry {
         primary: "get_graph_schema",
@@ -563,12 +561,12 @@ fn registered() -> HashSet<String> {
 }
 
 #[test]
-fn removed_superseded_tools_are_absent_from_registry() {
+fn hard_removed_tools_are_absent_from_registry() {
     let reg = registered();
     for tool in REMOVED_TOOLS {
         assert!(
             !reg.contains(*tool),
-            "removed tool `{tool}` still registered"
+            "hard-removed tool `{tool}` still registered"
         );
     }
 }
@@ -599,44 +597,6 @@ fn replacement_tools_remain_registered() {
             "kg_semantic_context missing with embeddings feature"
         );
     }
-}
-
-#[test]
-fn soft_deprecated_tools_mark_replacement_in_description() {
-    let tools = ToolRegistry::list_tools();
-    let wake = tools
-        .iter()
-        .find(|t| t.name == "wake_up")
-        .expect("wake_up still registered during deprecation window");
-    assert!(
-        wake.description.contains("DEPRECATED")
-            && wake.description.contains("get_overview_context"),
-        "wake_up must soft-deprecate toward get_overview_context: {}",
-        wake.description
-    );
-
-    let env_search = tools
-        .iter()
-        .find(|t| t.name == "search_by_environment")
-        .expect("search_by_environment still registered");
-    assert!(
-        env_search.description.contains("DEPRECATED")
-            && (env_search.description.contains("env=")
-                || env_search.description.contains("env =")),
-        "search_by_environment must point to env= on primary tools: {}",
-        env_search.description
-    );
-
-    let soft: Vec<_> = TOOL_CLASSIFICATION
-        .iter()
-        .filter(|e| e.kind == Kind::SoftDeprecated)
-        .map(|e| e.name)
-        .collect();
-    assert_eq!(
-        soft,
-        vec!["wake_up", "search_by_environment"],
-        "unexpected SoftDeprecated set: {soft:?}"
-    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- Hard-delete MCP tools `wake_up` and `search_by_environment` from registry/handlers; keep `wake_up_summary()` for `get_overview_context`
- Update matrix/redundancy tests, ontology workflow ref, benchmark C8, smoke/install hooks, and agent-facing docs/skills/plugins
- Mark Wave 1a tracker IDs DONE; evidence in `docs/reports/rel-062-mcp-surf-hard-delete-2026-07-21.md`

## Test plan
- [x] `cargo test --release --test redundant_tools_matrix` (default + `--features embeddings`)
- [x] `cargo test --release --test mcp_tools_redundancy_tests`
- [x] `cargo test --release -p leankg --lib mcp::tools`
- [x] Local `mcp-http :9700` — `tools/list` absent deleted tools; `get_overview_context` OK
- [ ] Redeploy Docker `:9699` to pick up new registry (currently still shows 84 tools pre-change)


Made with [Cursor](https://cursor.com)