### PR TITLE
ci(release): migrate Release Please to v4 config and manifest

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -3,19 +3,22 @@ name: Release Please
 # Automated semantic-version release pipeline for LeanKG.
 #
 # On every push to main:
-#   1. Scans the commits since the latest v* tag.
-#   2. Determines the next minor (feat) or patch (fix, perf, refactor)
+#   1. Reads the supported Release Please configuration from
+#      `release-please-config.json` and `manifest.json` at the repo
+#      root.
+#   2. Scans the commits since the latest v* tag.
+#   3. Determines the next minor (feat) or patch (fix, perf, refactor)
 #      version using conventional commits.
-#   3. Opens (or updates) a release PR that bumps Cargo.toml and
+#   4. Opens (or updates) a release PR that bumps Cargo.toml and
 #      appends a section to CHANGELOG.md.
-#   4. On merge of the release PR, pushes an annotated vX.Y.Z tag and
+#   5. On merge of the release PR, pushes an annotated vX.Y.Z tag and
 #      publishes the GitHub Release.
 #
-# The companion `.github/workflows/release.yml` (already in main) listens
-# for the new v* tag and is responsible for publishing crates.io and
-# building the cross-platform binary artifacts. This file owns the
-# versioning, changelog, and tag/release step; `release.yml` owns the
-# artifact step.
+# The companion `.github/workflows/release.yml` listens for the new v*
+# tag and is responsible for publishing crates.io and building the
+# cross-platform binary artifacts. This file owns the versioning,
+# changelog, and tag/release step; `release.yml` owns the artifact
+# step.
 #
 # Major releases are NOT auto-created. See the
 # "Handling a major release (manual)" section in
@@ -48,74 +51,18 @@ jobs:
         uses: googleapis/release-please-action@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Pin a specific major version of the action so behavior is
-          # reproducible. Bump deliberately and review the changelog
-          # when upgrading.
-          release-type: cargo
-          package-name: leankg
-          # Version file managed by the cargo strategy.
-          version-file: Cargo.toml
+          # Pin to a major version. Release Please v4 reads the
+          # supported inputs below; the `release-type`, `package-name`,
+          # `version-file`, `draft`, and inline `config` inputs from
+          # earlier revisions are not accepted and must live in the
+          # config/manifest files instead.
+          config-file: release-please-config.json
+          manifest-file: manifest.json
           # Open / update the release PR against main.
           target-branch: main
           # Publish the GitHub Release immediately on merge of the
           # release PR; not a draft.
           skip-github-release: false
-          draft: false
-          # Repo-local config so the release PR / changelog behavior
-          # is tracked in this repository instead of relying on
-          # external defaults.
-          config: |
-            bump-minor-pre-major: true
-            bump-patch-for-minor-pre-major: true
-            include-component-in-tag: false
-            packages:
-              leankg:
-                release-type: cargo
-                package-name: leankg
-                version-file: Cargo.toml
-                changelog-path: CHANGELOG.md
-                changelog-sections:
-                  - type: feat
-                    section: Features
-                  - type: fix
-                    section: Bug Fixes
-                  - type: perf
-                    section: Performance
-                  - type: refactor
-                    section: Refactoring
-                  - type: revert
-                    section: Reverts
-                exclude-types:
-                  - docs
-                  - chore
-                  - test
-                  - style
-                  - ci
-                  - build
-                skip-github-release: false
-                draft: false
-                pull-request:
-                  base-branch: main
-                  branch: release-please--branches--main
-                  labels:
-                    - release
-                    - automated
-                  reviewers: []
-                  body: |
-                    ## Release summary
-
-                    - **Next version:** {{version}}
-                    - **Bump level:** {{bump-type}}
-                    - **Release PR:** {{pr}}
-
-                    This PR was generated automatically by the
-                    `release-please.yml` GitHub Actions workflow.
-                    Review the changelog entries and the version bump
-                    before merging. On merge, the `v{{version}}` tag and
-                    GitHub Release will be created.
-
-                    See `docs/workflow-opencode-agent.md` for the
-                    release policy and troubleshooting guidance.
 
       - name: Verify release output
         if: steps.release.outputs.release_created == 'true'

