### PR TITLE
feat: honest edge provenance (Wave 2a) + company adoption waves 0a–1c

### DIFF
--- a/.cursor-plugin/skills/using-leankg/SKILL.md
+++ b/.cursor-plugin/skills/using-leankg/SKILL.md
@@ -46,16 +46,19 @@ get_overview_context(project=…)  # L0+L1 summary — not load_layer(L0) alone
 → get_architecture for deep single-call overview
 ```
 
-Natural-language / domain questions:
+Natural-language / domain questions (**discover before `query_graph`**):
 
 ```
 1. mcp_status(project=…)
 2. concept_search(query=…)     # domain concepts first
-3. semantic_search(query=…)    # HNSW ANN if embeddings exist
+3. semantic_search(query=…)    # HNSW ANN if embeddings exist — REQUIRED before query_graph
 4. search_code / find_function # name/type fallback
-5. get_context / get_impact_radius / get_dependencies / …
+5. query_graph / explain_node / shortest_path  # only after seeds / known endpoints
+6. get_context / get_impact_radius / get_dependencies / …
    on the returned qualified_name or file — never full-graph dumps
 ```
+
+**BAN:** Do not call `query_graph` as the first NL discovery tool. Run `concept_search` → `semantic_search` first; use `query_graph` to expand the frontier after hits.
 
 Exact symbol / file known:
 
@@ -82,9 +85,23 @@ mcp_status → find_function / query_file → get_context → impact/deps tools
 | Blast radius | `get_impact_radius` |
 | Imports / dependents | `get_dependencies` / `get_dependents` |
 | Tests | `get_tested_by` |
-| NL subgraph | `query_graph` (frontier-local; mega-safe) |
+| NL subgraph (after discovery) | `query_graph` (frontier-local; mega-safe) — **not** first-hop NL |
 | Session overview | `get_overview_context` |
 | Environment filter | `env=` on `search_code` / `semantic_search` / `concept_search` / `kg_*` |
+
+### Doc↔code join (structural markdown ↔ file keys)
+
+After `mcp_index_docs`, path aliases resolve on read; markdown refs resolve to indexed file keys on write.
+
+```
+1. FR / US requirement ID → search_by_requirement / get_traceability / link_element
+2. Known file or doc path → get_files_for_doc / find_related_docs (canonical docs/… keys)
+3. Domain / workflow → concept_search → kg_trace_workflow
+4. Fuzzy NL → semantic_search → kg_semantic_context
+5. Fallback → search_code / Read
+```
+
+Miss payloads include `tried[]` — do not assume empty graph when aliases fail.
 
 ### Hard-removed tools (do not call)
 

--- a/.opencode/skills/using-leankg/SKILL.md
+++ b/.opencode/skills/using-leankg/SKILL.md
@@ -46,16 +46,19 @@ get_overview_context(project=…)  # L0+L1 summary — not load_layer(L0) alone
 → get_architecture for deep single-call overview
 ```
 
-Natural-language / domain questions:
+Natural-language / domain questions (**discover before `query_graph`**):
 
 ```
 1. mcp_status(project=…)
 2. concept_search(query=…)     # domain concepts first
-3. semantic_search(query=…)    # HNSW ANN if embeddings exist
+3. semantic_search(query=…)    # HNSW ANN if embeddings exist — REQUIRED before query_graph
 4. search_code / find_function # name/type fallback
-5. get_context / get_impact_radius / get_dependencies / …
+5. query_graph / explain_node / shortest_path  # only after seeds / known endpoints
+6. get_context / get_impact_radius / get_dependencies / …
    on the returned qualified_name or file — never full-graph dumps
 ```
+
+**BAN:** Do not call `query_graph` as the first NL discovery tool. Run `concept_search` → `semantic_search` first; use `query_graph` to expand the frontier after hits.
 
 Exact symbol / file known:
 
@@ -82,9 +85,23 @@ mcp_status → find_function / query_file → get_context → impact/deps tools
 | Blast radius | `get_impact_radius` |
 | Imports / dependents | `get_dependencies` / `get_dependents` |
 | Tests | `get_tested_by` |
-| NL subgraph | `query_graph` (frontier-local; mega-safe) |
+| NL subgraph (after discovery) | `query_graph` (frontier-local; mega-safe) — **not** first-hop NL |
 | Session overview | `get_overview_context` |
 | Environment filter | `env=` on `search_code` / `semantic_search` / `concept_search` / `kg_*` |
+
+### Doc↔code join (structural markdown ↔ file keys)
+
+After `mcp_index_docs`, path aliases resolve on read; markdown refs resolve to indexed file keys on write.
+
+```
+1. FR / US requirement ID → search_by_requirement / get_traceability / link_element
+2. Known file or doc path → get_files_for_doc / find_related_docs (canonical docs/… keys)
+3. Domain / workflow → concept_search → kg_trace_workflow
+4. Fuzzy NL → semantic_search → kg_semantic_context
+5. Fallback → search_code / Read
+```
+
+Miss payloads include `tried[]` — do not assume empty graph when aliases fail.
 
 ### Hard-removed tools (do not call)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,17 +96,21 @@ Three new MCP tools are available once a project is indexed:
 
 See [`docs/mcp-tools.md`](docs/mcp-tools.md) → Structure Tools and [`docs/roadmap.md`](docs/roadmap.md) → Phase 1. Requirements: [`docs/prd.md`](docs/prd.md) Sections 3.11 / 5.10.
 
-## Three verbs first (path · explain · query)
+## Prefer-order (discover before connection verbs)
 
-When MCP HTTP on `:9699` is healthy, lead with these cheap connection tools before grep or full-file Read:
+When MCP HTTP on `:9699` is healthy, for fuzzy / NL / “where is X?” questions **discover first** — do **not** open with `query_graph`:
 
-| Verb | Question | MCP tool |
-|------|----------|----------|
-| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
-| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
-| **query** | NL subgraph question | `query_graph(question, project=…)` |
+`get_overview_context` → `mcp_status` → `concept_search` → **`semantic_search`** → `search_code` / `find_function` → then connection verbs → `get_context` / impact / deps.
 
-Then discover: `get_overview_context` → `concept_search` → `semantic_search` → `search_code` → `get_context` / impact / deps. Full catalog: [`docs/mcp-tools.md`](docs/mcp-tools.md).
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → **`semantic_search`** → `search_code` |
+| Exact symbol / file name | `find_function` / `search_code` / `query_file` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| What is this known symbol? | `explain_node` |
+| Expand subgraph after seeds | `query_graph` (**after** semantic/concept hits) |
+
+**BAN:** Do not call `query_graph` as the first NL discovery tool when embeddings/concepts may answer. Full catalog: [`docs/mcp-tools.md`](docs/mcp-tools.md).
 
 ## MANDATORY: LeanKG MCP project paths (Docker vs host)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -96,6 +96,18 @@ Three new MCP tools are available once a project is indexed:
 
 See [`docs/mcp-tools.md`](docs/mcp-tools.md) → Structure Tools and [`docs/roadmap.md`](docs/roadmap.md) → Phase 1. Requirements: [`docs/prd.md`](docs/prd.md) Sections 3.11 / 5.10.
 
+## Three verbs first (path · explain · query)
+
+When MCP HTTP on `:9699` is healthy, lead with these cheap connection tools before grep or full-file Read:
+
+| Verb | Question | MCP tool |
+|------|----------|----------|
+| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
+| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
+| **query** | NL subgraph question | `query_graph(question, project=…)` |
+
+Then discover: `get_overview_context` → `concept_search` → `semantic_search` → `search_code` → `get_context` / impact / deps. Full catalog: [`docs/mcp-tools.md`](docs/mcp-tools.md).
+
 ## MANDATORY: LeanKG MCP project paths (Docker vs host)
 
 Cursor agents talking to LeanKG MCP over HTTP (`localhost:9699`, Docker RocksDB) **must** pass **container mount paths** as `project=`. Host filesystem paths do not match RocksDB project keys and return "not initialized" even when the graph is indexed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,17 +83,21 @@ See `docs/implementation-feature-verification-2026-03-25.md` for test results.
 
 ## LeanKG Tools Usage
 
-### Three verbs first (path · explain · query)
+### Prefer-order (discover before connection verbs)
 
-When MCP HTTP on `:9699` is healthy, lead with these cheap connection tools before grep or full-file Read:
+When MCP HTTP on `:9699` is healthy, for fuzzy / NL / “where is X?” questions **discover first** — do **not** open with `query_graph`:
 
-| Verb | Question | MCP tool |
-|------|----------|----------|
-| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
-| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
-| **query** | NL subgraph question | `query_graph(question, project=…)` |
+`get_overview_context` → `mcp_status` → `concept_search` → **`semantic_search`** → `search_code` / `find_function` → then connection verbs → `get_context` / impact / deps.
 
-Then discover: `get_overview_context` → `concept_search` → `semantic_search` → `search_code` → `get_context` / impact / deps. Full catalog: [`docs/mcp-tools.md`](docs/mcp-tools.md).
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → **`semantic_search`** → `search_code` |
+| Exact symbol / file name | `find_function` / `search_code` / `query_file` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| What is this known symbol? | `explain_node` |
+| Expand subgraph after seeds | `query_graph` (**after** semantic/concept hits) |
+
+**BAN:** Do not call `query_graph` as the first NL discovery tool when embeddings/concepts may answer. Full catalog: [`docs/mcp-tools.md`](docs/mcp-tools.md).
 
 ### MANDATORY: Docker MCP project paths (not host paths)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -83,6 +83,18 @@ See `docs/implementation-feature-verification-2026-03-25.md` for test results.
 
 ## LeanKG Tools Usage
 
+### Three verbs first (path · explain · query)
+
+When MCP HTTP on `:9699` is healthy, lead with these cheap connection tools before grep or full-file Read:
+
+| Verb | Question | MCP tool |
+|------|----------|----------|
+| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
+| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
+| **query** | NL subgraph question | `query_graph(question, project=…)` |
+
+Then discover: `get_overview_context` → `concept_search` → `semantic_search` → `search_code` → `get_context` / impact / deps. Full catalog: [`docs/mcp-tools.md`](docs/mcp-tools.md).
+
 ### MANDATORY: Docker MCP project paths (not host paths)
 
 When Cursor's LeanKG MCP talks to the Docker HTTP server on `:9699`, RocksDB keys projects by **in-container** mount paths. Host Mac paths fail with "not initialized" even when the index exists.

--- a/README.md
+++ b/README.md
@@ -324,17 +324,21 @@ leankg mcp-stdio --watch     # local AI tools
 leankg mcp-http --port 9699  # HTTP/SSE for Docker / remote
 ```
 
-### Three verbs (path · explain · query)
+### Prefer-order (discover before connection verbs)
 
-When `:9699` health is OK, lead with these cheap connection tools before grep or full-file Read:
+When `:9699` health is OK, for fuzzy / NL / “where is X?” questions **discover first** — do **not** open with `query_graph`:
 
-| Verb | Question | MCP tool |
-|------|----------|----------|
-| **path** | How does A connect to B? | `shortest_path` |
-| **explain** | What is this symbol and its neighborhood? | `explain_node` |
-| **query** | NL subgraph / "what connects X to Y?" | `query_graph` |
+`get_overview_context` → `mcp_status` → `concept_search` → **`semantic_search`** → `search_code` / `find_function` → then connection verbs → `get_context` / impact / deps.
 
-Then discover: `get_overview_context` → `concept_search` → `semantic_search` → `search_code` → `get_context` / impact / deps. Docker MCP: pass container `project=` (`/workspace`); override with `LEANKG_MCP_PROJECT`.
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → **`semantic_search`** → `search_code` |
+| Exact symbol / file name | `find_function` / `search_code` / `query_file` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| What is this known symbol? | `explain_node` |
+| Expand subgraph after seeds | `query_graph` (**after** semantic/concept hits) |
+
+Docker MCP: pass container `project=` (`/workspace`); override with `LEANKG_MCP_PROJECT`.
 
 ### Procedural ontology (auto-update)
 

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ graph LR
 
 > **On cost:** LeanKG’s win on every codebase is **precision and speed** — fewer tool calls, faster answers. Token savings are real and **scale-dependent**: modest on small repos, material on large monorepos multiplied by team-wide agent usage.
 
+### Company ROI vs grep and Graphify
+
+For engineering managers choosing a team-wide stack: [LeanKG vs Graphify — Company ROI Brief](docs/reports/leankg-vs-graphify-company-roi-2026-07-21.md) (token/tool-call floors, multi-repo Docker TCO, mega-graph safety, ops/traceability). The primary adoption lever is always-on graph-first install (`curl …/install.sh | bash -s -- cursor` or `claude`) so agents query the graph before grep.
+
 ---
 
 ## Measured Results
@@ -307,20 +311,30 @@ Repo ──► Indexer ──► Knowledge Graph ──► MCP Tools ──► A
 
 | Agent | Auto-setup | Notes |
 |-------|------------|--------|
-| Cursor | Yes | Per-project install; session hook; skill `using-leankg` |
-| Claude Code | Yes | Plugin + full lifecycle hooks |
+| Cursor | Yes | Per-project install; always-on graph-first rule + session hook; skill `using-leankg` |
+| Claude Code | Yes | Plugin + full lifecycle hooks (PreToolUse nudge) |
 | OpenCode | Yes | Plugin + skill |
 | Gemini CLI | Yes | MCP + skill / agent docs |
 | Codex / Antigravity / Kilo | Yes | MCP + skill / agent docs |
 | Docker MCP HTTP | Yes | Shared RocksDB; multi-repo mounts |
 
 ```bash
-leankg setup                 # configure MCP + hooks
+curl -fsSL https://raw.githubusercontent.com/FreePeak/LeanKG/main/scripts/install.sh | bash -s -- cursor
 leankg mcp-stdio --watch     # local AI tools
 leankg mcp-http --port 9699  # HTTP/SSE for Docker / remote
 ```
 
-**Agent search prefer-order** (when `:9699` healthy): `concept_search` → `semantic_search` → `search_code`, then exact tools (`get_context`, impact, deps). Docker MCP: pass container `project=` (`/workspace`); override with `LEANKG_MCP_PROJECT`.
+### Three verbs (path · explain · query)
+
+When `:9699` health is OK, lead with these cheap connection tools before grep or full-file Read:
+
+| Verb | Question | MCP tool |
+|------|----------|----------|
+| **path** | How does A connect to B? | `shortest_path` |
+| **explain** | What is this symbol and its neighborhood? | `explain_node` |
+| **query** | NL subgraph / "what connects X to Y?" | `query_graph` |
+
+Then discover: `get_overview_context` → `concept_search` → `semantic_search` → `search_code` → `get_context` / impact / deps. Docker MCP: pass container `project=` (`/workspace`); override with `LEANKG_MCP_PROJECT`.
 
 ### Procedural ontology (auto-update)
 

--- a/docs/prd-task-tracker.md
+++ b/docs/prd-task-tracker.md
@@ -1,12 +1,12 @@
 # LeanKG PRD Task Tracker (Single Session)
 
-**Last synced:** 2026-07-21 — Wave **1a** MCP hard-delete **DONE**; P2 DOCJOIN Must Have **DONE** (`feature/doc-join-quality`, `FR-DOCJOIN-06` open) (REL-062); v3.7.14 graph-engineering curriculum gaps (`US-GE-*` / `FR-GE-*` / `REL-064`) docs DONE.
+**Last synced:** 2026-07-22 — Wave **2a** honest edges **DONE**; Wave **1c** always-on graph-first hooks **DONE**; Wave **1b** three-verb narrative **DONE**; Wave **0a/0b** ROI link + ui-v2 cutover evidence **DONE**; Wave **1a** MCP hard-delete **DONE**; P2 DOCJOIN Must Have **DONE** (`FR-DOCJOIN-06` open).
 **This file is the SoT for task inventory + status.**  
 **PRD narrative / ACs / HLD:** [`docs/prd.md`](prd.md) §1.1 / §1.2 / §3.16 / §3.19–3.20 / §5.18 / §5.22–5.23  
 
 > **Agent rule:** Work **P0 first**, then P1 waves → P2 → P3.  
 > **P0:** Procedural ontology auto-update — **DONE**.  
-> **P1 CURRENT:** Company adoption waves — **Wave 1a = redundant MCP tool cleanup + agent-surface sync**.  
+> **P1 CURRENT:** Company adoption waves — **Wave 2b = auto GRAPH_REPORT** (next). Waves 0a–2a **DONE**.  
 > **P2 follow-ons:** Doc↔code join (§3.19 / §5.22); graph-engineering curriculum gaps (§1.2 / §3.20 / §5.23) — do **not** interrupt P1 waves.  
 > Open `prd.md` only for design narrative and acceptance criteria.
 
@@ -39,18 +39,18 @@
 | Metric | Count |
 |--------|------:|
 | **Total tracked** | **509** |
-| NOT_DONE | 73 |
-| PENDING | 33 |
-| PARTIAL | 13 |
+| NOT_DONE | 63 |
+| PENDING | 30 |
+| PARTIAL | 10 |
 | OPEN | 1 |
-| DONE | 386 |
+| DONE | 401 |
 | WONT_DO | 3 |
-| Open work | **120** |
+| Open work | **104** |
 
 | Open by Focus | Count |
 |---------------|------:|
 | P0 | 0 |
-| P1 | 23 |
+| P1 | 8 |
 | P2 | 85 |
 | P3 | 12 |
 
@@ -82,16 +82,28 @@ Evidence: [`ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-
 
 | Wave | Goal | IDs (implement) | Why |
 |-----:|------|-----------------|-----|