--- a/docs/workflow-opencode-agent.md
+++ b/docs/workflow-opencode-agent.md
@@ -7,6 +7,9 @@ This document defines the workflow pattern for OpenCode AI agent to implement fe
 The release step (Step 8) is now automated through the
 [`.github/workflows/release-please.yml`](../../.github/workflows/release-please.yml)
 workflow once the change is merged to `main` and the CI quality checks pass.
+Release Please is configured through two repository files,
+[`release-please-config.json`](../../release-please-config.json) and
+[`manifest.json`](../../manifest.json), at the repo root.
 See [Automated Releases](#automated-releases) for the end-to-end process.
 
 ## Core Principle: One Feature Per Branch
@@ -80,6 +83,22 @@ push to main / merge of PR
 | `Cargo.toml` | bumps `[package].version` | Release Please via `cargo` strategy |
 | `Cargo.lock` | refreshed via `cargo build` in the workflow | Release Please |
 | `CHANGELOG.md` | appends a release section with categorized commits | Release Please |
+
+### Release Please configuration files
+
+Release Please v4 is configured through the files below, not through inline
+workflow inputs. Editing these files is how the pipeline is customized.
+
+| File | Purpose |
+|------|---------|
+| [`release-please-config.json`](../../release-please-config.json) | Top-level config: bump policy, package definitions, changelog sections, exclude types, release-PR branch / labels / body |
+| [`manifest.json`](../../manifest.json) | Maps the repository path (`.`) to a Release Please package: `release-type: cargo`, `package-name: leankg`, `version-file: Cargo.toml` |
+
+The `.github/workflows/release-please.yml` workflow only declares supported
+action inputs: `token`, `config-file`, `manifest-file`, and `target-branch`.
+Inline inputs from earlier action revisions (`release-type`, `package-name`,
+`version-file`, `draft`, `config`) are rejected by Release Please v4 and
+must live in the config/manifest files instead.
 
 ### Required permissions and secrets
 
@@ -164,6 +183,7 @@ resolved.
 | Release PR bumps the wrong version | A previous commit was rewritten or the tag is missing on `origin` | Confirm `git ls-remote --tags origin | grep vX.Y.Z` returns the expected tag; re-tag locally and push |
 | `cargo build` fails in the release PR | The Cargo.lock change is out of sync with the workspace | Re-run `cargo build --release` locally, commit the lockfile, and push |
 | Workflow fails with `403 Forbidden` on Release Please | The `GITHUB_TOKEN` lacks `contents: write` | Update the workflow's `permissions:` block and the repository settings |
+| Release Please fails with `Unknown release type: cargo` or `Unexpected input(s) 'package-name', 'version-file', 'draft', 'config'` | The workflow uses inline action inputs that Release Please v4 rejects | Move `release-type`, `package-name`, `version-file`, changelog sections, and exclude types into `release-please-config.json` and `manifest.json`, and pass only `config-file` and `manifest-file` from the workflow |
 
 ## Standard Feature Implementation Workflow
 
@@ -579,8 +599,10 @@ gh release create vX.Y.Z --notes "Release notes"
 
 ## Document Revision
 
-**Version:** 1.1  
+**Version:** 1.2  
 **Date:** 2026-07-23  
-**Change:** Added the [Automated Releases](#automated-releases) section and
-replaced the manual release step with the Release Please pipeline.  
+**Change:** Documented Release Please v4 configuration via
+`release-please-config.json` and `manifest.json`, added the troubleshooting
+row for `Unknown release type: cargo`, and noted that inline action inputs
+are no longer accepted.  
 **Based on:** LeanKG Phase 2 implementation session

--- a/manifest.json
+++ b/manifest.json
@@ -1,0 +1,7 @@
+{
+  ".": {
+    "release-type": "cargo",
+    "package-name": "leankg",
+    "version-file": "Cargo.toml"
+  }
+}

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,0 +1,40 @@
+{
+  "bump-minor-pre-major": true,
+  "bump-patch-for-minor-pre-major": true,
+  "include-component-in-tag": false,
+  "packages": {
+    ".": {
+      "release-type": "cargo",
+      "package-name": "leankg",
+      "version-file": "Cargo.toml",
+      "changelog-path": "CHANGELOG.md",
+      "changelog-sections": [
+        { "type": "feat", "section": "Features" },
+        { "type": "fix", "section": "Bug Fixes" },
+        { "type": "perf", "section": "Performance" },
+        { "type": "refactor", "section": "Refactoring" },
+        { "type": "revert", "section": "Reverts" }
+      ],
+      "exclude-types": [
+        "docs",
+        "chore",
+        "test",
+        "style",
+        "ci",
+        "build"
+      ],
+      "skip-github-release": false,
+      "draft": false,
+      "pull-request": {
+        "base-branch": "main",
+        "branch": "release-please--branches--main",
+        "labels": [
+          "release",
+          "automated"
+        ],
+        "reviewers": [],
+        "body": "## Release summary\n\n- **Next version:** {{version}}\n- **Bump level:** {{bump-type}}\n- **Release PR:** {{pr}}\n\nThis PR was generated automatically by the `release-please.yml` GitHub Actions workflow. Review the changelog entries and the version bump before merging. On merge, the `v{{version}}` tag and GitHub Release will be created.\n\nSee `docs/workflow-opencode-agent.md` for the release policy and troubleshooting guidance."
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
Fixes the failing Release Please run on `main` (PR #102 run:
https://github.com/FreePeak/LeanKG/actions/runs/29978685260/job/89115812041).

The Release Please action v4 rejects the inline inputs `release-type`,
`package-name`, `version-file`, `draft`, and `config` that the merged
workflow forwarded in `with:`. The validator raised
`Unexpected input(s) ...`, which then surfaced as the secondary
`Unknown release type: cargo` error.

This PR migrates the configuration to the supported v4 model:

- New [`release-please-config.json`](/Users/linh.doan/work/harvey/freepeak/leankg/.worktrees/fix/release-please-v4-config/release-please-config.json) at the repo root with the same package
  configuration that was previously inline: bump policy, changelog
  sections, exclude types, and release-PR branch / labels / body.
- New [`manifest.json`](/Users/linh.doan/work/harvey/freepeak/leankg/.worktrees/fix/release-please-v4-config/manifest.json) at the repo root mapping the single Cargo
  package `leankg` to the repository root, with `release-type: cargo`
  and `Cargo.toml` as the version file.
- [`/Users/linh.doan/work/harvey/freepeak/leankg/.worktrees/fix/release-please-v4-config/.github/workflows/release-please.yml`](/Users/linh.doan/work/harvey/freepeak/leankg/.worktrees/fix/release-please-v4-config/.github/workflows/release-please.yml)
  trimmed to only the inputs Release Please v4 accepts:
  `token`, `config-file`, `manifest-file`, `target-branch`. Concurrency,
  permissions, the verification step, and the no-release summary are
  preserved.
- [`/Users/linh.doan/work/harvey/freepeak/leankg/.worktrees/fix/release-please-v4-config/docs/workflow-opencode-agent.md`](/Users/linh.doan/work/harvey/freepeak/leankg/.worktrees/fix/release-please-v4-config/docs/workflow-opencode-agent.md)
  updated to describe the config/manifest files, drop references to
  inline inputs that are no longer supported, and add a troubleshooting
  row for the `Unknown release type: cargo` /
  `Unexpected input(s)` errors observed in the failed run.

## Test plan
- [x] `python3 -c "import yaml,json; yaml.safe_load(open('.github/workflows/release-please.yml')); json.load(open('release-please-config.json')); json.load(open('manifest.json'))"` succeeds.
- [x] Worktree `feature/ci-semantic-release` was used to author the original workflow; this PR was authored in a fresh worktree `fix/release-please-v4-config` branched from `origin/main`.
- [ ] After merge to `main`, the `Release Please` workflow run should no longer fail with `Unexpected input(s)` or `Unknown release type: cargo`.
- [ ] Verify a release PR is opened or updated on the next push.
- [ ] Confirm the merged release PR still produces a `vX.Y.Z` tag and triggers the existing `release.yml` job that publishes crates.io and uploads platform artifacts.

## Checklist
- [x] Implemented in the dedicated `fix/release-please-v4-config` worktree
- [x] No AI attribution in the commit message
- [x] Config files and workflow validated locally before pushing
- [x] Documentation updated alongside the change

Made with [Cursor](https://cursor.com)