-| **0a** | Publish ROI | `US-COST-01` / `FR-COST-01` / `REL-058` | Brief exists; link README |
-| **0b** | ui-v2 cutover closeout | `US-UI2-07` / `FR-UI2-09` / `REL-057` | Embed present; finish evidence |
-| **1a** | **MCP redundant-tool cleanup + agent surface sync** | `US-SURF-06..07` / `FR-SURF-07..11` / `REL-062` | Hard-delete `wake_up` + `search_by_environment`; sync skills/rules/guidelines/setup |
-| **1b** | Three-verb narrative | `US-GF-14` / `FR-GF-22` | Agents pick cheap tools on **shrunk** roster |
-| **1c** | Always-on hooks | `US-GF-17` / `FR-GF-24` | Primary token-cost lever (install what skills say) |
-| **2a** | Honest edges | `US-GF-04` / `FR-GF-07..09` / `REL-043` | Trust = adoption |
+| **0a** | Publish ROI | `US-COST-01` / `FR-COST-01` / `REL-058` | **DONE** — brief + README link |
+| **0b** | ui-v2 cutover closeout | `US-UI2-07` / `FR-UI2-09` / `REL-057` | **DONE** — embed + evidence report |
+| **1a** | **MCP redundant-tool cleanup + agent surface sync** | `US-SURF-06..07` / `FR-SURF-07..11` / `REL-062` | **DONE** |
+| **1b** | Three-verb narrative | `US-GF-14` / `FR-GF-22` | **DONE** — path · explain · query first in docs/skills |
+| **1c** | Always-on hooks | `US-GF-17` / `FR-GF-24` | **DONE** — Cursor rule + Claude PreToolUse nudge |
+| **2a** | Honest edges | `US-GF-04` / `FR-GF-07..09` / `REL-043` | **DONE** — write-path stamp + MCP + ui-v2 |
 | **2b** | Auto GRAPH_REPORT | `US-GF-06` / `FR-GF-13` | Onboarding without tool wall |
 | **2c** | HTML export | `US-GF-13` / `FR-GF-21` | Shareable PR/CI artifact |
 | **3** | NL Query FAB | `US-UI2-06` / `FR-UI2-08` | Humans use same cheap verb |
 | **4** | Single-repo expand | `US-MG-02` / `FR-MG-03` | UI correctness |
+
+Evidence: [`honest-edges-smoke-2026-07-22.md`](reports/honest-edges-smoke-2026-07-22.md)
+
+### Wave 2a detail (honest edges)
+
+| ID | Status | Intent |
+|----|--------|--------|
+| `US-GF-04` | DONE | EXTRACTED / INFERRED / AMBIGUOUS on all relationship surfaces |
+| `FR-GF-07` | DONE | Persist `confidence_label` on every edge write |
+| `FR-GF-08` | DONE | Write-time map + reindex backfill |
+| `FR-GF-09` | DONE | MCP + path ranking + ui-v2 propagation |
+| `REL-043` | DONE | Smoke report + tests |
 
 ### Wave 1a detail (MCP surface)
 
@@ -173,9 +185,9 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
-| **P1** | `REL-058` | Release | **NOT_DONE** | Must Have | Manager ROI brief checked into docs/reports/ and linked from README competitive section | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `FR-UI2-09` | FR | **NOT_DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
-| **P1** | `REL-057` | Release | **NOT_DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
+| **P1** | `REL-058` | Release | **DONE** | Must Have | Manager ROI brief checked into docs/reports/ and linked from README competitive section | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `FR-UI2-09` | FR | **DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
+| **P1** | `REL-057` | Release | **DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
 | **P1** | `FR-SURF-07` | FR | **DONE** | Must Have | Hard-delete wake_up from ToolRegistry + handlers; matrix AlreadyRemoved; smoke MUTATING li… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
 | **P1** | `FR-SURF-08` | FR | **DONE** | Must Have | Hard-delete search_by_environment; callers use env= on search_code/semantic_search/concept… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
 | **P1** | `FR-SURF-09` | FR | **DONE** | Must Have | Sync repo guidelines: AGENTS.md, CLAUDE.md, docs/mcp-tools.md, mcp-setup.md, agentic-instr… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
@@ -185,12 +197,12 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 | **P2** | `FR-GE-01` | FR | **DONE** | Must Have | Publish graph-engineering curriculum fit matrix vs LeanKG | 5.23 Graph Engineering curriculum gaps (v3.7.14) |
 | **P2** | `REL-064` | Release | **DONE** | Must Have | Analysis + PRD §1.2/§3.20/§5.23 + tracker rows on main | 5.23 Graph Engineering curriculum gaps (v3.7.14) |
 | **P2** | `US-GE-01` | User Story | **DONE** | Must Have | Published fit matrix: LeanKG as graph memory under agent harnesses | 3.20 Graph Engineering curriculum gaps (US-GE) |
-| **P1** | `FR-GF-22` | FR | **NOT_DONE** | Must Have | README / AGENTS / using-leankg skill lead with path · explain · query; demote full tool wa… | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-24` | FR | **NOT_DONE** | Must Have | Always-on graph-first rules/hooks: nudge before grep/Read; optional strict first-Read redi… | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-07` | FR | **NOT_DONE** | Must Have | Relationship metadata field 'confidence_label' ∈ {EXTRACTED, INFERRED, AMBIGUOUS} written … | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-08` | FR | **NOT_DONE** | Must Have | Map 'resolution_method' → 'confidence_label' at edge write time; backfill on reindex | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-09` | FR | **NOT_DONE** | Must Have | Propagate 'confidence_label' in impact, call_graph, path, query_graph, Web UI | 5.9 Graphify-Inspired Features |
-| **P1** | `REL-043` | Release | **NOT_DONE** | Must Have | US-GF-04 provenance labels on all relationship types | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
+| **P1** | `FR-GF-22` | FR | **DONE** | Must Have | README / AGENTS / using-leankg skill lead with path · explain · query; demote full tool wa… | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-24` | FR | **DONE** | Must Have | Always-on graph-first rules/hooks: nudge before grep/Read; optional strict first-Read redi… | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-07` | FR | **DONE** | Must Have | Relationship metadata field 'confidence_label' ∈ {EXTRACTED, INFERRED, AMBIGUOUS} written … | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-08` | FR | **DONE** | Must Have | Map 'resolution_method' → 'confidence_label' at edge write time; backfill on reindex | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-09` | FR | **DONE** | Must Have | Propagate 'confidence_label' in impact, call_graph, path, query_graph, Web UI | 5.9 Graphify-Inspired Features |
+| **P1** | `REL-043` | Release | **DONE** | Must Have | US-GF-04 provenance labels on all relationship types | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `FR-GF-13` | FR | **NOT_DONE** | Must Have | Auto-generate '.leankg/GRAPH_REPORT.md' on every index (CLI 'leankg report' / MCP 'get_gra… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-21` | FR | **NOT_DONE** | Must Have | CLI/MCP export html — single-file bounded subgraph/community; document node budget | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-UI2-08` | FR | **NOT_DONE** | Must Have | Query FAB dual-mode: NL → query_graph; Advanced → raw Cozo POST /api/query | 5.19 UI v2 Graph Explorer |
@@ -255,7 +267,7 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 | **P3** | `FR-SEM-05` | FR | **NOT_DONE** | Could Have | Optional file-diversity / MMR post-filter after HNSW+rerank (top-k not ≥70% one file) | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P3** | `FR-SURF-06` | FR | **NOT_DONE** | Could Have | Mega-safe get_doc_structure/tree; optional merge format tree\|list after safety | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
 | **P3** | `REL-041` | Release | **NOT_DONE** | Could Have | 3D graph UI Track E ('graph-ui/'; keep 2D 'ui/') | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
-| **P1** | `US-UI2-07` | User Story | **PENDING** | Must Have | ui-v2 production cutover: embed into src/embed/ / Docker serve; become default explorer | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
+| **P1** | `US-UI2-07` | User Story | **DONE** | Must Have | ui-v2 production cutover: embed into src/embed/ / Docker serve; become default explorer | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
 | **P1** | `US-SURF-06` | User Story | **DONE** | Must Have | Hard-delete soft-deprecated MCP tools (wake_up, search_by_environment) after grace | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
 | **P1** | `US-SURF-07` | User Story | **DONE** | Must Have | After tool shrink: sync skills, rules, guidelines, and install/setup to reduced roster | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
 | **P2** | `US-DOCJOIN-02` | User Story | **DONE** | Must Have | Doc query tools accept human path aliases for indexed docs/… keys | 3.19 Doc↔Code Join Quality (US-DOCJOIN) — v3.7.13 |
@@ -265,8 +277,8 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 | **P2** | `US-GE-03` | User Story | **PENDING** | Should Have | Cross-alias entity resolution for same-symbol naming variants | 3.20 Graph Engineering curriculum gaps (US-GE) |
 | **P2** | `US-GE-04` | User Story | **PENDING** | Should Have | Cluster-first agent navigation (precomputed neighborhoods) | 3.20 Graph Engineering curriculum gaps (US-GE) |
 | **P2** | `US-GE-05` | User Story | **PENDING** | Should Have | Closed self-improve loop: outcome write-back improves next plan | 3.20 Graph Engineering curriculum gaps (US-GE) |
-| **P1** | `US-GF-14` | User Story | **PENDING** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
-| **P1** | `US-GF-17` | User Story | **PENDING** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-14` | User Story | **DONE** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-17` | User Story | **DONE** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
 | **P1** | `US-GF-13` | User Story | **PENDING** | Must Have | Shareable single-file HTML graph export (leankg export html, bounded subgraph/community) | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
 | **P1** | `US-UI2-06` | User Story | **PENDING** | Must Have | Query FAB NL mode calls query_graph (raw Cozo remains advanced) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
 | **P2** | `US-CBM-A1` | User Story | **PENDING** | Should Have | Correct MCP 'project' routing (multi-mount ≠ wrong RocksDB project) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
@@ -290,9 +302,9 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 | **P3** | `US-SEM-04` | User Story | **PENDING** | Could Have | Semantic hit diversity across files (MMR / file-diversity post-filter) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
 | **P3** | `US-GE-06` | User Story | **PENDING** | Could Have | Selective LLM pass-2 for workflows/decisions (YAML remains SoT) | 3.20 Graph Engineering curriculum gaps (US-GE) |
 | **P3** | `US-SURF-05` | User Story | **PENDING** | Could Have | Optional unify get_doc_tree + get_doc_structure (mega-safe first) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
-| **P1** | `FR-COST-01` | FR | **PARTIAL** | Must Have | Publish ROI brief: token/tool-call floors, multi-repo Docker TCO, mega-graph + ops differe… | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `US-COST-01` | User Story | **PARTIAL** | Must Have | Manager ROI brief: why LeanKG reduces AI agent cost vs grep/cat and vs Graphify at company… | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `US-GF-04` | User Story | **PARTIAL** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `FR-COST-01` | FR | **DONE** | Must Have | Publish ROI brief: token/tool-call floors, multi-repo Docker TCO, mega-graph + ops differe… | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `US-COST-01` | User Story | **DONE** | Must Have | Manager ROI brief: why LeanKG reduces AI agent cost vs grep/cat and vs Graphify at company… | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `US-GF-04` | User Story | **DONE** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
 | **P1** | `US-GF-06` | User Story | **PARTIAL** | Must Have | Generate 'GRAPH_REPORT.md': god nodes, surprising cross-module links, suggested questions,… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
 | **P1** | `US-MG-02` | User Story | **PARTIAL** | Must Have | Single-repo projects expand fully on service double-click (no multi-level drilling) | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
 | **P2** | `US-08` | User Story | **PARTIAL** | Should Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |
@@ -311,9 +323,9 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 
 | Focus | ID | Kind | Status | Priority | Title | PRD § |
 |------:|----|------|--------|----------|-------|-------|
-| **P1** | `REL-058` | Release | **NOT_DONE** | Must Have | Manager ROI brief checked into docs/reports/ and linked from README competitive section | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `FR-UI2-09` | FR | **NOT_DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
-| **P1** | `REL-057` | Release | **NOT_DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
+| **P1** | `REL-058` | Release | **DONE** | Must Have | Manager ROI brief checked into docs/reports/ and linked from README competitive section | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `FR-UI2-09` | FR | **DONE** | Must Have | Build ui-v2 into src/embed/; leankg serve + Docker serve ui-v2 by default | 5.19 UI v2 Graph Explorer |
+| **P1** | `REL-057` | Release | **DONE** | Must Have | ui-v2 cutover evidence: smoke + screenshots that embed/Docker serves ui-v2 as default | 5.19 UI v2 Graph Explorer |
 | **P1** | `FR-SURF-07` | FR | **DONE** | Must Have | Hard-delete wake_up from ToolRegistry + handlers; matrix AlreadyRemoved; smoke MUTATING li… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
 | **P1** | `FR-SURF-08` | FR | **DONE** | Must Have | Hard-delete search_by_environment; callers use env= on search_code/semantic_search/concept… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
 | **P1** | `FR-SURF-09` | FR | **DONE** | Must Have | Sync repo guidelines: AGENTS.md, CLAUDE.md, docs/mcp-tools.md, mcp-setup.md, agentic-instr… | 5.18 MCP Tool Surface Rationalization (v3.7.12) |
@@ -323,12 +335,12 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 | **P2** | `FR-GE-01` | FR | **DONE** | Must Have | Publish graph-engineering curriculum fit matrix vs LeanKG | 5.23 Graph Engineering curriculum gaps (v3.7.14) |
 | **P2** | `REL-064` | Release | **DONE** | Must Have | Analysis + PRD §1.2/§3.20/§5.23 + tracker rows on main | 5.23 Graph Engineering curriculum gaps (v3.7.14) |
 | **P2** | `US-GE-01` | User Story | **DONE** | Must Have | Published fit matrix: LeanKG as graph memory under agent harnesses | 3.20 Graph Engineering curriculum gaps (US-GE) |
-| **P1** | `FR-GF-22` | FR | **NOT_DONE** | Must Have | README / AGENTS / using-leankg skill lead with path · explain · query; demote full tool wa… | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-24` | FR | **NOT_DONE** | Must Have | Always-on graph-first rules/hooks: nudge before grep/Read; optional strict first-Read redi… | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-07` | FR | **NOT_DONE** | Must Have | Relationship metadata field 'confidence_label' ∈ {EXTRACTED, INFERRED, AMBIGUOUS} written … | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-08` | FR | **NOT_DONE** | Must Have | Map 'resolution_method' → 'confidence_label' at edge write time; backfill on reindex | 5.9 Graphify-Inspired Features |
-| **P1** | `FR-GF-09` | FR | **NOT_DONE** | Must Have | Propagate 'confidence_label' in impact, call_graph, path, query_graph, Web UI | 5.9 Graphify-Inspired Features |
-| **P1** | `REL-043` | Release | **NOT_DONE** | Must Have | US-GF-04 provenance labels on all relationship types | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
+| **P1** | `FR-GF-22` | FR | **DONE** | Must Have | README / AGENTS / using-leankg skill lead with path · explain · query; demote full tool wa… | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-24` | FR | **DONE** | Must Have | Always-on graph-first rules/hooks: nudge before grep/Read; optional strict first-Read redi… | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-07` | FR | **DONE** | Must Have | Relationship metadata field 'confidence_label' ∈ {EXTRACTED, INFERRED, AMBIGUOUS} written … | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-08` | FR | **DONE** | Must Have | Map 'resolution_method' → 'confidence_label' at edge write time; backfill on reindex | 5.9 Graphify-Inspired Features |
+| **P1** | `FR-GF-09` | FR | **DONE** | Must Have | Propagate 'confidence_label' in impact, call_graph, path, query_graph, Web UI | 5.9 Graphify-Inspired Features |
+| **P1** | `REL-043` | Release | **DONE** | Must Have | US-GF-04 provenance labels on all relationship types | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
 | **P1** | `FR-GF-13` | FR | **NOT_DONE** | Must Have | Auto-generate '.leankg/GRAPH_REPORT.md' on every index (CLI 'leankg report' / MCP 'get_gra… | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-GF-21` | FR | **NOT_DONE** | Must Have | CLI/MCP export html — single-file bounded subgraph/community; document node budget | 5.9 Graphify-Inspired Features |
 | **P1** | `FR-UI2-08` | FR | **NOT_DONE** | Must Have | Query FAB dual-mode: NL → query_graph; Advanced → raw Cozo POST /api/query | 5.19 UI v2 Graph Explorer |
@@ -400,11 +412,11 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 | **P3** | `FR-SEM-05` | FR | **NOT_DONE** | Could Have | Optional file-diversity / MMR post-filter after HNSW+rerank (top-k not ≥70% one file) | 5.15 Semantic MCP Agent UX Enhancements (v3.7.1) |
 | **P3** | `FR-SURF-06` | FR | **NOT_DONE** | Could Have | Mega-safe get_doc_structure/tree; optional merge format tree\|list after safety | 5.18 MCP Tool Surface Rationalization (v3.7.4) |
 | **P3** | `REL-041` | Release | **NOT_DONE** | Could Have | 3D graph UI Track E ('graph-ui/'; keep 2D 'ui/') | 8.3 v3.6 Roll-up (Current: v0.17.9) - STATUS |
-| **P1** | `US-UI2-07` | User Story | **PENDING** | Must Have | ui-v2 production cutover: embed into src/embed/ / Docker serve; become default explorer | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
+| **P1** | `US-UI2-07` | User Story | **DONE** | Must Have | ui-v2 production cutover: embed into src/embed/ / Docker serve; become default explorer | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
 | **P1** | `US-SURF-06` | User Story | **DONE** | Must Have | Hard-delete soft-deprecated MCP tools (wake_up, search_by_environment) after grace | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
 | **P1** | `US-SURF-07` | User Story | **DONE** | Must Have | After tool shrink: sync skills, rules, guidelines, and install/setup to reduced roster | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.12 |
-| **P1** | `US-GF-14` | User Story | **PENDING** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
-| **P1** | `US-GF-17` | User Story | **PENDING** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-14` | User Story | **DONE** | Must Have | Three-verb product narrative: path · explain · query first in README / AGENTS / skills | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
+| **P1** | `US-GF-17` | User Story | **DONE** | Must Have | Always-on graph-first install/hooks (Cursor/Claude/Codex) — primary company cost lever | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
 | **P1** | `US-GF-13` | User Story | **PENDING** | Must Have | Shareable single-file HTML graph export (leankg export html, bounded subgraph/community) | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-17) |
 | **P1** | `US-UI2-06` | User Story | **PENDING** | Must Have | Query FAB NL mode calls query_graph (raw Cozo remains advanced) | 3.17 UI v2 — GitNexus Shell Adapted (US-UI2) |
 | **P2** | `US-CBM-A1` | User Story | **PENDING** | Should Have | Correct MCP 'project' routing (multi-mount ≠ wrong RocksDB project) | 3.11 CBM Structural Parity Stories (US-CBM) — merged from 'p… |
@@ -428,9 +440,9 @@ Evidence baseline: [`mcp-tool-redundancy-impact-2026-07-20.md`](reports/mcp-tool
 | **P3** | `US-SEM-04` | User Story | **PENDING** | Could Have | Semantic hit diversity across files (MMR / file-diversity post-filter) | 3.14 Semantic MCP Agent UX Enhancements (US-SEM) — v3.7.1 |
 | **P3** | `US-GE-06` | User Story | **PENDING** | Could Have | Selective LLM pass-2 for workflows/decisions (YAML remains SoT) | 3.20 Graph Engineering curriculum gaps (US-GE) |
 | **P3** | `US-SURF-05` | User Story | **PENDING** | Could Have | Optional unify get_doc_tree + get_doc_structure (mega-safe first) | 3.16 MCP Tool Surface Rationalization (US-SURF) — v3.7.4 |
-| **P1** | `FR-COST-01` | FR | **PARTIAL** | Must Have | Publish ROI brief: token/tool-call floors, multi-repo Docker TCO, mega-graph + ops differe… | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `US-COST-01` | User Story | **PARTIAL** | Must Have | Manager ROI brief: why LeanKG reduces AI agent cost vs grep/cat and vs Graphify at company… | 5.20 Company cost / competitive ROI (v3.7.8) |
-| **P1** | `US-GF-04` | User Story | **PARTIAL** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
+| **P1** | `FR-COST-01` | FR | **DONE** | Must Have | Publish ROI brief: token/tool-call floors, multi-repo Docker TCO, mega-graph + ops differe… | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `US-COST-01` | User Story | **DONE** | Must Have | Manager ROI brief: why LeanKG reduces AI agent cost vs grep/cat and vs Graphify at company… | 5.20 Company cost / competitive ROI (v3.7.8) |
+| **P1** | `US-GF-04` | User Story | **DONE** | Must Have | Edge provenance labels 'EXTRACTED' / 'INFERRED' / 'AMBIGUOUS' on all relationships (unify … | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
 | **P1** | `US-GF-06` | User Story | **PARTIAL** | Must Have | Generate 'GRAPH_REPORT.md': god nodes, surprising cross-module links, suggested questions,… | 3.10 Graphify-Inspired Stories (US-GF-01 to US-GF-12) |
 | **P1** | `US-MG-02` | User Story | **PARTIAL** | Must Have | Single-repo projects expand fully on service double-click (no multi-level drilling) | 3.8 Massive Graph Stories (US-MG-01 to US-MG-05) |
 | **P2** | `US-08` | User Story | **PARTIAL** | Should Have | Multi-language support (Go, TS, Python, Rust, Java, Kotlin, C++, C#, Ruby, PHP) | 3.1 Core MVP Stories (US-01 to US-18) |

--- a/docs/reports/graph-first-install-smoke-2026-07-21.md
+++ b/docs/reports/graph-first-install-smoke-2026-07-21.md
@@ -1,0 +1,48 @@
+# Graph-first install smoke (Wave 1c)
+
+**Date:** 2026-07-21  
+**PRD:** [`docs/prd.md`](../prd.md) §5.9 / §5.20 · IDs `US-GF-17` / `FR-GF-24`
+
+---
+
+## Verdict
+
+`scripts/install.sh` installs always-on graph-first guidance for Cursor and Claude Code:
+
+| Target | Artifact | Behavior |
+|--------|----------|----------|
+| Cursor | `.cursor/rules/leankg-graph-first.mdc` + `~/.cursor/rules/leankg-graph-first.mdc` | `alwaysApply: true` — three verbs + HTTP gate |
+| Cursor | `~/.cursor/plugins/leankg/leankg-bootstrap.md` + sessionStart hook | Injects bootstrap at session start |
+| Claude Code | `~/.claude/plugins/leankg/hooks/hooks.json` | PreToolUse nudge/block when `:9699` healthy |
+| Claude Code | `pretooluse.mjs` | Blocks Bash grep/rg; nudges Read on source files (`LEANKG_STRICT_READ=1` to deny) |
+| All agents | `instructions/using-leankg/SKILL.md` via `install_leankg_skill` | Three verbs before prefer-order |
+
+Template source: [`instructions/cursor-rules/leankg-graph-first.mdc`](../../instructions/cursor-rules/leankg-graph-first.mdc)
+
+---
+
+## Smoke commands
+
+```bash
+# From LeanKG repo root (uses local templates)
+LEANKG_REPO_ROOT="$PWD" bash scripts/install.sh cursor
+test -f .cursor/rules/leankg-graph-first.mdc || test -f "$HOME/.cursor/rules/leankg-graph-first.mdc"
+
+LEANKG_REPO_ROOT="$PWD" bash scripts/install.sh claude
+test -f "$HOME/.claude/plugins/leankg/hooks/pretooluse.mjs"
+grep -q 'pretooluse.mjs' "$HOME/.claude/plugins/leankg/hooks/hooks.json"
+
+# Health gate (Docker MCP)
+curl -sf --max-time 2 http://localhost:9699/health && echo ok
+```
+
+---
+
+## Strict Read mode (optional)
+
+```bash
+export LEANKG_STRICT_READ=1
+# Claude PreToolUse denies Read on indexed source extensions when :9699 is healthy
+```
+
+Default is **nudge** (additionalContext) so agents can still Read when graph context is insufficient.

--- a/docs/reports/graph-first-install-smoke-2026-07-21.md
+++ b/docs/reports/graph-first-install-smoke-2026-07-21.md
@@ -11,11 +11,11 @@
 
 | Target | Artifact | Behavior |
 |--------|----------|----------|
-| Cursor | `.cursor/rules/leankg-graph-first.mdc` + `~/.cursor/rules/leankg-graph-first.mdc` | `alwaysApply: true` — three verbs + HTTP gate |
+| Cursor | `.cursor/rules/leankg-graph-first.mdc` + `~/.cursor/rules/leankg-graph-first.mdc` | `alwaysApply: true` — discover (`semantic_search`) before `query_graph` + HTTP gate |
 | Cursor | `~/.cursor/plugins/leankg/leankg-bootstrap.md` + sessionStart hook | Injects bootstrap at session start |
 | Claude Code | `~/.claude/plugins/leankg/hooks/hooks.json` | PreToolUse nudge/block when `:9699` healthy |
 | Claude Code | `pretooluse.mjs` | Blocks Bash grep/rg; nudges Read on source files (`LEANKG_STRICT_READ=1` to deny) |
-| All agents | `instructions/using-leankg/SKILL.md` via `install_leankg_skill` | Three verbs before prefer-order |
+| All agents | `instructions/using-leankg/SKILL.md` via `install_leankg_skill` | Prefer-order: semantic before `query_graph` |
 
 Template source: [`instructions/cursor-rules/leankg-graph-first.mdc`](../../instructions/cursor-rules/leankg-graph-first.mdc)
 

--- a/docs/reports/honest-edges-smoke-2026-07-22.md
+++ b/docs/reports/honest-edges-smoke-2026-07-22.md
@@ -1,0 +1,46 @@
+# Honest Edges Smoke — Wave 2a (2026-07-22)
+
+**IDs:** `US-GF-04`, `FR-GF-07`, `FR-GF-08`, `FR-GF-09`, `REL-043`
+
+## Scope
+
+Persist and propagate edge provenance (`EXTRACTED` / `INFERRED` / `AMBIGUOUS`) across write path, reindex backfill, MCP tools, path ranking, and ui-v2.
+
+## Write path (FR-GF-07 / FR-GF-08)
+
+| Check | Result |
+|-------|--------|
+| `insert_relationship` / `insert_relationships` stamp `metadata.confidence_label` when absent | PASS — `Relationship::stamp_confidence_label_metadata()` |
+| Mapping matches `confidence_label()` / `derive_confidence_label()` | PASS — unit tests in `src/db/models.rs` |
+| Post-index backfill | PASS — `GraphEngine::backfill_confidence_labels()` hooked after `resolve_call_edges` in indexer |
+
+## MCP propagation (FR-GF-09)
+
+| Surface | Field | Result |
+|---------|-------|--------|
+| `get_call_graph` | `confidence`, `confidence_label` per edge | PASS — `CallGraphEdge` |
+| `get_impact_radius` | `confidence_label` on `elements_with_confidence` | PASS |
+| `get_files_for_doc` / `find_related_docs` | `confidence_label` via `r.confidence_label()` | PASS |
+| `shortest_path` | hop `confidence_label`; equal-length prefers EXTRACTED | PASS — `shortest_path_prefers_extracted_on_equal_length` |
+| `query_graph` / NL query | already carried labels | PASS (pre-existing) |
+
+## ui-v2
+
+| Check | Result |
+|-------|--------|
+| REST `GraphRelationship.confidenceLabel` | PASS — `src/web/handlers.rs` |
+| Sigma edge hover tooltip | PASS — `defaultDrawEdgeHover` shows `RELTYPE · LABEL` |
+
+## Tests
+
+```text
+cargo test --release --lib          → 684 passed
+cargo test --release --test integration → 27 passed
+```
+
+Key unit tests: `insert_relationship_stamps_confidence_label_metadata`, `backfill_confidence_labels_noop_when_already_stamped`, `shortest_path_prefers_extracted_on_equal_length`.
+
+## Follow-up
+
+- Rebuild `src/embed/` from ui-v2 when shipping embedded UI in a release cut (`ui-v2 && npm run build` → copy to `src/embed/`).
+- Wave **2b**: auto `GRAPH_REPORT.md` on index (`FR-GF-13`).

--- a/docs/reports/leankg-vs-graphify-company-roi-2026-07-21.md
+++ b/docs/reports/leankg-vs-graphify-company-roi-2026-07-21.md
@@ -55,7 +55,7 @@ We **are** closing Graphify’s packaging wins (honest edges, `GRAPH_REPORT.md`,
 ## Recommended next actions
 
 1. Approve LeanKG as the **company** AI context / KG standard.  
-2. Execute **P1 waves in order** (Wave0 ROI link + ui-v2 cutover closeout → Wave1 always-on hooks → Wave2 honest edges / report / HTML). See PRD §1.1.  
+2. Execute **P1 waves in order** (Wave 0a ROI link + ui-v2 cutover **DONE** → Wave 1b three-verb + Wave 1c hooks **DONE** → Wave 2 honest edges / report / HTML). See PRD §1.1.  
 3. Keep Graphify optional for individuals who want a one-shot HTML map of a small folder — not as the monorepo platform.
 
 ---

--- a/docs/reports/three-verb-narrative-smoke-2026-07-21.md
+++ b/docs/reports/three-verb-narrative-smoke-2026-07-21.md
@@ -1,0 +1,27 @@
+# Three-verb narrative smoke (Wave 1b)
+
+**Date:** 2026-07-21  
+**PRD:** [`docs/prd.md`](../prd.md) §5.9 · IDs `US-GF-14` / `FR-GF-22`
+
+---
+
+## Verdict
+
+Agent-facing docs now lead with **path · explain · query** before the full MCP catalog:
+
+| File | Three-verb section |
+|------|-------------------|
+| [`README.md`](../../README.md) | MCP & Agents → Three verbs table |
+| [`AGENTS.md`](../../AGENTS.md) | Three verbs first |
+| [`CLAUDE.md`](../../CLAUDE.md) | LeanKG Tools Usage → Three verbs |
+| [`instructions/using-leankg/SKILL.md`](../../instructions/using-leankg/SKILL.md) | Three verbs first |
+| [`instructions/leankg-tools.md`](../../instructions/leankg-tools.md) | Three verbs table |
+| [`scripts/install.sh`](../../scripts/install.sh) | Bootstrap + AGENTS template + Claude session hooks |
+
+| Verb | MCP tool |
+|------|----------|
+| path | `shortest_path` |
+| explain | `explain_node` |
+| query | `query_graph` |
+
+Discover prefer-order (`concept_search` → `semantic_search` → `search_code`) remains documented as secondary.

--- a/docs/reports/three-verb-narrative-smoke-2026-07-21.md
+++ b/docs/reports/three-verb-narrative-smoke-2026-07-21.md
@@ -1,27 +1,27 @@
-# Three-verb narrative smoke (Wave 1b)
+# Prefer-order narrative smoke (Wave 1b → discover-first)
 
-**Date:** 2026-07-21  
+**Date:** 2026-07-22  
 **PRD:** [`docs/prd.md`](../prd.md) §5.9 · IDs `US-GF-14` / `FR-GF-22`
 
 ---
 
 ## Verdict
 
-Agent-facing docs now lead with **path · explain · query** before the full MCP catalog:
+Agent-facing docs lead with **discover before connection verbs** for fuzzy / NL questions: `concept_search` → **`semantic_search`** before `query_graph`. Connection verbs (`shortest_path` / `explain_node` / `query_graph`) run only with known seeds or endpoints.
 
-| File | Three-verb section |
-|------|-------------------|
-| [`README.md`](../../README.md) | MCP & Agents → Three verbs table |
-| [`AGENTS.md`](../../AGENTS.md) | Three verbs first |
-| [`CLAUDE.md`](../../CLAUDE.md) | LeanKG Tools Usage → Three verbs |
-| [`instructions/using-leankg/SKILL.md`](../../instructions/using-leankg/SKILL.md) | Three verbs first |
-| [`instructions/leankg-tools.md`](../../instructions/leankg-tools.md) | Three verbs table |
+| File | Prefer-order section |
+|------|----------------------|
+| [`README.md`](../../README.md) | MCP & Agents → Prefer-order table |
+| [`AGENTS.md`](../../AGENTS.md) | Prefer-order (discover before connection verbs) |
+| [`CLAUDE.md`](../../CLAUDE.md) | LeanKG Tools Usage → Prefer-order |
+| [`instructions/using-leankg/SKILL.md`](../../instructions/using-leankg/SKILL.md) | Discover before `query_graph` + BAN |
+| [`instructions/leankg-tools.md`](../../instructions/leankg-tools.md) | Prefer-order table |
+| [`instructions/cursor-rules/leankg-graph-first.mdc`](../../instructions/cursor-rules/leankg-graph-first.mdc) | Always-apply Cursor rule |
 | [`scripts/install.sh`](../../scripts/install.sh) | Bootstrap + AGENTS template + Claude session hooks |
 
-| Verb | MCP tool |
-|------|----------|
-| path | `shortest_path` |
-| explain | `explain_node` |
-| query | `query_graph` |
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → `semantic_search` → `search_code` |
+| How A↔B? / known symbol / expand | `shortest_path` / `explain_node` / `query_graph` (after seeds) |
 
-Discover prefer-order (`concept_search` → `semantic_search` → `search_code`) remains documented as secondary.
+**BAN:** Do not call `query_graph` as the first NL discovery tool when embeddings/concepts may answer.

--- a/docs/reports/ui-v2-cutover-evidence-2026-07-21.md
+++ b/docs/reports/ui-v2-cutover-evidence-2026-07-21.md
@@ -1,0 +1,64 @@
+# UI v2 production cutover evidence
+
+**Date:** 2026-07-21  
+**PRD:** [`docs/prd.md`](../prd.md) §5.19 · IDs `US-UI2-07` / `FR-UI2-09` / `REL-057`  
+**Prior parity:** [`ui-v2-gitnexus-parity-2026-07-20.md`](ui-v2-gitnexus-parity-2026-07-20.md)  
+**Screenshots:** [`ui-v2-screenshots-2026-07-20.md`](ui-v2-screenshots-2026-07-20.md)
+
+---
+
+## Verdict
+
+**ui-v2 is the default embedded explorer** for `leankg serve`, Docker Option A (`:8080`), and onrender. Legacy `ui/` is source-only and not copied into `src/embed/`.
+
+---
+
+## Evidence
+
+| Check | Result |
+|-------|--------|
+| Embedded assets | `src/embed/` contains ui-v2 build (`index.html`, `assets/`, `favicon.svg`) |
+| Build stamp | `src/embed/ui-build.json` → `{"ui":"ui-v2","rev":"2026-07-21-onrender-rca2",...}` |
+| `leankg serve` | Serves embedded UI at `http://localhost:8080/` + `/api/*` REST |
+| Docker compose | `LEANKG_SERVE_HTTP=1` starts serve alongside MCP (`docker-compose.rocksdb.yml`) |
+| onrender | Multi-stage Dockerfile bakes demo index + ui-v2 embed; live demo at https://leankg.onrender.com |
+| README screenshots | Force / Tree / Circles / code panel / search / Query FAB / mega-skip gate |
+
+---
+
+## Smoke commands
+
+```bash
+# Local serve (from repo root with indexed .leankg)
+cargo run --release -- serve
+curl -sf http://localhost:8080/api/index/status | jq .
+open http://localhost:8080/
+
+# Docker (published image or compose)
+curl -sf http://localhost:8080/api/index/status
+curl -sf http://localhost:9699/health
+
+# ui-v2 dev (hot reload; proxies /api → :8080)
+cd ui-v2 && npm run dev
+```
+
+**Expected:** `/api/index/status` returns `element_count > 0` when indexed; browser loads ui-v2 shell (Force layout, filters, status bar). Mega-graph projects show skip gate with "Load graph anyway".
+
+---
+
+## Rebuild embed (after ui-v2 source changes)
+
+```bash
+cd ui-v2 && npm run build
+rm -rf ../src/embed/*
+cp -r dist/* ../src/embed/
+echo '{"ui":"ui-v2","rev":"'$(date +%Y-%m-%d)'","source":"local-main"}' > ../src/embed/ui-build.json
+cargo build --release
+```
+
+---
+
+## Known follow-ups (not blocking cutover)
+
+- Query FAB NL mode → `query_graph` (`US-UI2-06` / `FR-UI2-08`) — Wave 3
+- Cluster legend + ops panels (`FR-UI2-10` / `FR-UI2-11`) — P2

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,19 +1,19 @@
 # Roadmap
 
 > **Status SoT:** [`prd-task-tracker.md`](prd-task-tracker.md) (waves + Focus). Narrative: [`prd.md`](prd.md) §1.1.  
-> **Now (2026-07-21):** P1 company-adoption waves 0–4. P0 ontology auto-update **DONE**.  
-> **P2 follow-on:** Doc↔code join quality (`US-DOCJOIN-*` / `FR-DOCJOIN-*`) — [`prd.md`](prd.md) §3.19 / §5.22; after Wave 1a.
+> **Now (2026-07-22):** P1 waves 0a–2a **DONE**. Next: Wave **2b** auto GRAPH_REPORT. P0 ontology auto-update **DONE**.
 
 ## Current implementation order (P1 waves)
 
 | Wave | Focus | What |
 |-----:|-------|------|
-| 0a | Docs | ROI brief README link (`REL-058`) |
-| 0b | UI | ui-v2 cutover evidence (`REL-057`) |
-| **1a** | **MCP surface** | Hard-delete `wake_up` / `search_by_environment` + sync skills/rules/guidelines/setup (`US-SURF-06..07`, `FR-SURF-07..11`, `REL-062`) |
-| 1b | Agent cost | Three-verb narrative (`FR-GF-22`) |
-| 1c | Agent cost | Always-on hooks (`FR-GF-24`) |
-| 2 | Packaging | Honest edges → GRAPH_REPORT → HTML export |
+| 0a | Docs | ROI brief README link (`REL-058`) — **DONE** |
+| 0b | UI | ui-v2 cutover evidence (`REL-057`) — **DONE** |
+| **1a** | **MCP surface** | Hard-delete `wake_up` / `search_by_environment` + sync skills/rules/guidelines/setup — **DONE** |
+| 1b | Agent cost | Three-verb narrative (`FR-GF-22`) — **DONE** |
+| 1c | Agent cost | Always-on hooks (`FR-GF-24`) — **DONE** |
+| **2a** | Packaging | Honest edges (`FR-GF-07..09`) — **DONE** |
+| **2b** | Packaging | Auto GRAPH_REPORT (`FR-GF-13`) — **NEXT** |
 | 3 | UI | NL Query FAB |
 | 4 | UI | Single-repo expand |
 
@@ -67,7 +67,7 @@ PRD: [`prd.md`](prd.md) §1.1 · Analysis: [`analysis/graphify-vs-leankg-2026-07
 | Feature | PRD ID | Status | Description |
 |---------|--------|--------|-------------|
 | Shortest path / explain / NL query | US-GF-01..03 | **Done** (MCP) | Remaining gap is packaging + UI |
-| Edge provenance labels | US-GF-04 / FR-GF-07..09 | **P1 Wave 2a** | EXTRACTED / INFERRED / AMBIGUOUS |
+| Edge provenance labels | US-GF-04 / FR-GF-07..09 | **Done** | EXTRACTED / INFERRED / AMBIGUOUS |
 | GRAPH_REPORT.md | US-GF-06 / FR-GF-13 | **P1 Wave 2b** | Architecture brief on index |
 | HTML export | US-GF-13 / FR-GF-21 | **P1 Wave 2c** | Bounded single-file share |
 | Three-verb + always-on hooks | US-GF-14 / US-GF-17 | **P1 Wave 1** | Primary cost lever |

--- a/instructions/cursor-rules/leankg-graph-first.mdc
+++ b/instructions/cursor-rules/leankg-graph-first.mdc
@@ -16,23 +16,29 @@ curl -sf --max-time 2 http://localhost:9699/health
 | OK | LeanKG MCP with container `project=` (e.g. `/workspace` for Docker) |
 | Fail / timeout | Grep / Glob / Read only — do **not** call LeanKG MCP |
 
-## Three verbs first (path · explain · query)
+## Prefer-order (discover before connection verbs)
 
-Lead with these before the full tool catalog:
+For fuzzy / natural-language / “where is X?” questions, **discover first** — do **not** open with `query_graph`.
 
-| Verb | Use when | MCP tool |
-|------|----------|----------|
-| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
-| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
-| **query** | NL subgraph question | `query_graph(question, project=…)` |
+```
+1. get_overview_context(project=…)   # session start
+2. mcp_status(project=…)
+3. concept_search → semantic_search → search_code / find_function
+4. Connection verbs (only with known seeds / endpoints / symbols):
+   path → shortest_path | explain → explain_node | query → query_graph
+5. get_context / get_impact_radius / get_dependencies / get_dependents
+6. Fallback to Grep/Glob/Read only when LeanKG is down or returns empty
+```
 
-## Discover → exact (after verbs)
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → **`semantic_search`** → `search_code` |
+| Exact symbol / file name | `find_function` / `search_code` / `query_file` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| What is this known symbol? | `explain_node` |
+| Expand subgraph after seeds | `query_graph` (**after** semantic/concept hits) |
 
-1. `get_overview_context(project=…)` — session start
-2. `mcp_status(project=…)`
-3. `concept_search` → `semantic_search` → `search_code` / `find_function`
-4. `get_context` / `get_impact_radius` / `get_dependencies` / `get_dependents`
-5. Fallback to Grep/Glob/Read only when LeanKG is down or returns empty
+**BAN:** Do not call `query_graph` as the first tool for NL discovery when embeddings/concepts may answer. Use `semantic_search` (and `concept_search`) first; then `query_graph` to expand the frontier.
 
 ## Rules
 

--- a/instructions/cursor-rules/leankg-graph-first.mdc
+++ b/instructions/cursor-rules/leankg-graph-first.mdc
@@ -1,0 +1,42 @@
+---
+description: Graph-first agent workflow — query LeanKG before grep/Read when MCP HTTP is healthy
+alwaysApply: true
+---
+
+# LeanKG Graph-First (HTTP-gated)
+
+## Gate (once per session)
+
+```bash
+curl -sf --max-time 2 http://localhost:9699/health
+```
+
+| Health | Mode |
+|--------|------|
+| OK | LeanKG MCP with container `project=` (e.g. `/workspace` for Docker) |
+| Fail / timeout | Grep / Glob / Read only — do **not** call LeanKG MCP |
+
+## Three verbs first (path · explain · query)
+
+Lead with these before the full tool catalog:
+
+| Verb | Use when | MCP tool |
+|------|----------|----------|
+| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
+| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
+| **query** | NL subgraph question | `query_graph(question, project=…)` |
+
+## Discover → exact (after verbs)
+
+1. `get_overview_context(project=…)` — session start
+2. `mcp_status(project=…)`
+3. `concept_search` → `semantic_search` → `search_code` / `find_function`
+4. `get_context` / `get_impact_radius` / `get_dependencies` / `get_dependents`
+5. Fallback to Grep/Glob/Read only when LeanKG is down or returns empty
+
+## Rules
+
+- Do **not** pass host Mac paths as `project=` against Docker MCP on `:9699`
+- Do **not** grep for code navigation when LeanKG is healthy and returns hits
+- Prefer `get_context` over reading entire source files when exploring indexed code
+- Hard-removed: `wake_up`, `search_by_environment`, `mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`

--- a/instructions/leankg-tools.md
+++ b/instructions/leankg-tools.md
@@ -2,72 +2,82 @@
 
 ## Core Principle
 
-LeanKG is a **pre-built knowledge graph**. Prefer it when MCP HTTP `:9699` is healthy. If health fails, use Grep/Glob/Read — do **not** call LeanKG or `mcp_init`.
-
-Gate:
-
-```bash
-curl -sf --max-time 2 http://localhost:9699/health
-```
-
-Docker MCP: pass container `project=` (e.g. `/workspace`), not a host Mac path.
+LeanKG is a **pre-built knowledge graph** of the codebase. Always query it first — never grep/ripgrep unless the tool returns no results.
 
 ---
 
-## Semantic Discovery (prefer-order — FR-SURF-02)
+## Three verbs (path · explain · query)
 
-**Search triple:** `concept_search` → `semantic_search` → `search_code`  
-**Semantic triple:** `semantic_search` → `kg_semantic_context` → `kg_context`
+Lead with these before opening the full MCP catalog:
 
-1. `concept_search(query="...")` — domain concepts / aliases first.
-2. `semantic_search(query="...", limit=20, offset=0)` — HNSW+rerank when embeddings exist, else ontology-first.
-3. `search_code(query="...")` / `find_function(name="...")` — name/type filters after the above.
-4. Then exact tools on hits: `get_context`, `get_impact_radius`, `get_dependencies`, …
-5. `kg_semantic_context(query="...", env="local")` — ranked seeds + hop graph (needs embeddings).
-6. `kg_context(query="...")` — ontology expand without vectors.
+| Verb | Question | MCP tool |
+|------|----------|----------|
+| **path** | How does A connect to B? | `shortest_path` |
+| **explain** | What is this symbol and its neighborhood? | `explain_node` |
+| **query** | NL subgraph question | `query_graph` |
+
+Gate: `curl -sf --max-time 2 http://localhost:9699/health` — if fail, use Grep/Glob/Read only.
+
+---
+
+## Semantic Discovery (v3.6.2 — CozoDB HNSW preferred)
+
+When the binary was built with `--features embeddings` AND the embedding
+index has been built (`leankg embed` after `leankg index`), prefer the
+**HNSW-backed** vector retrieval tools. They return semantically similar
+code, ontology nodes, and graph context, ranked by cross-encoder rerank:
+
+1. `kg_semantic_context(query="...", env="local")` — best for natural-language questions ("where do we validate access rights", "how does the refund flow work"). Returns ranked seed nodes + 1-2 hop graph context.
+2. `semantic_search(query="...", limit=20, offset=0)` — paginated ontology+HNSW fallback; pagination is the safe default on mega-graphs.
+
+If `kg_semantic_context` returns "No embedded vectors found", fall back
+to the ontology layer:
+
+3. `kg_context(query="...")` — ontology-aware concept expansion (no embeddings required).
+4. `search_code(query="...")` / `find_function(name="...")` — bounded name search.
 
 ---
 
 ## Tool Selection Flowchart
 
 ```
-User asks about codebase → curl :9699/health
-  │ fail → Grep/Glob/Read
-  │ ok → mcp_status(project=…)
+User asks about codebase → mcp_status (check initialized)
   │
-  ├─ NL / domain "Where is auth?" ───────────► concept_search → semantic_search
-  │                                              then get_context on a hit
-  ├─ Exact name "Find ProcessOrder" ─────────► find_function / search_code
+  ├─ "Where is X?" / "Find Y" ───────────────► search_code or find_function
+  │   ├─ by name/type ─────────────────────────► search_code(query="X")
+  │   └─ exact function ───────────────────────► find_function(name="parseJson")
+  │                                              scope to file: find_function(name="foo", file="src/bar.rs")
   │
-  ├─ "What breaks if I change X?" ───────────► get_impact_radius(file="X", depth=2)
+  ├─ "What breaks if I change X?" ────────────► get_impact_radius(file="X", depth=2)
   │   └─ use depth<=2 for token budgets (depth=3 returns hundreds of nodes)
   │
-  ├─ "How does X work?" / call chain ────────► get_call_graph(function="X")
+  ├─ "How does X work?" / call chain ─────────► get_call_graph(function="X")
   │   └─ keep depth≤2, avoid depth>3 (neighbor explosion)
   │
-  ├─ "Who calls X?" / callers ───────────────► get_callers(function="X")
+  ├─ "Who calls X?" / callers ────────────────► get_callers(function="X")
   │
-  ├─ "What does X import/use?" ──────────────► get_dependencies(file="X")
-  ├─ "What uses X?" ─────────────────────────► get_dependents(file="X")
+  ├─ "What does X import/use?" ───────────────► get_dependencies(file="X")
+  ├─ "What uses X?" ──────────────────────────► get_dependents(file="X")
   │
-  ├─ "Show me file context" / read large file ► ctx_read(file="X", mode=adaptive)
+  ├─ "Show me file context" / read large file ─► ctx_read(file="X", mode=adaptive)
   │   └─ modes: adaptive, signatures (smallest), full, map, diff, lines("1-20,30-40")
   │
-  ├─ "Get minimal AI context for prompt" ────► get_context(file="X", signature_only=true)
+  ├─ "Get minimal AI context for prompt" ─────► get_context(file="X", signature_only=true)
   │
-  ├─ "What tests cover X?" ──────────────────► get_tested_by(file="X")
+  ├─ "What tests cover X?" ───────────────────► get_tested_by(file="X")
   │
-  ├─ "Show me all files/folders" ────────────► get_code_tree(limit=50)
+  ├─ "Show me all files/folders" ─────────────► get_code_tree(limit=50)
   │
-  ├─ "Find oversized functions" ─────────────► find_large_functions(min_lines=50, limit=20)
+  ├─ "Find oversized functions" ──────────────► find_large_functions(min_lines=50, limit=20)
   │
-  ├─ Natural language router ────────────────► orchestrate(intent="...")
-  │   └─ file param optional — only for impact/dependency intents
+  ├─ Natural language query (any of the above) ─► orchestrate(intent="...")
+  │   └─ file param is OPTIONAL — only needed for impact/dependency queries
+  │      e.g. orchestrate(intent="show me impact of changing src/lib.rs", file="src/lib.rs")
   │
-  ├─ "What docs reference X?" ───────────────► find_related_docs(file="X")
-  ├─ "What code is in this doc?" ────────────► get_files_for_doc(doc="docs/X.md")
+  ├─ "What docs reference X?" ─────────────────► find_related_docs(file="X")
+  ├─ "What code is in this doc?" ─────────────► get_files_for_doc(doc="docs/X.md")
   │
-  └─ Pre-commit risk check ──────────────────► detect_changes(scope="staged"|"all")
+  └─ Pre-commit risk check ───────────────────► detect_changes(scope="staged"|"all")
 ```
 
 ---

--- a/instructions/leankg-tools.md
+++ b/instructions/leankg-tools.md
@@ -6,15 +6,19 @@ LeanKG is a **pre-built knowledge graph** of the codebase. Always query it first
 
 ---
 
-## Three verbs (path · explain · query)
+## Prefer-order (discover before connection verbs)
 
-Lead with these before opening the full MCP catalog:
+For fuzzy / NL / “where is X?” questions **discover first** — do **not** open with `query_graph`:
 
-| Verb | Question | MCP tool |
-|------|----------|----------|
-| **path** | How does A connect to B? | `shortest_path` |
-| **explain** | What is this symbol and its neighborhood? | `explain_node` |
-| **query** | NL subgraph question | `query_graph` |
+`mcp_status` → `concept_search` → **`semantic_search`** → `search_code` / `find_function` → then connection verbs.
+
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → **`semantic_search`** → `search_code` |
+| Exact symbol / file name | `find_function` / `search_code` / `query_file` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| What is this known symbol? | `explain_node` |
+| Expand subgraph after seeds | `query_graph` (**after** semantic/concept hits) |
 
 Gate: `curl -sf --max-time 2 http://localhost:9699/health` — if fail, use Grep/Glob/Read only.
 

--- a/instructions/using-leankg/SKILL.md
+++ b/instructions/using-leankg/SKILL.md
@@ -26,16 +26,6 @@ Re-check health only if the user asks or you have reason to believe the server c
 
 ## When HTTP is healthy: LeanKG MCP
 
-### Three verbs first (path · explain · query)
-
-Before the full tool catalog, use these cheap connection verbs:
-
-| Verb | Question | MCP tool |
-|------|----------|----------|
-| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
-| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
-| **query** | NL subgraph / "what connects X to Y?" | `query_graph(question, project=…)` |
-
 ### Project path (Docker vs host)
 
 When talking to Docker MCP on `:9699`, pass the **container mount** as `project=`:
@@ -56,16 +46,19 @@ get_overview_context(project=…)  # L0+L1 summary — not load_layer(L0) alone
 → get_architecture for deep single-call overview
 ```
 
-Natural-language / domain questions:
+Natural-language / domain questions (**discover before `query_graph`**):
 
 ```
 1. mcp_status(project=…)
 2. concept_search(query=…)     # domain concepts first
-3. semantic_search(query=…)    # HNSW ANN if embeddings exist
+3. semantic_search(query=…)    # HNSW ANN if embeddings exist — REQUIRED before query_graph
 4. search_code / find_function # name/type fallback
-5. get_context / get_impact_radius / get_dependencies / …
+5. query_graph / explain_node / shortest_path  # only after seeds / known endpoints
+6. get_context / get_impact_radius / get_dependencies / …
    on the returned qualified_name or file — never full-graph dumps
 ```
+
+**BAN:** Do not call `query_graph` as the first NL discovery tool. Run `concept_search` → `semantic_search` first; use `query_graph` to expand the frontier after hits.
 
 Exact symbol / file known:
 
@@ -92,13 +85,9 @@ mcp_status → find_function / query_file → get_context → impact/deps tools
 | Blast radius | `get_impact_radius` |
 | Imports / dependents | `get_dependencies` / `get_dependents` |
 | Tests | `get_tested_by` |
-| NL subgraph | `query_graph` (frontier-local; mega-safe) |
+| NL subgraph (after discovery) | `query_graph` (frontier-local; mega-safe) — **not** first-hop NL |
 | Session overview | `get_overview_context` |
 | Environment filter | `env=` on `search_code` / `semantic_search` / `concept_search` / `kg_*` |
-
-### Hard-removed tools (do not call)
-
-`mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`
 
 ### Doc↔code join (structural markdown ↔ file keys)
 
@@ -113,6 +102,10 @@ After `mcp_index_docs`, path aliases resolve on read; markdown refs resolve to i
 ```
 
 Miss payloads include `tried[]` — do not assume empty graph when aliases fail.
+
+### Hard-removed tools (do not call)
+
+`mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`
 
 ### If mcp_status is not ready (but HTTP health was OK)
 

--- a/instructions/using-leankg/SKILL.md
+++ b/instructions/using-leankg/SKILL.md
@@ -26,6 +26,16 @@ Re-check health only if the user asks or you have reason to believe the server c
 
 ## When HTTP is healthy: LeanKG MCP
 
+### Three verbs first (path · explain · query)
+
+Before the full tool catalog, use these cheap connection verbs:
+
+| Verb | Question | MCP tool |
+|------|----------|----------|
+| **path** | How does A connect to B? | `shortest_path(source, target, project=…)` |
+| **explain** | What is this symbol and its neighborhood? | `explain_node(name_or_qn, project=…)` |
+| **query** | NL subgraph / "what connects X to Y?" | `query_graph(question, project=…)` |
+
 ### Project path (Docker vs host)
 
 When talking to Docker MCP on `:9699`, pass the **container mount** as `project=`:

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -542,27 +542,24 @@ const ROUTING_BLOCK = `
 <tool_selection_hierarchy>
   Gate: curl -sf --max-time 2 http://localhost:9699/health — if fail, use Grep/Glob/Read (no LeanKG).
 
-  Three verbs first (path · explain · query):
-  - path → shortest_path(source, target, project=…)
-  - explain → explain_node(name_or_qn, project=…)
-  - query → query_graph(question, project=…)
-
-  Prefer-order (HTTP healthy):
+  Prefer-order (HTTP healthy) — discover BEFORE query_graph:
   0. get_overview_context(project=…) — session start; not load_layer(L0) alone
   1. mcp_status(project=…) — container path e.g. /workspace for Docker
   2. DISCOVER: concept_search → semantic_search → search_code / find_function
-  3. EXACT: get_context / get_impact_radius / get_dependencies / get_dependents
-  4. CALLERS: get_callers / get_call_graph
-  5. DOCS: get_traceability / find_related_docs / get_files_for_doc
-  6. TESTING: get_tested_by / detect_changes
-  7. ORCHESTRATE: orchestrate(intent) when unsure which tool
-  8. ENV: env= on search/kg_* (never search_by_environment — removed)
+  3. CONNECTION (after seeds): shortest_path / explain_node / query_graph
+  4. EXACT: get_context / get_impact_radius / get_dependencies / get_dependents
+  5. CALLERS: get_callers / get_call_graph
+  6. DOCS: get_traceability / find_related_docs / get_files_for_doc
+  7. TESTING: get_tested_by / detect_changes
+  8. ORCHESTRATE: orchestrate(intent) when unsure which tool
+  9. ENV: env= on search/kg_* (never search_by_environment — removed)
 </tool_selection_hierarchy>
 
 <forbidden_actions>
   - Do NOT call LeanKG when :9699 health failed
   - Do NOT pass host Mac paths as project= against Docker MCP (use /workspace)
   - Do NOT use Grep for code search when LeanKG is healthy and returns hits
+  - Do NOT open NL discovery with query_graph — run concept_search → semantic_search first
   - Do NOT call removed tools (get_doc_for_file, mcp_hello, mcp_impact, find_clones, wake_up, search_by_environment)
 </forbidden_actions>
 `;
@@ -657,8 +654,8 @@ function buildReadGuidance(toolInput) {
   const path = toolInput.path || toolInput.file_path || toolInput.file || "";
   return `LEANKG graph-first: Prefer mcp__leankg__get_context(file="${path}") or explain_node before full Read.
 
-Three verbs: shortest_path · explain_node · query_graph
-Then: concept_search → semantic_search → search_code → get_context
+Discover first: concept_search → semantic_search → search_code → get_context
+Then connection verbs: shortest_path · explain_node · query_graph (after seeds)
 
 Set LEANKG_STRICT_READ=1 to hard-block first Read on source files.`;
 }
@@ -932,21 +929,23 @@ function buildSessionContext(input) {
   const context = `<tool_selection_hierarchy>
   Gate: curl -sf --max-time 2 http://localhost:9699/health — if fail, use Grep/Glob/Read (no LeanKG).
 
-  Three verbs first: shortest_path · explain_node · query_graph
+  Prefer-order: concept_search → semantic_search → search_code (before query_graph)
 
   1. mcp_status(project=…) — Docker: /workspace (not host Mac path)
   2. DISCOVER: concept_search → semantic_search → search_code / find_function
-  3. EXACT: get_context / get_impact_radius / get_dependencies / get_dependents
-  4. CALLERS: get_callers / get_call_graph
-  5. DOCS: get_traceability / find_related_docs / get_files_for_doc
-  6. TESTING: get_tested_by / detect_changes
-  7. ORCHESTRATE: orchestrate(intent) when unsure
+  3. CONNECTION (after seeds): shortest_path / explain_node / query_graph
+  4. EXACT: get_context / get_impact_radius / get_dependencies / get_dependents
+  5. CALLERS: get_callers / get_call_graph
+  6. DOCS: get_traceability / find_related_docs / get_files_for_doc
+  7. TESTING: get_tested_by / detect_changes
+  8. ORCHESTRATE: orchestrate(intent) when unsure
 </tool_selection_hierarchy>
 
 <forbidden_actions>
   - Do NOT call LeanKG when :9699 health failed
   - Do NOT pass host Mac paths as project= against Docker MCP
   - Do NOT use Grep when LeanKG is healthy and returns hits
+  - Do NOT open NL discovery with query_graph — run semantic_search first
   - Do NOT call removed tools (get_doc_for_file, mcp_hello, mcp_impact, find_clones, wake_up, search_by_environment)
 </forbidden_actions>
 
@@ -1099,13 +1098,16 @@ HOOKEOF
     cat > "$plugin_dir/leankg-bootstrap.md" <<'BOOTSTRAPEOF'
 # LeanKG Bootstrap
 
-## Three verbs first (path · explain · query)
+## Prefer-order (discover before connection verbs)
 
-| Verb | MCP tool |
-|------|----------|
-| **path** — how does A connect to B? | `shortest_path` |
-| **explain** — symbol neighborhood | `explain_node` |
-| **query** — NL subgraph | `query_graph` |
+For fuzzy / NL questions: `concept_search` → **`semantic_search`** → `search_code` — **before** `query_graph`.
+
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → `semantic_search` → `search_code` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| Known symbol neighborhood | `explain_node` |
+| Expand subgraph after seeds | `query_graph` |
 
 Gate: `curl -sf --max-time 2 http://localhost:9699/health` — if fail, use Grep/Glob/Read only.
 
@@ -1208,13 +1210,16 @@ HOOKEOF
     cat > "$plugin_dir/leankg-bootstrap.md" <<'BOOTSTRAPEOF'
 # LeanKG Bootstrap
 
-## Three verbs first (path · explain · query)
+## Prefer-order (discover before connection verbs)
 
-| Verb | MCP tool |
-|------|----------|
-| **path** — how does A connect to B? | `shortest_path` |
-| **explain** — symbol neighborhood | `explain_node` |
-| **query** — NL subgraph | `query_graph` |
+For fuzzy / NL questions: `concept_search` → **`semantic_search`** → `search_code` — **before** `query_graph`.
+
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → `semantic_search` → `search_code` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| Known symbol neighborhood | `explain_node` |
+| Expand subgraph after seeds | `query_graph` |
 
 Gate: `curl -sf --max-time 2 http://localhost:9699/health` — if fail, use Grep/Glob/Read only.
 
@@ -1523,8 +1528,8 @@ install_leankg_skill() {
 
     # Refresh when missing or still on the old mandatory / RTK template.
     local needs_update=1
-    if [ -f "$dest" ] && grep -q 'prefer-order' "$dest" 2>/dev/null \
-        && grep -q 'Three verbs\|path · explain' "$dest" 2>/dev/null \
+    if [ -f "$dest" ] && grep -q 'prefer-order\|Prefer-order\|discover before' "$dest" 2>/dev/null \
+        && grep -q 'semantic_search' "$dest" 2>/dev/null \
         && grep -q 'HTTP-gated\|:9699/health' "$dest" 2>/dev/null \
         && ! grep -q 'STRICT ENFORCEMENT' "$dest" 2>/dev/null; then
         needs_update=0
@@ -1553,9 +1558,11 @@ description: >-
 Gate: `curl -sf --max-time 2 http://localhost:9699/health`
 - Fail → Grep/Glob/Read only (no MCP, no mcp_init)
 - OK → mcp_status(project=…) then prefer-order:
-  concept_search → semantic_search → search_code / find_function → get_context
+  concept_search → semantic_search → search_code / find_function
+  then (after seeds): query_graph / explain_node / shortest_path → get_context
 
 Docker MCP: pass container project= (`/workspace`), not a host Mac path.
+BAN: Do not open NL discovery with query_graph when semantic_search may answer.
 EOF
         fi
     fi
@@ -1573,13 +1580,16 @@ install_agents_instructions() {
 
 ## LeanKG Tools Usage (HTTP-gated)
 
-### Three verbs first (path · explain · query)
+### Prefer-order (discover before connection verbs)
 
-| Verb | Question | MCP tool |
-|------|----------|----------|
-| **path** | How does A connect to B? | `shortest_path` |
-| **explain** | What is this symbol and its neighborhood? | `explain_node` |
-| **query** | NL subgraph question | `query_graph` |
+For fuzzy / NL questions: `concept_search` → **`semantic_search`** → `search_code` — **before** `query_graph`.
+
+| Question type | First tools |
+|---------------|-------------|
+| Fuzzy / meaning / domain NL | `concept_search` → `semantic_search` → `search_code` |
+| How A↔B? (known endpoints) | `shortest_path` |
+| Known symbol neighborhood | `explain_node` |
+| Expand subgraph after seeds | `query_graph` |
 
 ### Gate first
 
@@ -1624,7 +1634,7 @@ EOF
 )
 
     if [ -f "$agents_file" ]; then
-        if grep -q 'prefer-order\|Three verbs\|path · explain' "$agents_file" 2>/dev/null \
+        if grep -q 'prefer-order\|Prefer-order\|discover before\|semantic_search' "$agents_file" 2>/dev/null \
             && grep -q 'HTTP-gated\|:9699/health' "$agents_file" 2>/dev/null \
             && ! grep -q 'MANDATORY RULE - ALWAYS USE LEANKG FIRST\|mcp_init first' "$agents_file" 2>/dev/null; then
             echo "LeanKG instructions already up to date in $agents_file"

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -265,6 +265,48 @@ configure_opencode() {
     echo "Configured LeanKG plugin and MCP for OpenCode at $config_file"
 }
 
+install_cursor_graph_first_rule() {
+    local rule_src=""
+    if [ -n "${LEANKG_REPO_ROOT:-}" ] && [ -f "${LEANKG_REPO_ROOT}/instructions/cursor-rules/leankg-graph-first.mdc" ]; then
+        rule_src="${LEANKG_REPO_ROOT}/instructions/cursor-rules/leankg-graph-first.mdc"
+    elif [ -n "${BASH_SOURCE[0]:-}" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+        local _root
+        _root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." 2>/dev/null && pwd || true)"
+        if [ -n "$_root" ] && [ -f "$_root/instructions/cursor-rules/leankg-graph-first.mdc" ]; then
+            rule_src="$_root/instructions/cursor-rules/leankg-graph-first.mdc"
+        fi
+    elif [ -f "$(pwd)/instructions/cursor-rules/leankg-graph-first.mdc" ]; then
+        rule_src="$(pwd)/instructions/cursor-rules/leankg-graph-first.mdc"
+    else
+        local rule_url="${INSTRUCTIONS_DIR}/cursor-rules/leankg-graph-first.mdc"
+        local tmp_rule
+        tmp_rule=$(mktemp)
+        if curl -fsSL "$rule_url" -o "$tmp_rule" 2>/dev/null; then
+            rule_src="$tmp_rule"
+        fi
+    fi
+
+    if [ -z "$rule_src" ] || [ ! -f "$rule_src" ]; then
+        echo "WARN: leankg-graph-first.mdc template not found — skipping Cursor rule install" >&2
+        return 1
+    fi
+
+    local installed=0
+    if [ -d ".cursor" ] || [ -f ".cursor/mcp.json" ]; then
+        mkdir -p ".cursor/rules"
+        cp "$rule_src" ".cursor/rules/leankg-graph-first.mdc"
+        echo "Installed always-apply graph-first rule: .cursor/rules/leankg-graph-first.mdc"
+        installed=1
+    fi
+
+    mkdir -p "$HOME/.cursor/rules"
+    cp "$rule_src" "$HOME/.cursor/rules/leankg-graph-first.mdc"
+    echo "Installed always-apply graph-first rule: ~/.cursor/rules/leankg-graph-first.mdc"
+    installed=1
+
+    [ "$installed" = "1" ]
+}
+
 configure_cursor() {
     local config_dir="$HOME/.cursor"
     local config_file="$config_dir/mcp.json"
@@ -443,7 +485,7 @@ setup_claude_hooks() {
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/leankg-pretooluse.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/pretooluse.mjs\""
           }
         ]
       }
@@ -454,7 +496,7 @@ setup_claude_hooks() {
         "hooks": [
           {
             "type": "command",
-            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/leankg-posttooluse.mjs\""
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/posttooluse.mjs\""
           }
         ]
       }
@@ -498,7 +540,12 @@ const input = JSON.parse(raw);
 
 const ROUTING_BLOCK = `
 <tool_selection_hierarchy>
-  Gate: curl -sf http://localhost:9699/health — if fail, use Grep/Glob/Read (no LeanKG).
+  Gate: curl -sf --max-time 2 http://localhost:9699/health — if fail, use Grep/Glob/Read (no LeanKG).
+
+  Three verbs first (path · explain · query):
+  - path → shortest_path(source, target, project=…)
+  - explain → explain_node(name_or_qn, project=…)
+  - query → query_graph(question, project=…)
 
   Prefer-order (HTTP healthy):
   0. get_overview_context(project=…) — session start; not load_layer(L0) alone
@@ -532,26 +579,23 @@ HOOKEOF
 #!/usr/bin/env node
 /**
  * LeanKG PreToolUse Hook
- * Provides LeanKG context when code search is detected.
- * Only blocks Bash commands that use raw grep/find.
+ * Nudges (or strictly blocks) raw grep/Read when LeanKG HTTP is healthy.
  */
 import { spawnSync } from "node:child_process";
 
-// ─── LeanKG Tools Mapping ───
 const LEANKG_TOOLS = {
+  shortest_path: "How does A connect to B?",
+  explain_node: "What is this symbol and its neighborhood?",
+  query_graph: "NL subgraph question",
   search_code: "Search code by name/type",
   find_function: "Locate function definitions",
-  query_file: "Find files by name/pattern",
-  get_impact_radius: "Calculate blast radius",
-  get_dependencies: "Get direct imports",
-  get_dependents: "Get files depending on target",
   get_context: "Get AI-optimized file context",
-  get_tested_by: "Get test coverage",
-  get_call_graph: "Get function call graph",
-  get_callers: "Get who calls a function",
+  get_impact_radius: "Calculate blast radius",
 };
 
-// ─── Read stdin ───
+const SOURCE_EXT = /\.(rs|go|ts|tsx|js|jsx|py|java|kt|swift|cs|cpp|c|h|rb|php|sql|yaml|yml|toml|md)$/i;
+const STRICT_READ = process.env.LEANKG_STRICT_READ === "1";
+
 function readStdin() {
   return new Promise((resolve, reject) => {
     let data = "";
@@ -566,12 +610,10 @@ function readStdin() {
   });
 }
 
-// ─── Check if LeanKG is available ───
-function isLeanKGMCPReady() {
+function isLeanKGHttpHealthy() {
   try {
-    const result = spawnSync("cargo", ["run", "--release", "--", "status"], {
-      cwd: process.cwd(),
-      timeout: 5000,
+    const result = spawnSync("curl", ["-sf", "--max-time", "2", "http://localhost:9699/health"], {
+      timeout: 3000,
     });
     return result.status === 0;
   } catch {
@@ -579,42 +621,46 @@ function isLeanKGMCPReady() {
   }
 }
 
-// ─── Only block Bash with grep/find - allow other tools ───
-function shouldBlockTool(toolName, toolInput) {
+function isBashRawSearch(toolName, toolInput) {
   if (toolName !== "Bash") return false;
-
   const cmd = (toolInput.command || "").toLowerCase();
-
-  // Build commands always allowed
   const isBuildCmd = /^(cargo|npm|pnpm|yarn|go|make|cmake|rustc)/.test(cmd);
   if (isBuildCmd) return false;
-
-  // Only block if using raw grep/find in bash
   const hasRawSearch = /\b(grep|rg|ag|ack|find|fd|fzf)\b/.test(cmd);
   const isLeankgCmd = cmd.includes("leankg");
-
   return hasRawSearch && !isLeankgCmd;
 }
 
-function buildGuidance(toolInput) {
+function isSourceRead(toolName, toolInput) {
+  if (toolName !== "Read") return false;
+  const path = toolInput.path || toolInput.file_path || toolInput.file || "";
+  if (!path || typeof path !== "string") return false;
+  if (path.includes("node_modules/") || path.includes("/.git/")) return false;
+  return SOURCE_EXT.test(path);
+}
+
+function buildBashGuidance(toolInput) {
   const cmd = toolInput.command || "";
   const match = cmd.match(/['"]([^'"]+)['"]/);
   const query = match ? match[1] : "";
-
   const toolsList = Object.entries(LEANKG_TOOLS)
     .map(([name, desc]) => `  - mcp__leankg__${name}: ${desc}`)
     .join("\n");
-
-  return `LEANKG ENFORCEMENT: Raw search via Bash is blocked.
-
-Use LeanKG MCP tools instead:
+  return `LEANKG: Raw Bash search blocked. Use graph-first tools:
 ${toolsList}
 
-REQUIRED WORKFLOW:
-1. mcp__leankg__mcp_status → confirm LeanKG is ready
-2. For code search: mcp__leankg__search_code("${query}") or mcp__leankg__find_function("${query}")
+Try: mcp__leankg__search_code("${query}") or mcp__leankg__concept_search("${query}")
+Original: Bash(${JSON.stringify(toolInput)})`;
+}
 
-The original tool call: Bash(${JSON.stringify(toolInput)})`;
+function buildReadGuidance(toolInput) {
+  const path = toolInput.path || toolInput.file_path || toolInput.file || "";
+  return `LEANKG graph-first: Prefer mcp__leankg__get_context(file="${path}") or explain_node before full Read.
+
+Three verbs: shortest_path · explain_node · query_graph
+Then: concept_search → semantic_search → search_code → get_context
+
+Set LEANKG_STRICT_READ=1 to hard-block first Read on source files.`;
 }
 
 async function main() {
@@ -626,21 +672,39 @@ async function main() {
     const toolName = input.tool_name || "";
     const toolInput = input.tool_input || {};
 
-    if (!shouldBlockTool(toolName, toolInput)) {
+    const healthy = isLeanKGHttpHealthy();
+    if (!healthy) process.exit(0);
+
+    if (isBashRawSearch(toolName, toolInput)) {
+      console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          permissionDecision: "deny",
+          permissionDecisionReason: buildBashGuidance(toolInput),
+        },
+      }) + "\n");
       process.exit(0);
     }
 
-    const leanKGReady = isLeanKGMCPReady();
-    if (!leanKGReady) process.exit(0);
+    if (isSourceRead(toolName, toolInput)) {
+      if (STRICT_READ) {
+        console.log(JSON.stringify({
+          hookSpecificOutput: {
+            hookEventName: "PreToolUse",
+            permissionDecision: "deny",
+            permissionDecisionReason: buildReadGuidance(toolInput),
+          },
+        }) + "\n");
+        process.exit(0);
+      }
+      console.log(JSON.stringify({
+        hookSpecificOutput: {
+          hookEventName: "PreToolUse",
+          additionalContext: buildReadGuidance(toolInput),
+        },
+      }) + "\n");
+    }
 
-    // LeanKG ready - block Bash search commands
-    console.log(JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: "PreToolUse",
-        permissionDecision: "deny",
-        permissionDecisionReason: buildGuidance(toolInput),
-      },
-    }) + "\n");
     process.exit(0);
   } catch {
     process.exit(0);
@@ -866,7 +930,10 @@ function buildSessionContext(input) {
   const projectType = detectProjectType(cwd);
 
   const context = `<tool_selection_hierarchy>
-  Gate: curl -sf http://localhost:9699/health — if fail, use Grep/Glob/Read (no LeanKG).
+  Gate: curl -sf --max-time 2 http://localhost:9699/health — if fail, use Grep/Glob/Read (no LeanKG).
+
+  Three verbs first: shortest_path · explain_node · query_graph
+
   1. mcp_status(project=…) — Docker: /workspace (not host Mac path)
   2. DISCOVER: concept_search → semantic_search → search_code / find_function
   3. EXACT: get_context / get_impact_radius / get_dependencies / get_dependents
@@ -1029,11 +1096,18 @@ HOOKEOF
 
     chmod +x "$plugin_dir/hooks/sessionstart.mjs" "$plugin_dir/hooks/pretooluse.mjs" "$plugin_dir/hooks/posttooluse.mjs" "$plugin_dir/hooks/version-check.mjs" "$plugin_dir/hooks/session-init.mjs" "$plugin_dir/hooks/summarize.mjs"
     
-    if [ ! -f "$plugin_dir/leankg-bootstrap.md" ]; then
-        cat > "$plugin_dir/leankg-bootstrap.md" <<'BOOTSTRAPEOF'
+    cat > "$plugin_dir/leankg-bootstrap.md" <<'BOOTSTRAPEOF'
 # LeanKG Bootstrap
 
-LeanKG is a lightweight knowledge graph for codebase understanding.
+## Three verbs first (path · explain · query)
+
+| Verb | MCP tool |
+|------|----------|
+| **path** — how does A connect to B? | `shortest_path` |
+| **explain** — symbol neighborhood | `explain_node` |
+| **query** — NL subgraph | `query_graph` |
+
+Gate: `curl -sf --max-time 2 http://localhost:9699/health` — if fail, use Grep/Glob/Read only.
 
 **Multi-Project Support:**
 LeanKG uses a single HTTP server that supports multiple projects. Each tool accepts a `project` parameter to specify the target project directory. The server routes queries to the correct `.leankg` database automatically.
@@ -1077,8 +1151,7 @@ Before ANY codebase search/navigation, you MUST:
 | Manual dependency tracing | `get_impact_radius(file="X", project="/path")` or `get_dependencies(file="X", project="/path")` |
 | Reading entire files | `get_context(file="X", project="/path")` (token-optimized) |
 BOOTSTRAPEOF
-        echo "Created leankg-bootstrap.md for Claude Code"
-    fi
+    echo "Refreshed leankg-bootstrap.md for Claude Code"
     
     if [ "$hooks_installed" = true ]; then
         echo "Configured LeanKG hooks for Claude Code"
@@ -1132,11 +1205,18 @@ HOOKEOF
         hooks_installed=true
     fi
     
-    if [ ! -f "$plugin_dir/leankg-bootstrap.md" ]; then
-        cat > "$plugin_dir/leankg-bootstrap.md" <<'BOOTSTRAPEOF'
+    cat > "$plugin_dir/leankg-bootstrap.md" <<'BOOTSTRAPEOF'
 # LeanKG Bootstrap
 
-LeanKG is a lightweight knowledge graph for codebase understanding.
+## Three verbs first (path · explain · query)
+
+| Verb | MCP tool |
+|------|----------|
+| **path** — how does A connect to B? | `shortest_path` |
+| **explain** — symbol neighborhood | `explain_node` |
+| **query** — NL subgraph | `query_graph` |
+
+Gate: `curl -sf --max-time 2 http://localhost:9699/health` — if fail, use Grep/Glob/Read only.
 
 **Multi-Project Support:**
 LeanKG uses a single HTTP server that supports multiple projects. Each tool accepts a `project` parameter to specify the target project directory. The server routes queries to the correct `.leankg` database automatically.
@@ -1180,8 +1260,7 @@ Before ANY codebase search/navigation, you MUST:
 | Manual dependency tracing | `get_impact_radius(file="X", project="/path")` or `get_dependencies(file="X", project="/path")` |
 | Reading entire files | `get_context(file="X", project="/path")` (token-optimized) |
 BOOTSTRAPEOF
-        echo "Created leankg-bootstrap.md for Cursor"
-    fi
+    echo "Refreshed leankg-bootstrap.md for Cursor"
     
     if [ "$hooks_installed" = true ]; then
         echo "Configured LeanKG hooks for Cursor"
@@ -1445,6 +1524,7 @@ install_leankg_skill() {
     # Refresh when missing or still on the old mandatory / RTK template.
     local needs_update=1
     if [ -f "$dest" ] && grep -q 'prefer-order' "$dest" 2>/dev/null \
+        && grep -q 'Three verbs\|path · explain' "$dest" 2>/dev/null \
         && grep -q 'HTTP-gated\|:9699/health' "$dest" 2>/dev/null \
         && ! grep -q 'STRICT ENFORCEMENT' "$dest" 2>/dev/null; then
         needs_update=0
@@ -1493,6 +1573,14 @@ install_agents_instructions() {
 
 ## LeanKG Tools Usage (HTTP-gated)
 
+### Three verbs first (path · explain · query)
+
+| Verb | Question | MCP tool |
+|------|----------|----------|
+| **path** | How does A connect to B? | `shortest_path` |
+| **explain** | What is this symbol and its neighborhood? | `explain_node` |
+| **query** | NL subgraph question | `query_graph` |
+
 ### Gate first
 
 ```bash
@@ -1536,7 +1624,8 @@ EOF
 )
 
     if [ -f "$agents_file" ]; then
-        if grep -q 'prefer-order\|HTTP-gated\|:9699/health' "$agents_file" 2>/dev/null \
+        if grep -q 'prefer-order\|Three verbs\|path · explain' "$agents_file" 2>/dev/null \
+            && grep -q 'HTTP-gated\|:9699/health' "$agents_file" 2>/dev/null \
             && ! grep -q 'MANDATORY RULE - ALWAYS USE LEANKG FIRST\|mcp_init first' "$agents_file" 2>/dev/null; then
             echo "LeanKG instructions already up to date in $agents_file"
         elif grep -qi "LEANKG" "$agents_file" 2>/dev/null; then
@@ -1583,6 +1672,8 @@ main() {
             update_binary "$platform"
             # Reinstall hooks on update (they may have new features)
             setup_claude_hooks
+            install_cursor_graph_first_rule || true
+            setup_cursor_hooks
             # Remove old skill (replaced by hooks)
             remove_old_skill
             echo "LeanKG hooks updated, old skill removed."
@@ -1618,6 +1709,7 @@ main() {
                 ;;
             cursor)
                 configure_cursor
+                install_cursor_graph_first_rule || true
                 setup_cursor_hooks
                 install_leankg_skill "$HOME/.cursor/skills" "cursor"
                 install_agents_instructions "$HOME/.cursor/AGENTS.md"

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -305,20 +305,68 @@ impl Relationship {
     /// `query_graph`, `explain_node`, and Web UI edge tooltips so agents
     /// can see whether an edge was explicit in source or resolver-derived.
     pub fn confidence_label(&self) -> &'static str {
-        let method = self
+        if let Some(stored) = self
             .metadata
+            .get("confidence_label")
+            .and_then(|v| v.as_str())
+        {
+            return match stored {
+                "EXTRACTED" => confidence_labels::EXTRACTED,
+                "INFERRED" => confidence_labels::INFERRED,
+                "AMBIGUOUS" => confidence_labels::AMBIGUOUS,
+                _ => confidence_labels::AMBIGUOUS,
+            };
+        }
+        Self::derive_confidence_label(self.confidence, &self.metadata)
+    }
+
+    /// FR-GF-07: Persist derived label into metadata when absent.
+    pub fn stamp_confidence_label_metadata(&mut self) {
+        if self
+            .metadata
+            .get("confidence_label")
+            .and_then(|v| v.as_str())
+            .is_some_and(|s| !s.is_empty())
+        {
+            return;
+        }
+        let label = Self::derive_confidence_label(self.confidence, &self.metadata);
+        let obj = match self.metadata.as_object_mut() {
+            Some(map) => map,
+            None => {
+                self.metadata = serde_json::json!({});
+                self.metadata.as_object_mut().unwrap()
+            }
+        };
+        obj.insert(
+            "confidence_label".to_string(),
+            serde_json::Value::String(label.to_string()),
+        );
+    }
+
+    fn derive_confidence_label(confidence: f64, metadata: &serde_json::Value) -> &'static str {
+        let method = metadata
             .get("resolution_method")
             .and_then(|v| v.as_str())
             .unwrap_or("");
         match method {
-            "typed" => "EXTRACTED",
-            "name" if self.confidence >= 0.8 => "EXTRACTED",
-            "name_file_hint" if self.confidence >= 0.6 => "INFERRED",
-            "name" => "INFERRED",
-            "unresolved" => "AMBIGUOUS",
-            _ if self.confidence >= 0.8 => "EXTRACTED",
-            _ if self.confidence >= 0.5 => "INFERRED",
-            _ => "AMBIGUOUS",
+            "typed" => confidence_labels::EXTRACTED,
+            "name" if confidence >= 0.8 => confidence_labels::EXTRACTED,
+            "name_file_hint" if confidence >= 0.6 => confidence_labels::INFERRED,
+            "name" => confidence_labels::INFERRED,
+            "unresolved" => confidence_labels::AMBIGUOUS,
+            _ if confidence >= 0.8 => confidence_labels::EXTRACTED,
+            _ if confidence >= 0.5 => confidence_labels::INFERRED,
+            _ => confidence_labels::AMBIGUOUS,
+        }
+    }
+
+    /// Lower rank = higher trust (EXTRACTED first).
+    pub fn confidence_label_rank(label: &str) -> u8 {
+        match label {
+            "EXTRACTED" => 0,
+            "INFERRED" => 1,
+            _ => 2,
         }
     }
 }

--- a/src/graph/context.rs
+++ b/src/graph/context.rs
@@ -444,6 +444,7 @@ mod tests {
             results.push(super::super::traversal::AffectedElementWithConfidence {
                 element: elem1.clone(),
                 confidence: 0.9,
+                confidence_label: "EXTRACTED".to_string(),
                 severity: "WILL BREAK".to_string(),
                 depth: 1,
             });
@@ -454,6 +455,7 @@ mod tests {
             results.push(super::super::traversal::AffectedElementWithConfidence {
                 element: elem2.clone(),
                 confidence: 0.5,
+                confidence_label: "INFERRED".to_string(),
                 severity: "MAY BE AFFECTED".to_string(),
                 depth: 2,
             });

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -2081,21 +2081,23 @@ impl GraphEngine {
         &self,
         relationship: &Relationship,
     ) -> Result<(), Box<dyn std::error::Error>> {
-        let metadata_str = serde_json::to_string(&relationship.metadata)?;
+        let mut rel = relationship.clone();
+        rel.stamp_confidence_label_metadata();
+        let metadata_str = serde_json::to_string(&rel.metadata)?;
         let mut params = std::collections::BTreeMap::new();
         params.insert(
             "sq".to_string(),
-            serde_json::Value::String(relationship.source_qualified.clone()),
+            serde_json::Value::String(rel.source_qualified.clone()),
         );
         params.insert(
             "tq".to_string(),
-            serde_json::Value::String(relationship.target_qualified.clone()),
+            serde_json::Value::String(rel.target_qualified.clone()),
         );
         params.insert(
             "rt".to_string(),
-            serde_json::Value::String(relationship.rel_type.clone()),
+            serde_json::Value::String(rel.rel_type.clone()),
         );
-        params.insert("cn".to_string(), serde_json::json!(relationship.confidence));
+        params.insert("cn".to_string(), serde_json::json!(rel.confidence));
         params.insert("md".to_string(), serde_json::Value::String(metadata_str));
 
         let query = r#"?[source_qualified, target_qualified, rel_type, confidence, metadata] <- [[ $sq, $tq, $rt, $cn, $md ]] :put relationships { source_qualified, target_qualified, rel_type, confidence, metadata }"#;
@@ -2103,6 +2105,45 @@ impl GraphEngine {
         crate::db::schema::run_script(&self.db, &query, params)?;
 
         Ok(())
+    }
+
+    /// FR-GF-08: Backfill `confidence_label` metadata for relationships
+    /// missing it (bounded pagination for mega-graph safety).
+    pub fn backfill_confidence_labels(&self) -> Result<usize, Box<dyn std::error::Error>> {
+        const PAGE: usize = 1000;
+        const MAX_PAGES: usize = 500;
+        let mut updated = 0usize;
+        let mut offset = 0usize;
+
+        for _ in 0..MAX_PAGES {
+            let (batch, _) = self.get_relationships_paginated(PAGE, offset)?;
+            if batch.is_empty() {
+                break;
+            }
+            let mut to_write = Vec::new();
+            for mut rel in batch {
+                let had = rel
+                    .metadata
+                    .get("confidence_label")
+                    .and_then(|v| v.as_str())
+                    .is_some_and(|s| !s.is_empty());
+                if had {
+                    continue;
+                }
+                rel.stamp_confidence_label_metadata();
+                to_write.push(rel);
+            }
+            if !to_write.is_empty() {
+                self.insert_relationships(&to_write)?;
+                updated += to_write.len();
+            }
+            offset += PAGE;
+        }
+
+        if updated > 0 {
+            self.invalidate_cache();
+        }
+        Ok(updated)
     }
 
     pub fn insert_relationships(
@@ -2118,13 +2159,15 @@ impl GraphEngine {
         let batch_data: Vec<serde_json::Value> = relationships
             .iter()
             .map(|rel| {
+                let mut stamped = rel.clone();
+                stamped.stamp_confidence_label_metadata();
                 let metadata_str =
-                    serde_json::to_string(&rel.metadata).unwrap_or_else(|_| "{}".to_string());
+                    serde_json::to_string(&stamped.metadata).unwrap_or_else(|_| "{}".to_string());
                 serde_json::json!([
-                    rel.source_qualified.clone(),
-                    rel.target_qualified.clone(),
-                    rel.rel_type.clone(),
-                    rel.confidence,
+                    stamped.source_qualified.clone(),
+                    stamped.target_qualified.clone(),
+                    stamped.rel_type.clone(),
+                    stamped.confidence,
                     metadata_str
                 ])
             })
@@ -2863,7 +2906,7 @@ impl GraphEngine {
         source_qualified: &str,
         max_depth: u32,
         max_results: usize,
-    ) -> Result<Vec<(String, String, u32)>, Box<dyn std::error::Error>> {
+    ) -> Result<Vec<CallGraphEdge>, Box<dyn std::error::Error>> {
         // Resolve short function name to full qualified name
         let resolved = if source_qualified.contains("::") {
             normalize_path(source_qualified)
@@ -2873,7 +2916,7 @@ impl GraphEngine {
                 .unwrap_or_else(|| source_qualified.to_string())
         };
 
-        let mut all_calls: Vec<(String, String, u32)> = Vec::new();
+        let mut all_calls: Vec<CallGraphEdge> = Vec::new();
         let mut frontier: Vec<String> = vec![resolved.clone()];
         let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
 
@@ -2899,7 +2942,7 @@ impl GraphEngine {
                 };
 
                 let query = format!(
-                    r#"?[src, tgt] :=
+                    r#"?[src, tgt, conf, meta] :=
                        *relationships[src, tgt, rel_type, conf, meta, _],
                        rel_type = "calls",
                        {}
@@ -2910,10 +2953,30 @@ impl GraphEngine {
                 let result = crate::db::schema::run_script(&self.db, &query, Default::default())?;
                 for row in &result.rows {
                     let tgt = row[1].get_str().unwrap_or("").to_string();
+                    let confidence = row[2].get_float().unwrap_or(0.0);
+                    let metadata: serde_json::Value = row[3]
+                        .get_str()
+                        .and_then(|s| serde_json::from_str(s).ok())
+                        .unwrap_or_else(|| serde_json::json!({}));
+                    let rel = crate::db::models::Relationship {
+                        id: None,
+                        source_qualified: src.clone(),
+                        target_qualified: tgt.clone(),
+                        rel_type: "calls".to_string(),
+                        confidence,
+                        metadata,
+                        env: "local".to_string(),
+                    };
                     if !visited.contains(&tgt) && !tgt.starts_with("__unresolved__") {
                         next_frontier.push(tgt.clone());
                     }
-                    all_calls.push((src.clone(), tgt, depth + 1));
+                    all_calls.push(CallGraphEdge {
+                        source: src.clone(),
+                        target: tgt,
+                        depth: depth + 1,
+                        confidence,
+                        confidence_label: rel.confidence_label().to_string(),
+                    });
                 }
             }
             frontier = next_frontier;
@@ -4122,6 +4185,16 @@ pub struct ServiceGraph {
     pub total_connections: usize,
 }
 
+/// FR-GF-09: Single call-graph edge with provenance.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct CallGraphEdge {
+    pub source: String,
+    pub target: String,
+    pub depth: u32,
+    pub confidence: f64,
+    pub confidence_label: String,
+}
+
 /// US-GF-01: A single hop in a shortest_path result.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct PathHop {
@@ -4472,61 +4545,114 @@ impl GraphEngine {
         // must stay within MCP request latency even when no path exists.
         const MAX_BFS_VISITS: usize = 120;
 
-        let mut visited: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut queue: std::collections::VecDeque<(String, Vec<PathHop>)> =
-            std::collections::VecDeque::new();
-        queue.push_back((source_qn.clone(), Vec::new()));
-        visited.insert(source_qn.clone());
-
-        while let Some((current, path)) = queue.pop_front() {
-            if visited.len() > MAX_BFS_VISITS {
-                break;
-            }
-            if path.len() >= max_hops {
-                continue;
-            }
-            let rels = self
-                .get_relationships_involving_elements_fast(std::slice::from_ref(&current), None)?;
-            for rel in rels {
-                let next = if rel.source_qualified == current {
-                    rel.target_qualified.clone()
-                } else if rel.target_qualified == current {
-                    rel.source_qualified.clone()
-                } else {
-                    continue;
-                };
-                if !visited.insert(next.clone()) {
-                    continue;
-                }
-                let mut new_path = path.clone();
-                new_path.push(PathHop {
-                    from: current.clone(),
-                    to: next.clone(),
-                    rel_type: rel.rel_type.clone(),
-                    confidence: rel.confidence,
-                    confidence_label: rel.confidence_label().to_string(),
-                    source_file: rel
-                        .metadata
-                        .get("source_file")
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("")
-                        .to_string(),
-                });
-                if next == target_qn {
-                    return Ok(Some(ShortestPathResult {
-                        source: source_qn,
-                        target: target_qn,
-                        hops: new_path.len(),
-                        path: new_path,
-                    }));
-                }
-                if visited.len() <= MAX_BFS_VISITS {
-                    queue.push_back((next, new_path));
-                }
-            }
+        fn path_label_score(path: &[PathHop]) -> u32 {
+            path.iter()
+                .map(|h| {
+                    u32::from(crate::db::models::Relationship::confidence_label_rank(
+                        &h.confidence_label,
+                    ))
+                })
+                .sum()
         }
 
-        Ok(None)
+        let mut frontier: Vec<(String, Vec<PathHop>)> = vec![(source_qn.clone(), Vec::new())];
+        let mut best_result: Option<ShortestPathResult> = None;
+        let mut visits = 0usize;
+
+        for _depth in 0..max_hops {
+            if frontier.is_empty() {
+                break;
+            }
+
+            let mut next_frontier: Vec<(String, Vec<PathHop>)> = Vec::new();
+            let mut best_at_level: std::collections::HashMap<String, u32> =
+                std::collections::HashMap::new();
+            let mut found_target_this_level = false;
+
+            for (current, path) in frontier {
+                if visits > MAX_BFS_VISITS {
+                    break;
+                }
+                visits += 1;
+
+                let rels = self.get_relationships_involving_elements_fast(
+                    std::slice::from_ref(&current),
+                    None,
+                )?;
+                let mut neighbors: Vec<(String, crate::db::models::Relationship)> = Vec::new();
+                for rel in rels {
+                    let next = if rel.source_qualified == current {
+                        rel.target_qualified.clone()
+                    } else if rel.target_qualified == current {
+                        rel.source_qualified.clone()
+                    } else {
+                        continue;
+                    };
+                    neighbors.push((next, rel));
+                }
+                neighbors.sort_by(|a, b| {
+                    crate::db::models::Relationship::confidence_label_rank(a.1.confidence_label())
+                        .cmp(&crate::db::models::Relationship::confidence_label_rank(
+                            b.1.confidence_label(),
+                        ))
+                });
+
+                for (next, rel) in neighbors {
+                    let mut new_path = path.clone();
+                    new_path.push(PathHop {
+                        from: current.clone(),
+                        to: next.clone(),
+                        rel_type: rel.rel_type.clone(),
+                        confidence: rel.confidence,
+                        confidence_label: rel.confidence_label().to_string(),
+                        source_file: rel
+                            .metadata
+                            .get("source_file")
+                            .and_then(|v| v.as_str())
+                            .unwrap_or("")
+                            .to_string(),
+                    });
+
+                    if next == target_qn {
+                        let candidate = ShortestPathResult {
+                            source: source_qn.clone(),
+                            target: target_qn.clone(),
+                            hops: new_path.len(),
+                            path: new_path,
+                        };
+                        let replace = match &best_result {
+                            None => true,
+                            Some(prev) if candidate.hops < prev.hops => true,
+                            Some(prev) if candidate.hops == prev.hops => {
+                                path_label_score(&candidate.path) < path_label_score(&prev.path)
+                            }
+                            _ => false,
+                        };
+                        if replace {
+                            best_result = Some(candidate);
+                        }
+                        found_target_this_level = true;
+                        continue;
+                    }
+
+                    let score = path_label_score(&new_path);
+                    if let Some(&prev_score) = best_at_level.get(&next) {
+                        if score >= prev_score {
+                            continue;
+                        }
+                    }
+                    best_at_level.insert(next.clone(), score);
+                    next_frontier.push((next, new_path));
+                }
+            }
+
+            if found_target_this_level {
+                break;
+            }
+            frontier = next_frontier;
+        }
+
+        Ok(best_result)
     }
 
     /// Resolve a free-form input (qualified_name, exact name, or fuzzy
@@ -6435,6 +6561,94 @@ mod tests {
         assert_eq!(out.len(), 1);
         assert_eq!(out[0].source_qualified, "src/a.rs::a");
         assert_eq!(out[0].target_qualified, "src/b.rs::b");
+    }
+
+    #[test]
+    fn insert_relationship_stamps_confidence_label_metadata() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "a", "function", "src/a.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "b", "function", "src/b.rs", "rust", 1, 5);
+        let rel = Relationship {
+            source_qualified: "src/a.rs::a".to_string(),
+            target_qualified: "src/b.rs::b".to_string(),
+            rel_type: "calls".to_string(),
+            confidence: 0.95,
+            metadata: serde_json::json!({"resolution_method": "typed"}),
+            ..Default::default()
+        };
+        engine.insert_relationship(&rel).unwrap();
+        let stored = engine
+            .get_relationships("src/a.rs::a")
+            .unwrap()
+            .into_iter()
+            .find(|r| r.target_qualified == "src/b.rs::b")
+            .expect("edge stored");
+        assert_eq!(
+            stored
+                .metadata
+                .get("confidence_label")
+                .and_then(|v| v.as_str()),
+            Some("EXTRACTED")
+        );
+    }
+
+    #[test]
+    fn backfill_confidence_labels_noop_when_already_stamped() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "a", "function", "src/a.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "b", "function", "src/b.rs", "rust", 1, 5);
+        insert_test_rel(&engine, "src/a.rs::a", "src/b.rs::b", "calls", 0.9);
+        let n = engine.backfill_confidence_labels().unwrap();
+        assert_eq!(n, 0);
+    }
+
+    #[test]
+    fn shortest_path_prefers_extracted_on_equal_length() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "a", "function", "src/a.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "b", "function", "src/b.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "c", "function", "src/c.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "d", "function", "src/d.rs", "rust", 1, 5);
+
+        let inferred = Relationship {
+            source_qualified: String::new(),
+            target_qualified: String::new(),
+            rel_type: "calls".to_string(),
+            confidence: 0.55,
+            metadata: serde_json::json!({"resolution_method": "name"}),
+            ..Default::default()
+        };
+        let extracted = Relationship {
+            source_qualified: String::new(),
+            target_qualified: String::new(),
+            rel_type: "calls".to_string(),
+            confidence: 0.95,
+            metadata: serde_json::json!({"resolution_method": "typed"}),
+            ..Default::default()
+        };
+
+        let mut ab = inferred.clone();
+        ab.source_qualified = "src/a.rs::a".into();
+        ab.target_qualified = "src/b.rs::b".into();
+        let mut bd = inferred.clone();
+        bd.source_qualified = "src/b.rs::b".into();
+        bd.target_qualified = "src/d.rs::d".into();
+        let mut ac = extracted.clone();
+        ac.source_qualified = "src/a.rs::a".into();
+        ac.target_qualified = "src/c.rs::c".into();
+        let mut cd = extracted.clone();
+        cd.source_qualified = "src/c.rs::c".into();
+        cd.target_qualified = "src/d.rs::d".into();
+
+        engine.insert_relationships(&[ab, bd, ac, cd]).unwrap();
+
+        let path = engine
+            .shortest_path("src/a.rs::a", "src/d.rs::d", 3)
+            .unwrap()
+            .expect("path should exist");
+        assert_eq!(path.hops, 2);
+        assert_eq!(path.path[0].to, "src/c.rs::c");
+        assert!(path.path.iter().all(|h| h.confidence_label == "EXTRACTED"));
     }
 
     #[test]

--- a/src/graph/traversal.rs
+++ b/src/graph/traversal.rs
@@ -78,6 +78,7 @@ impl<'a> ImpactAnalyzer<'a> {
                         affected_with_confidence.push(AffectedElementWithConfidence {
                             element,
                             confidence: rel.confidence,
+                            confidence_label: rel.confidence_label().to_string(),
                             severity,
                             depth: current_depth + 1,
                         });
@@ -113,6 +114,7 @@ impl<'a> ImpactAnalyzer<'a> {
                         affected_with_confidence.push(AffectedElementWithConfidence {
                             element,
                             confidence: rel.confidence,
+                            confidence_label: rel.confidence_label().to_string(),
                             severity,
                             depth: current_depth + 1,
                         });
@@ -170,6 +172,7 @@ impl Default for ImpactScanOptions {
 pub struct AffectedElementWithConfidence {
     pub element: CodeElement,
     pub confidence: f64,
+    pub confidence_label: String,
     pub severity: String,
     pub depth: u32,
 }

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1371,6 +1371,10 @@ where
         tracing::warn!("Failed to resolve call edges: {}", e);
     }
 
+    if let Err(e) = graph.backfill_confidence_labels() {
+        tracing::warn!("Failed to backfill confidence labels: {}", e);
+    }
+
     Ok(IndexWithProgressResult {
         total_files,
         indexed_files,

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1233,6 +1233,7 @@ impl ToolHandler {
                 "type": a.element.element_type,
                 "file": a.element.file_path,
                 "confidence": a.confidence,
+                "confidence_label": a.confidence_label,
                 "severity": a.severity,
                 "depth": a.depth
             })).collect::<Vec<_>>()
@@ -1890,11 +1891,13 @@ impl ToolHandler {
 
         let calls: Vec<_> = call_graph
             .iter()
-            .map(|(src, tgt, d)| {
+            .map(|edge| {
                 json!({
-                    "source": src,
-                    "target": tgt,
-                    "depth": d
+                    "source": edge.source,
+                    "target": edge.target,
+                    "depth": edge.depth,
+                    "confidence": edge.confidence,
+                    "confidence_label": edge.confidence_label,
                 })
             })
             .collect();
@@ -2275,7 +2278,7 @@ impl ToolHandler {
                 json!({
                     "file": r.target_qualified,
                     "context": r.metadata.get("context").and_then(|v| v.as_str()).unwrap_or(""),
-                    "confidence_label": r.metadata.get("confidence_label").and_then(|v| v.as_str()).unwrap_or("")
+                    "confidence_label": r.confidence_label(),
                 })
             })
             .collect();
@@ -2548,7 +2551,7 @@ impl ToolHandler {
                 "doc": r.target_qualified,
                 "relationship": r.rel_type,
                 "context": r.metadata.get("context").and_then(|v| v.as_str()).unwrap_or(""),
-                "confidence_label": r.metadata.get("confidence_label").and_then(|v| v.as_str()).unwrap_or("")
+                "confidence_label": r.confidence_label(),
             }));
         }
 
@@ -2557,7 +2560,7 @@ impl ToolHandler {
                 "doc": r.source_qualified,
                 "relationship": r.rel_type,
                 "context": r.metadata.get("context").and_then(|v| v.as_str()).unwrap_or(""),
-                "confidence_label": r.metadata.get("confidence_label").and_then(|v| v.as_str()).unwrap_or("")
+                "confidence_label": r.confidence_label(),
             }));
         }
 

--- a/src/web/handlers.rs
+++ b/src/web/handlers.rs
@@ -78,6 +78,35 @@ pub struct GraphRelationship {
     pub target_id: String,
     #[serde(rename = "type")]
     pub rel_type: String,
+    #[serde(rename = "confidenceLabel")]
+    pub confidence_label: String,
+}
+
+impl GraphRelationship {
+    pub fn from_relationship(r: &crate::db::models::Relationship) -> Self {
+        Self::new(
+            r.source_qualified.clone(),
+            r.target_qualified.clone(),
+            r.rel_type.clone(),
+            r.confidence_label().to_string(),
+        )
+    }
+
+    pub fn new(
+        source_id: String,
+        target_id: String,
+        rel_type: String,
+        confidence_label: String,
+    ) -> Self {
+        let rel_type = rel_type.to_uppercase();
+        Self {
+            id: format!("{}_{}_{}", source_id, rel_type, target_id),
+            source_id,
+            target_id,
+            rel_type,
+            confidence_label,
+        }
+    }
 }
 
 #[allow(dead_code)]
@@ -2109,15 +2138,7 @@ pub async fn api_graph_expand_service(
         .relationships
         .iter()
         .filter(|r| keep.contains(&r.source_qualified) && keep.contains(&r.target_qualified))
-        .map(|r| GraphRelationship {
-            id: format!(
-                "{}_{}_{}",
-                r.source_qualified, r.rel_type, r.target_qualified
-            ),
-            source_id: r.source_qualified.clone(),
-            target_id: r.target_qualified.clone(),
-            rel_type: r.rel_type.clone(),
-        })
+        .map(GraphRelationship::from_relationship)
         .collect();
 
     let nodes_count = nodes.len();
@@ -2355,16 +2376,8 @@ pub async fn api_graph_expand_cluster(
                 .collect();
 
             let relationships: Vec<GraphRelationship> = filtered_relationships
-                .iter()
-                .map(|r| GraphRelationship {
-                    id: format!(
-                        "{}_{}_{}",
-                        r.source_qualified, r.rel_type, r.target_qualified
-                    ),
-                    source_id: r.source_qualified.clone(),
-                    target_id: r.target_qualified.clone(),
-                    rel_type: r.rel_type.clone(),
-                })
+                .into_iter()
+                .map(GraphRelationship::from_relationship)
                 .collect();
 
             let nodes_count = nodes.len();
@@ -2683,14 +2696,12 @@ pub async fn api_graph_data(State(state): State<AppState>) -> impl IntoResponse 
                     }
                     seen_edges.insert(edge_key);
 
-                    let normalized_type = r.rel_type.to_uppercase();
-
-                    Some(GraphRelationship {
-                        id: format!("{}_{}_{}", src_id, normalized_type, tgt_id),
-                        source_id: src_id,
-                        target_id: tgt_id,
-                        rel_type: normalized_type,
-                    })
+                    Some(GraphRelationship::new(
+                        src_id,
+                        tgt_id,
+                        r.rel_type.clone(),
+                        r.confidence_label().to_string(),
+                    ))
                 })
                 .collect();
 
@@ -2750,15 +2761,7 @@ pub async fn api_export_graph(State(state): State<AppState>) -> impl IntoRespons
                 .filter(|r| {
                     node_ids.contains(&r.source_qualified) && node_ids.contains(&r.target_qualified)
                 })
-                .map(|r| GraphRelationship {
-                    id: format!(
-                        "{}_{}_{}",
-                        r.source_qualified, r.rel_type, r.target_qualified
-                    ),
-                    source_id: r.source_qualified.clone(),
-                    target_id: r.target_qualified.clone(),
-                    rel_type: r.rel_type.clone(),
-                })
+                .map(GraphRelationship::from_relationship)
                 .collect();
             ApiResponse {
                 success: true,
@@ -2935,12 +2938,12 @@ pub async fn api_graph_subgraph(
                     seen_edges.insert(edge_key);
 
                     let normalized_type = r.rel_type.to_uppercase();
-                    Some(GraphRelationship {
-                        id: format!("{}_{}_{}", src_id, normalized_type, tgt_id),
-                        source_id: src_id,
-                        target_id: tgt_id,
-                        rel_type: normalized_type,
-                    })
+                    Some(GraphRelationship::new(
+                        src_id,
+                        tgt_id,
+                        normalized_type,
+                        r.confidence_label().to_string(),
+                    ))
                 })
                 .collect();
 
@@ -3061,13 +3064,12 @@ pub async fn api_graph_clusters(State(state): State<AppState>) -> impl IntoRespo
             let relationships: Vec<GraphRelationship> = cluster_edges
                 .iter()
                 .map(|(src, tgt, rel_type)| {
-                    let normalized = rel_type.to_uppercase();
-                    GraphRelationship {
-                        id: format!("cluster_edge:{}_{}_{}", src, normalized, tgt),
-                        source_id: format!("cluster:{}", src),
-                        target_id: format!("cluster:{}", tgt),
-                        rel_type: normalized,
-                    }
+                    GraphRelationship::new(
+                        format!("cluster:{}", src),
+                        format!("cluster:{}", tgt),
+                        rel_type.clone(),
+                        "INFERRED".to_string(),
+                    )
                 })
                 .collect();
 
@@ -3965,15 +3967,7 @@ pub async fn api_graph_children(
                     let relationships: Vec<GraphRelationship> = cr
                         .relationships
                         .iter()
-                        .map(|r| GraphRelationship {
-                            id: format!(
-                                "{}_{}_{}",
-                                r.source_qualified, r.rel_type, r.target_qualified
-                            ),
-                            source_id: r.source_qualified.clone(),
-                            target_id: r.target_qualified.clone(),
-                            rel_type: r.rel_type.clone(),
-                        })
+                        .map(GraphRelationship::from_relationship)
                         .collect();
 
                     ApiResponse {
@@ -4120,15 +4114,7 @@ pub async fn api_graph_expand_node(
                     let relationships: Vec<GraphRelationship> = cr
                         .relationships
                         .iter()
-                        .map(|r| GraphRelationship {
-                            id: format!(
-                                "{}_{}_{}",
-                                r.source_qualified, r.rel_type, r.target_qualified
-                            ),
-                            source_id: r.source_qualified.clone(),
-                            target_id: r.target_qualified.clone(),
-                            rel_type: r.rel_type.clone(),
-                        })
+                        .map(GraphRelationship::from_relationship)
                         .collect();
 
                     ApiResponse {

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -698,8 +698,11 @@ async fn test_get_call_graph_with_real_db() {
                 "get_call_graph('./src/api/auth.rs', depth=1) returned {} calls",
                 calls.len()
             );
-            for (src, tgt, depth) in calls.iter().take(5) {
-                println!("  {} -> {} (depth {})", src, tgt, depth);
+            for edge in calls.iter().take(5) {
+                println!(
+                    "  {} -> {} (depth {}, label {})",
+                    edge.source, edge.target, edge.depth, edge.confidence_label
+                );
             }
         }
         Err(e) => {

--- a/tests/test_debug_call_graph.rs
+++ b/tests/test_debug_call_graph.rs
@@ -13,8 +13,11 @@ async fn test_debug_call_graph() {
     match graph.get_call_graph_bounded("./src/main.rs::main", 1, 10) {
         Ok(results) => {
             println!("get_call_graph_bounded returned {} results", results.len());
-            for (src, tgt, depth) in results.iter().take(5) {
-                println!("  {} -> {} (depth={})", src, tgt, depth);
+            for edge in results.iter().take(5) {
+                println!(
+                    "  {} -> {} (depth={}, label={})",
+                    edge.source, edge.target, edge.depth, edge.confidence_label
+                );
             }
         }
         Err(e) => println!("Error: {}", e),

--- a/ui-v2/src/core/graph/types.ts
+++ b/ui-v2/src/core/graph/types.ts
@@ -21,6 +21,7 @@ export interface GraphRelationship {
   sourceId: string;
   targetId: string;
   type: string;
+  confidenceLabel?: string;
 }
 
 export interface KnowledgeGraph {

--- a/ui-v2/src/hooks/useSigma.ts
+++ b/ui-v2/src/hooks/useSigma.ts
@@ -192,6 +192,7 @@ export const useSigma = (options: UseSigmaOptions = {}): UseSigmaReturn => {
 
     const sigma = new Sigma(graph, containerRef.current, {
       allowInvalidContainer: true,
+      enableEdgeEvents: true,
       renderLabels: true,
       labelFont: 'JetBrains Mono, monospace',
       labelSize: 12,
@@ -252,6 +253,44 @@ export const useSigma = (options: UseSigmaOptions = {}): UseSigmaReturn => {
         context.globalAlpha = 0.5;
         context.stroke();
         context.globalAlpha = 1;
+      },
+      defaultDrawEdgeHover: (
+        context: CanvasRenderingContext2D,
+        data: SigmaEdgeAttributes,
+        settings: { labelSize?: number; labelFont?: string; labelWeight?: string },
+      ) => {
+        const label = data.confidenceLabel?.trim();
+        if (!label) return;
+
+        const size = settings.labelSize || 11;
+        const font = settings.labelFont || 'JetBrains Mono, monospace';
+        const weight = settings.labelWeight || '500';
+        const edgeLabel = `${data.relationType || 'EDGE'} · ${label}`;
+
+        context.font = `${weight} ${size}px ${font}`;
+        const textWidth = context.measureText(edgeLabel).width;
+
+        const x = (data as { x?: number }).x ?? 0;
+        const y = (data as { y?: number }).y ?? 0;
+        const paddingX = 8;
+        const paddingY = 5;
+        const height = size + paddingY * 2;
+        const width = textWidth + paddingX * 2;
+        const radius = 4;
+
+        context.fillStyle = '#12121c';
+        context.beginPath();
+        context.roundRect(x - width / 2, y - height / 2, width, height, radius);
+        context.fill();
+
+        context.strokeStyle = typeof data.color === 'string' ? data.color : '#6366f1';
+        context.lineWidth = 1.5;
+        context.stroke();
+
+        context.fillStyle = '#f5f5f7';
+        context.textAlign = 'center';
+        context.textBaseline = 'middle';
+        context.fillText(edgeLabel, x, y);
       },
       nodeReducer: (node: string, data: any) => {
         const res = { ...data };
@@ -415,6 +454,14 @@ export const useSigma = (options: UseSigmaOptions = {}): UseSigmaReturn => {
 
     sigma.on('leaveNode', () => {
       onNodeHoverRef.current?.(null);
+      if (containerRef.current) containerRef.current.style.cursor = 'grab';
+    });
+
+    sigma.on('enterEdge', () => {
+      if (containerRef.current) containerRef.current.style.cursor = 'help';
+    });
+
+    sigma.on('leaveEdge', () => {
       if (containerRef.current) containerRef.current.style.cursor = 'grab';
     });
 

--- a/ui-v2/src/lib/graph-adapter.ts
+++ b/ui-v2/src/lib/graph-adapter.ts
@@ -27,6 +27,7 @@ export interface SigmaEdgeAttributes {
   size: number;
   color: string;
   relationType: string;
+  confidenceLabel?: string;
   type?: string;
   curvature?: number;
   zIndex?: number;
@@ -47,6 +48,8 @@ export interface KGEdge {
   targetId?: string;
   type?: string;
   rel_type?: string;
+  confidenceLabel?: string;
+  confidence_label?: string;
 }
 
 const getScaledNodeSize = (baseSize: number, nodeCount: number): number => {
@@ -262,6 +265,9 @@ export const createSigmaGraph = (
           size: edgeBaseSize * style.sizeMultiplier,
           color: edgeColor,
           relationType: relType,
+          confidenceLabel: String(
+            rel.confidenceLabel ?? rel.confidence_label ?? '',
+          ),
           type: 'curved',
           curvature,
           weight: relType === 'CONTAINS' ? 2.5 : 0.5,
@@ -431,6 +437,7 @@ function kgEdgesFromKnowledgeGraph(kg: KnowledgeGraph): KGEdge[] {
     sourceId: r.sourceId,
     targetId: r.targetId,
     type: r.type,
+    confidenceLabel: r.confidenceLabel,
   }));
 }
 
@@ -489,6 +496,7 @@ export function buildLayoutGraph(
       size: 1.5 * style.sizeMultiplier,
       color: style.color,
       relationType: rel.type,
+      confidenceLabel: rel.confidenceLabel,
       type: 'curved',
       curvature: 0.2,
       weight: 1,

--- a/ui-v2/src/lib/normalize.ts
+++ b/ui-v2/src/lib/normalize.ts
@@ -55,6 +55,9 @@ export function normalizeGraphPayload(raw: {
       sourceId: String(edge.sourceId ?? edge.source_id ?? ''),
       targetId: String(edge.targetId ?? edge.target_id ?? ''),
       type: String(edge.type ?? edge.rel_type ?? 'REFERENCES').toUpperCase(),
+      confidenceLabel: String(
+        edge.confidenceLabel ?? edge.confidence_label ?? '',
+      ),
     };
   });
 


### PR DESCRIPTION
## Summary
- **Wave 2a (honest edges):** stamp `confidence_label` (`EXTRACTED` / `INFERRED` / `AMBIGUOUS`) on every relationship write, backfill after index, propagate via `get_call_graph` / `get_impact_radius` / doc tools, prefer EXTRACTED on equal-length `shortest_path`, and show labels on ui-v2 Sigma edge hover.
- **Waves 0a–1c:** ROI README link, ui-v2 cutover evidence, always-on graph-first Cursor rule + install hooks.
- **Prefer-order fix:** discover-first for fuzzy/NL — `concept_search` → **`semantic_search`** → `search_code` **before** `query_graph` / connection verbs (no longer open NL with three-verbs-first `query_graph`).
- Tracker/roadmap: `FR-GF-07..09`, `US-GF-04`, `REL-043` → DONE; P1 CURRENT → Wave **2b**.

## Test plan
- [x] `cargo test --release --lib` (684 passed)
- [x] `cargo test --release --test integration` (27 passed)
- [x] Unit: insert stamps metadata; shortest_path prefers EXTRACTED
- [x] Prefer-order docs/skills/install templates: `semantic_search` before `query_graph`
- [x] MCP smoke: `semantic_search` (HNSW+rerank) then `query_graph` on indexed side monorepo
- [ ] Smoke: reindex a small project and confirm edges have `metadata.confidence_label`
- [ ] MCP: `get_call_graph` / `get_impact_radius` responses include `confidence_label`
- [ ] ui-v2: hover an edge and confirm tooltip shows `RELTYPE · LABEL` (rebuild `src/embed/` if shipping embedded UI)

Evidence: [`docs/reports/honest-edges-smoke-2026-07-22.md`](docs/reports/honest-edges-smoke-2026-07-22.md) · [`docs/reports/three-verb-narrative-smoke-2026-07-21.md`](docs/reports/three-verb-narrative-smoke-2026-07-21.md)