### PR TITLE
feat(sources): add remote source indexing (GCP, git, local)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,3 +83,66 @@ jobs:
       - name: Install and build ui-v2
         working-directory: ui-v2
         run: npm ci && npm run build
+
+  gcs-e2e:
+    name: GCS Source E2E (Docker)
+    runs-on: ubuntu-latest
+    # The E2E test runs against a fake-gcs-server service container. The
+    # server's default HTTPS scheme is overridden via FAKE_GCS_SCHEME=http
+    # because GitHub service containers do not support entrypoint/command
+    # overrides (only `env:`), and the test client uses STORAGE_EMULATOR_HOST
+    # with `http://`.
+    services:
+      fake-gcs-server:
+        image: fsouza/fake-gcs-server:latest
+        env:
+          FAKE_GCS_SCHEME: http
+          FAKE_GCS_PORT: "4443"
+          FAKE_GCS_EXTERNAL_URL: http://localhost:4443
+        ports:
+          - 4443:4443
+        options: >-
+          --health-cmd "wget -qO- http://localhost:4443/storage/v1/b || exit 1"
+          --health-interval 2s
+          --health-timeout 2s
+          --health-retries 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        run: curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/registry
+          key: ${{ runner.os }}-cargo-registry-${{ hashFiles('**/Cargo.lock') }}
+
+      - name: Cache target directory
+        uses: actions/cache@v4
+        with:
+          path: target
+          key: ${{ runner.os }}-gcs-e2e-target-${{ hashFiles('**/Cargo.lock') }}-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-gcs-e2e-target-${{ hashFiles('**/Cargo.lock') }}-
+
+      - name: Build GCS E2E test binary
+        run: cargo test --release --test sources_gcs_e2e_tests --no-run
+
+      - name: Wait for fake-gcs-server
+        run: |
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:4443/storage/v1/b >/dev/null 2>&1; then
+              echo "fake-gcs-server ready"
+              exit 0
+            fi
+            echo "waiting for fake-gcs-server ($i)..."
+            sleep 1
+          done
+          echo "fake-gcs-server did not become ready" >&2
+          exit 1
+
+      - name: Run GCS E2E
+        env:
+          STORAGE_EMULATOR_HOST: http://localhost:4443
+        run: cargo test --release --test sources_gcs_e2e_tests -- --nocapture

--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ node_modules/
 # committed.
 docker-compose.override.yml
 vendor/
+actionlint/

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -38,6 +38,18 @@ pub enum CLICommand {
         /// Version tag for this index (semver or git sha)
         #[arg(long)]
         version: Option<String>,
+        /// Source URI for remote indexing (gs://bucket, git+https://..., etc.)
+        /// When provided, content is synced to a local staging directory before indexing.
+        /// Without this flag, indexes the local filesystem path as before.
+        #[arg(long)]
+        source: Option<String>,
+        /// Git branch/tag/commit to check out (used with --source git+...)
+        #[arg(long)]
+        ref_name: Option<String>,
+        /// Auth credential for the source (access token, key path, or service account JSON)
+        /// Prefer env vars (GCS_ACCESS_TOKEN, GIT_TOKEN, etc.) when possible.
+        #[arg(long)]
+        auth: Option<String>,
     },
     /// Query the knowledge graph
     Query {

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -13,6 +13,23 @@ pub struct ProjectConfig {
     /// FR-LSP-B: optional prefab / user LSP server block.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lsp: Option<crate::lsp::config::LspConfig>,
+    /// Remote source configuration for indexing from non-local sources.
+    /// When set, overrides the local `project.root` and syncs content to
+    /// `.leankg/sources/` before indexing. CLI flags `--source`, `--auth`,
+    /// and `--ref-name` take precedence over config values.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub source: Option<SourceConfig>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SourceConfig {
+    /// Source URI: gs://bucket, s3://bucket, git+https://..., etc.
+    pub uri: String,
+    /// Auth credential: access token, key file path, or env var reference.
+    pub auth: Option<String>,
+    /// Git reference (branch/tag/commit), only for git sources.
+    #[serde(default)]
+    pub ref_name: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -203,6 +220,7 @@ impl Default for ProjectConfig {
             microservice: None,
             auth: AuthSettings::default(),
             lsp: None,
+            source: None,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,5 +24,6 @@ pub mod registry;
 #[cfg(feature = "embeddings")]
 pub mod retrieval;
 pub mod runtime;
+pub mod sources;
 pub mod vector_engine;
 pub mod watcher;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1227,7 +1227,22 @@ async fn incremental_index_codebase(
             .sync_to_local(&staging_root, &mut progress)
             .await
             .map_err(|e| format!("source sync failed: {}", e))?;
-        synced.to_string_lossy().to_string()
+
+        // For remote sources, always do a full index after sync since
+        // incremental diff on the staged dir won't detect source changes.
+        println!("Remote source synced. Falling back to full index on latest content.");
+        return index_codebase(
+            &synced.to_string_lossy(),
+            db_path,
+            lang_filter,
+            exclude_patterns,
+            verbose,
+            env,
+            source_uri,
+            ref_name,
+            auth,
+        )
+        .await;
     } else {
         path.to_string()
     };
@@ -1273,7 +1288,7 @@ async fn incremental_index_codebase(
                 "Incremental index failed: {}. Falling back to full index.",
                 e
             );
-            index_codebase(&sync_path, db_path, lang_filter, exclude_patterns, verbose, env, source_uri, ref_name, auth).await?;
+            index_codebase(&sync_path, db_path, lang_filter, exclude_patterns, verbose, env, None, None, None).await?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -1008,6 +1008,7 @@ fn has_extension_recursive(dir: &std::path::Path, ext: &str, max_depth: u32) -> 
     false
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn index_codebase(
     path: &str,
     db_path: &std::path::Path,
@@ -1175,6 +1176,7 @@ async fn index_codebase(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn incremental_index_codebase(
     path: &str,
     db_path: &std::path::Path,
@@ -1221,7 +1223,10 @@ async fn incremental_index_codebase(
             .join("sources");
         tokio::fs::create_dir_all(&staging_root).await?;
 
-        println!("Re-syncing source '{}' for incremental index...", src.name());
+        println!(
+            "Re-syncing source '{}' for incremental index...",
+            src.name()
+        );
         let mut progress = sources::CliProgress;
         let synced = src
             .sync_to_local(&staging_root, &mut progress)
@@ -1288,7 +1293,18 @@ async fn incremental_index_codebase(
                 "Incremental index failed: {}. Falling back to full index.",
                 e
             );
-            index_codebase(&sync_path, db_path, lang_filter, exclude_patterns, verbose, env, None, None, None).await?;
+            index_codebase(
+                &sync_path,
+                db_path,
+                lang_filter,
+                exclude_patterns,
+                verbose,
+                env,
+                None,
+                None,
+                None,
+            )
+            .await?;
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,6 +22,7 @@ mod registry;
 #[cfg(feature = "embeddings")]
 mod retrieval;
 mod runtime;
+mod sources;
 mod watcher;
 mod web;
 
@@ -69,6 +70,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             env,
             service_name,
             version,
+            source,
+            ref_name,
+            auth,
         } => {
             let _service_name = service_name;
             let _version = version;
@@ -87,6 +91,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     &exclude_patterns,
                     verbose,
                     &env,
+                    source.as_deref(),
+                    ref_name.as_deref(),
+                    auth.as_deref(),
                 )
                 .await?;
             } else {
@@ -97,6 +104,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     &exclude_patterns,
                     verbose,
                     &env,
+                    source.as_deref(),
+                    ref_name.as_deref(),
+                    auth.as_deref(),
                 )
                 .await?;
             }
@@ -1005,6 +1015,9 @@ async fn index_codebase(
     exclude_patterns: &[String],
     verbose: bool,
     env: &str,
+    source_uri: Option<&str>,
+    ref_name: Option<&str>,
+    auth: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = env;
     let db = db::schema::init_db(db_path)?;
@@ -1023,7 +1036,33 @@ async fn index_codebase(
         config::ProjectConfig::default()
     };
 
-    let index_path = if path == "." {
+    // Resolve the effective source: CLI flags take precedence over leankg.yaml config.
+    let effective_source = source_uri.or(config.source.as_ref().map(|s| s.uri.as_str()));
+    let effective_auth = auth.or(config.source.as_ref().and_then(|s| s.auth.as_deref()));
+    let effective_ref_name =
+        ref_name.or(config.source.as_ref().and_then(|s| s.ref_name.as_deref()));
+
+    let index_path = if let Some(src_uri) = effective_source {
+        let uri = sources::parse_source_uri(src_uri)
+            .map_err(|e| format!("invalid source URI '{}': {}", src_uri, e))?;
+        let src = sources::SourceFactory::create(&uri, effective_auth, effective_ref_name)
+            .map_err(|e| format!("cannot create source for '{}': {}", src_uri, e))?;
+
+        let staging_root = db_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join(".leankg")
+            .join("sources");
+        tokio::fs::create_dir_all(&staging_root).await?;
+
+        println!("Syncing from source '{}'...", src.name());
+        let mut progress = sources::CliProgress;
+        let synced = src
+            .sync_to_local(&staging_root, &mut progress)
+            .await
+            .map_err(|e| format!("source sync failed: {}", e))?;
+        synced.to_string_lossy().to_string()
+    } else if path == "." {
         config.project.root.to_string_lossy().to_string()
     } else {
         path.to_string()
@@ -1143,6 +1182,9 @@ async fn incremental_index_codebase(
     exclude_patterns: &[String],
     verbose: bool,
     env: &str,
+    source_uri: Option<&str>,
+    ref_name: Option<&str>,
+    auth: Option<&str>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let _ = env;
     let db = db::schema::init_db(db_path)?;
@@ -1150,9 +1192,49 @@ async fn incremental_index_codebase(
     let mut parser_manager = indexer::ParserManager::new();
     parser_manager.init_parsers()?;
 
-    println!("Performing incremental indexing for {}...", path);
+    // Resolve the effective source: CLI flags take precedence over leankg.yaml config.
+    let config_path = db_path
+        .parent()
+        .unwrap_or(std::path::Path::new("."))
+        .join("leankg.yaml");
+    let config = if config_path.exists() {
+        let content = std::fs::read_to_string(&config_path)?;
+        serde_yaml::from_str::<config::ProjectConfig>(&content).unwrap_or_default()
+    } else {
+        config::ProjectConfig::default()
+    };
+    let effective_source = source_uri.or(config.source.as_ref().map(|s| s.uri.as_str()));
+    let effective_auth = auth.or(config.source.as_ref().and_then(|s| s.auth.as_deref()));
+    let effective_ref_name =
+        ref_name.or(config.source.as_ref().and_then(|s| s.ref_name.as_deref()));
 
-    match indexer::incremental_index_sync(&graph_engine, &mut parser_manager, path).await {
+    let sync_path: String = if let Some(src_uri) = effective_source {
+        let uri = sources::parse_source_uri(src_uri)
+            .map_err(|e| format!("invalid source URI '{}': {}", src_uri, e))?;
+        let src = sources::SourceFactory::create(&uri, effective_auth, effective_ref_name)
+            .map_err(|e| format!("cannot create source for '{}': {}", src_uri, e))?;
+
+        let staging_root = db_path
+            .parent()
+            .unwrap_or(std::path::Path::new("."))
+            .join(".leankg")
+            .join("sources");
+        tokio::fs::create_dir_all(&staging_root).await?;
+
+        println!("Re-syncing source '{}' for incremental index...", src.name());
+        let mut progress = sources::CliProgress;
+        let synced = src
+            .sync_to_local(&staging_root, &mut progress)
+            .await
+            .map_err(|e| format!("source sync failed: {}", e))?;
+        synced.to_string_lossy().to_string()
+    } else {
+        path.to_string()
+    };
+
+    println!("Performing incremental indexing for {}...", sync_path);
+
+    match indexer::incremental_index_sync(&graph_engine, &mut parser_manager, &sync_path).await {
         Ok(result) => {
             if result.changed_files.is_empty() && result.dependent_files.is_empty() {
                 println!("No changes detected since last index.");
@@ -1191,7 +1273,7 @@ async fn incremental_index_codebase(
                 "Incremental index failed: {}. Falling back to full index.",
                 e
             );
-            index_codebase(path, db_path, lang_filter, exclude_patterns, verbose, env).await?;
+            index_codebase(&sync_path, db_path, lang_filter, exclude_patterns, verbose, env, source_uri, ref_name, auth).await?;
         }
     }
 

--- a/src/sources/gcs.rs
+++ b/src/sources/gcs.rs
@@ -2,8 +2,7 @@ use super::{ProgressReporter, Source};
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 
-const GCS_LIST_URL: &str = "https://storage.googleapis.com/storage/v1/b";
-const GCS_DOWNLOAD_URL: &str = "https://storage.googleapis.com/storage/v1/b";
+const GCS_DEFAULT_ENDPOINT: &str = "https://storage.googleapis.com/storage/v1/b";
 
 /// Fetch source code from a GCS bucket.
 ///
@@ -13,6 +12,14 @@ const GCS_DOWNLOAD_URL: &str = "https://storage.googleapis.com/storage/v1/b";
 /// 1. `--auth <token>` -- a raw OAuth 2.0 access token.
 ///    Obtain via: `gcloud auth print-access-token`
 /// 2. `GCS_ACCESS_TOKEN` env var -- same as above.
+///
+/// ## Endpoint override (emulator support)
+///
+/// When `STORAGE_EMULATOR_HOST` is set, the source targets that base URL
+/// instead of the public `storage.googleapis.com`. This matches the convention
+/// used by the official GCS client libraries so a fake-gcs-server or other
+/// emulator can be pointed at without code changes. The endpoint is built as
+/// `<base>/storage/v1/b` to mirror the official SDK path resolution.
 ///
 /// ponytail: service-account JSON with JWT signing would need `rsa` + `pkcs8`
 /// crates. For now, pass a pre-fetched access token. Add when JWT support
@@ -24,14 +31,44 @@ pub struct GcsSource {
 }
 
 impl GcsSource {
-    fn resolve_token(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+    /// Resolve the GCS JSON API base URL (`<endpoint>/storage/v1/b`).
+    /// Priority: explicit override -> `STORAGE_EMULATOR_HOST` -> public default.
+    pub fn resolve_endpoint(&self) -> String {
+        if let Ok(override_endpoint) = std::env::var("GCS_ENDPOINT") {
+            let trimmed = override_endpoint.trim_end_matches('/');
+            return format!("{}/storage/v1/b", trimmed);
+        }
+        if let Ok(emulator_host) = std::env::var("STORAGE_EMULATOR_HOST") {
+            let trimmed = emulator_host.trim_end_matches('/');
+            return format!("{}/storage/v1/b", trimmed);
+        }
+        GCS_DEFAULT_ENDPOINT.to_string()
+    }
+
+    /// Bearer token used for all requests. Returns `None` when targeting an
+    /// emulator (which typically accepts any token or no token at all).
+    pub fn resolve_bearer_token(&self) -> Option<String> {
+        if std::env::var("STORAGE_EMULATOR_HOST").is_ok() {
+            // fake-gcs-server accepts any bearer token. Send a non-empty value
+            // so the request shape matches production without leaking real tokens.
+            return Some("emulator".to_string());
+        }
         if let Some(auth) = &self.auth {
             if !auth.trim().is_empty() {
-                return Ok(auth.clone());
+                return Some(auth.clone());
             }
         }
         if let Ok(token) = std::env::var("GCS_ACCESS_TOKEN") {
-            return Ok(token);
+            return Some(token);
+        }
+        None
+    }
+
+    /// Legacy wrapper: returns Err when no token can be resolved.
+    /// New code should prefer `resolve_bearer_token` so emulators can bypass auth.
+    fn require_token(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(t) = self.resolve_bearer_token() {
+            return Ok(t);
         }
         Err(
             "GCS source requires auth: pass --auth <access-token> or set GCS_ACCESS_TOKEN env var.\n\
@@ -44,13 +81,14 @@ impl GcsSource {
     async fn list_objects(
         &self,
         access_token: &str,
+        endpoint: &str,
     ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
         let client = reqwest::Client::new();
         let mut objects = Vec::new();
         let mut page_token: Option<String> = None;
 
         loop {
-            let url = format!("{}/{}/o", GCS_LIST_URL, self.bucket);
+            let url = format!("{}/{}/o", endpoint, self.bucket);
             let mut query_params: Vec<(&str, &str)> = Vec::new();
             if !self.prefix.is_empty() {
                 query_params.push(("prefix", self.prefix.as_str()));
@@ -114,10 +152,14 @@ impl Source for GcsSource {
         staging_root: &Path,
         progress: &mut dyn ProgressReporter,
     ) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
-        let token = self.resolve_token()?;
-        progress.report(&format!("listing gs://{}/{} ...", self.bucket, self.prefix));
+        let token = self.require_token()?;
+        let endpoint = self.resolve_endpoint();
+        progress.report(&format!(
+            "listing gs://{}/{} via {} ...",
+            self.bucket, self.prefix, endpoint
+        ));
 
-        let objects = self.list_objects(&token).await?;
+        let objects = self.list_objects(&token, &endpoint).await?;
         let total = objects.len();
         progress.report(&format!("found {} objects in bucket", total));
 
@@ -155,7 +197,7 @@ impl Source for GcsSource {
 
             let url = format!(
                 "{}/{}/o/{}",
-                GCS_DOWNLOAD_URL,
+                endpoint,
                 self.bucket,
                 percent_encode(obj_name)
             );

--- a/src/sources/gcs.rs
+++ b/src/sources/gcs.rs
@@ -79,8 +79,8 @@ impl GcsSource {
                 return Err(format!("GCS list returned {}: {}", status, body).into());
             }
 
-            let parsed: serde_json::Value = serde_json::from_str(&body)
-                .map_err(|e| format!("GCS list parse: {}", e))?;
+            let parsed: serde_json::Value =
+                serde_json::from_str(&body).map_err(|e| format!("GCS list parse: {}", e))?;
 
             if let Some(items) = parsed["items"].as_array() {
                 for item in items {
@@ -115,21 +115,14 @@ impl Source for GcsSource {
         progress: &mut dyn ProgressReporter,
     ) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
         let token = self.resolve_token()?;
-        progress.report(&format!(
-            "listing gs://{}/{} ...",
-            self.bucket, self.prefix
-        ));
+        progress.report(&format!("listing gs://{}/{} ...", self.bucket, self.prefix));
 
         let objects = self.list_objects(&token).await?;
         let total = objects.len();
         progress.report(&format!("found {} objects in bucket", total));
 
         if total == 0 {
-            return Err(format!(
-                "no objects found in gs://{}/{}",
-                self.bucket, self.prefix
-            )
-            .into());
+            return Err(format!("no objects found in gs://{}/{}", self.bucket, self.prefix).into());
         }
 
         let dir_name = super::uri_staging_dir(&super::SourceUri::Gcs {
@@ -195,7 +188,7 @@ impl Source for GcsSource {
             downloaded += 1;
             total_bytes += body.len() as u64;
 
-            if downloaded % 100 == 0 || downloaded == total {
+            if downloaded.is_multiple_of(100) || downloaded == total {
                 progress.report(&format!(
                     "synced {}/{} objects ({} MiB)",
                     downloaded,

--- a/src/sources/gcs.rs
+++ b/src/sources/gcs.rs
@@ -1,0 +1,239 @@
+use super::{ProgressReporter, Source};
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+const GCS_LIST_URL: &str = "https://storage.googleapis.com/storage/v1/b";
+const GCS_DOWNLOAD_URL: &str = "https://storage.googleapis.com/storage/v1/b";
+
+/// Fetch source code from a GCS bucket.
+///
+/// ## Authentication
+///
+/// Auth is read from (in priority order):
+/// 1. `--auth <token>` -- a raw OAuth 2.0 access token.
+///    Obtain via: `gcloud auth print-access-token`
+/// 2. `GCS_ACCESS_TOKEN` env var -- same as above.
+///
+/// ponytail: service-account JSON with JWT signing would need `rsa` + `pkcs8`
+/// crates. For now, pass a pre-fetched access token. Add when JWT support
+/// is required for CI/CD automation.
+pub struct GcsSource {
+    pub bucket: String,
+    pub prefix: String,
+    pub auth: Option<String>,
+}
+
+impl GcsSource {
+    fn resolve_token(&self) -> Result<String, Box<dyn std::error::Error + Send + Sync>> {
+        if let Some(auth) = &self.auth {
+            if !auth.trim().is_empty() {
+                return Ok(auth.clone());
+            }
+        }
+        if let Ok(token) = std::env::var("GCS_ACCESS_TOKEN") {
+            return Ok(token);
+        }
+        Err(
+            "GCS source requires auth: pass --auth <access-token> or set GCS_ACCESS_TOKEN env var.\n\
+             Obtain a token: gcloud auth print-access-token"
+                .into(),
+        )
+    }
+
+    /// List all objects under the bucket+prefix, returning their names.
+    async fn list_objects(
+        &self,
+        access_token: &str,
+    ) -> Result<Vec<String>, Box<dyn std::error::Error + Send + Sync>> {
+        let client = reqwest::Client::new();
+        let mut objects = Vec::new();
+        let mut page_token: Option<String> = None;
+
+        loop {
+            let url = format!("{}/{}/o", GCS_LIST_URL, self.bucket);
+            let mut query_params: Vec<(&str, &str)> = Vec::new();
+            if !self.prefix.is_empty() {
+                query_params.push(("prefix", self.prefix.as_str()));
+            }
+            if let Some(ref token) = page_token {
+                query_params.push(("pageToken", token.as_str()));
+            }
+            query_params.push(("maxResults", "1000"));
+
+            let resp = client
+                .get(&url)
+                .bearer_auth(access_token)
+                .query(&query_params)
+                .timeout(Duration::from_secs(30))
+                .send()
+                .await
+                .map_err(|e| format!("GCS list failed: {}", e))?;
+
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| format!("read GCS list body: {}", e))?;
+
+            if !status.is_success() {
+                return Err(format!("GCS list returned {}: {}", status, body).into());
+            }
+
+            let parsed: serde_json::Value = serde_json::from_str(&body)
+                .map_err(|e| format!("GCS list parse: {}", e))?;
+
+            if let Some(items) = parsed["items"].as_array() {
+                for item in items {
+                    let name = item["name"].as_str().unwrap_or("").to_string();
+                    let size = item["size"]
+                        .as_str()
+                        .and_then(|s| s.parse::<u64>().ok())
+                        .unwrap_or(0);
+                    // Skip directory placeholders (ending with / and size 0).
+                    if name.ends_with('/') && size == 0 {
+                        continue;
+                    }
+                    objects.push(name);
+                }
+            }
+
+            page_token = parsed["nextPageToken"].as_str().map(|s| s.to_string());
+            if page_token.is_none() {
+                break;
+            }
+        }
+
+        Ok(objects)
+    }
+}
+
+#[async_trait::async_trait]
+impl Source for GcsSource {
+    async fn sync_to_local(
+        &self,
+        staging_root: &Path,
+        progress: &mut dyn ProgressReporter,
+    ) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+        let token = self.resolve_token()?;
+        progress.report(&format!(
+            "listing gs://{}/{} ...",
+            self.bucket, self.prefix
+        ));
+
+        let objects = self.list_objects(&token).await?;
+        let total = objects.len();
+        progress.report(&format!("found {} objects in bucket", total));
+
+        if total == 0 {
+            return Err(format!(
+                "no objects found in gs://{}/{}",
+                self.bucket, self.prefix
+            )
+            .into());
+        }
+
+        let dir_name = super::uri_staging_dir(&super::SourceUri::Gcs {
+            bucket: self.bucket.clone(),
+            prefix: self.prefix.clone(),
+        });
+        let local_dir = staging_root.join(&dir_name);
+        tokio::fs::create_dir_all(&local_dir).await?;
+
+        let client = reqwest::Client::new();
+        let mut downloaded = 0usize;
+        let mut total_bytes: u64 = 0;
+        let max_size = super::max_file_size_bytes();
+
+        for obj_name in &objects {
+            // Strip prefix from the object name to get the relative path.
+            let relative_path = if self.prefix.is_empty() {
+                obj_name.as_str()
+            } else {
+                obj_name
+                    .strip_prefix(&self.prefix)
+                    .unwrap_or(obj_name)
+                    .trim_start_matches('/')
+            };
+            let local_path = local_dir.join(relative_path);
+
+            if let Some(parent) = local_path.parent() {
+                tokio::fs::create_dir_all(parent).await?;
+            }
+
+            let url = format!(
+                "{}/{}/o/{}",
+                GCS_DOWNLOAD_URL,
+                self.bucket,
+                percent_encode(obj_name)
+            );
+
+            let resp = client
+                .get(&url)
+                .query(&[("alt", "media")])
+                .bearer_auth(&token)
+                .timeout(Duration::from_secs(120))
+                .send()
+                .await
+                .map_err(|e| format!("download {} failed: {}", obj_name, e))?;
+
+            let body = resp
+                .bytes()
+                .await
+                .map_err(|e| format!("read {} body: {}", obj_name, e))?;
+
+            // Respect the max file size limit (same as local indexing).
+            if body.len() as u64 > max_size {
+                progress.report(&format!(
+                    "skipping oversized object {} ({} bytes)",
+                    obj_name,
+                    body.len()
+                ));
+                continue;
+            }
+
+            tokio::fs::write(&local_path, &body).await?;
+            downloaded += 1;
+            total_bytes += body.len() as u64;
+
+            if downloaded % 100 == 0 || downloaded == total {
+                progress.report(&format!(
+                    "synced {}/{} objects ({} MiB)",
+                    downloaded,
+                    total,
+                    total_bytes / (1024 * 1024)
+                ));
+            }
+        }
+
+        progress.report(&format!(
+            "complete: {} objects, {} MiB -> {}",
+            downloaded,
+            total_bytes / (1024 * 1024),
+            local_dir.display()
+        ));
+
+        Ok(local_dir)
+    }
+
+    fn name(&self) -> &str {
+        "gcs"
+    }
+}
+
+/// Percent-encode a GCS object name for use in the JSON API URL path.
+/// GCS requires `/` to be encoded as `%2F` in the object name portion.
+fn percent_encode(input: &str) -> String {
+    let mut result = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        match byte {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'_' | b'.' | b'~' => {
+                result.push(byte as char);
+            }
+            b'/' => result.push_str("%2F"),
+            _ => {
+                result.push_str(&format!("%{:02X}", byte));
+            }
+        }
+    }
+    result
+}

--- a/src/sources/git.rs
+++ b/src/sources/git.rs
@@ -1,0 +1,166 @@
+use super::{ProgressReporter, Source};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Clone or pull a git repository into the staging directory.
+pub struct GitSource {
+    pub url: String,
+    pub auth: Option<String>,
+    pub ref_name: String,
+}
+
+#[async_trait::async_trait]
+impl Source for GitSource {
+    async fn sync_to_local(
+        &self,
+        staging_root: &Path,
+        progress: &mut dyn ProgressReporter,
+    ) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+        let dir_name = super::uri_staging_dir(&super::SourceUri::Git {
+            url: self.url.clone(),
+        });
+        let local_dir = staging_root.join(&dir_name);
+
+        let git_dir = local_dir.join(".git");
+        if git_dir.exists() {
+            progress.report(&format!(
+                "git repo exists at {}, pulling {}...",
+                local_dir.display(),
+                self.ref_name
+            ));
+            fetch_and_checkout(&local_dir, &self.ref_name, progress)?;
+        } else {
+            tokio::fs::create_dir_all(&local_dir).await?;
+            progress.report(&format!(
+                "cloning {} (ref: {})...",
+                self.url, self.ref_name
+            ));
+            let clone_url = maybe_inject_auth(&self.url, self.auth.as_deref());
+            clone_repo(&clone_url, &local_dir, &self.ref_name, progress)?;
+        }
+
+        Ok(local_dir)
+    }
+
+    fn name(&self) -> &str {
+        "git"
+    }
+}
+
+fn maybe_inject_auth(url: &str, auth: Option<&str>) -> String {
+    let Some(token) = auth else {
+        return url.to_string();
+    };
+    // For https URLs, inject the token as userinfo.
+    if let Some(rest) = url.strip_prefix("https://") {
+        return format!("https://oauth2:{}@{}", token, rest);
+    }
+    url.to_string()
+}
+
+fn clone_repo(
+    url: &str,
+    dir: &Path,
+    ref_name: &str,
+    progress: &mut dyn ProgressReporter,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    progress.report(&format!("git clone --depth 1 --branch {} ...", ref_name));
+
+    let mut cmd = Command::new("git");
+    cmd.args(["clone", "--depth", "1", "--branch", ref_name, url])
+        .arg(dir);
+
+    let output = cmd.output().map_err(|e| format!("git clone failed: {}", e))?;
+
+    if !output.status.success() {
+        let _stderr = String::from_utf8_lossy(&output.stderr);
+        // Fallback: clone default branch then checkout.
+        progress.report("shallow clone failed, trying full clone + checkout...");
+        let mut cmd2 = Command::new("git");
+        cmd2.args(["clone", url]).arg(dir);
+        let out2 = cmd2
+            .output()
+            .map_err(|e| format!("git clone fallback failed: {}", e))?;
+        if !out2.status.success() {
+            return Err(format!(
+                "git clone fallback failed: {}",
+                String::from_utf8_lossy(&out2.stderr)
+            )
+            .into());
+        }
+    }
+
+    // Ensure we're on the right ref.
+    fetch_and_checkout(dir, ref_name, progress)?;
+    Ok(())
+}
+
+fn fetch_and_checkout(
+    repo_dir: &Path,
+    ref_name: &str,
+    progress: &mut dyn ProgressReporter,
+) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    // Fetch all to pick up new branches/tags.
+    let fetch = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["fetch", "--all", "--prune"])
+        .output()
+        .map_err(|e| format!("git fetch failed: {}", e))?;
+
+    if !fetch.status.success() {
+        return Err(format!(
+            "git fetch failed: {}",
+            String::from_utf8_lossy(&fetch.stderr)
+        )
+        .into());
+    }
+
+    progress.report(&format!("git checkout {} ...", ref_name));
+    let checkout = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["checkout", ref_name])
+        .output()
+        .map_err(|e| format!("git checkout failed: {}", e))?;
+
+    if !checkout.status.success() {
+        // Try as a remote branch reference.
+        let remote_ref = format!("origin/{}", ref_name);
+        progress.report(&format!("trying remote ref {}...", remote_ref));
+        let co2 = Command::new("git")
+            .current_dir(repo_dir)
+            .args(["checkout", "-b", ref_name, &remote_ref])
+            .output()
+            .map_err(|e| format!("git checkout remote ref failed: {}", e))?;
+
+        if !co2.status.success() {
+            return Err(format!(
+                "git checkout {} failed: {} (tried {}: {})",
+                ref_name,
+                String::from_utf8_lossy(&checkout.stderr),
+                remote_ref,
+                String::from_utf8_lossy(&co2.stderr)
+            )
+            .into());
+        }
+    }
+
+    // Pull latest if on a branch (not detached HEAD).
+    let pull = Command::new("git")
+        .current_dir(repo_dir)
+        .args(["pull", "--ff-only"])
+        .output();
+
+    match pull {
+        Ok(o) if o.status.success() => progress.report("pulled latest"),
+        Ok(o) => {
+            let stderr = String::from_utf8_lossy(&o.stderr);
+            progress.report(&format!(
+                "git pull skipped ({}): {}",
+                o.status, stderr
+            ));
+        }
+        Err(e) => progress.report(&format!("git pull error (non-fatal): {}", e)),
+    }
+
+    Ok(())
+}

--- a/src/sources/git.rs
+++ b/src/sources/git.rs
@@ -31,10 +31,7 @@ impl Source for GitSource {
             fetch_and_checkout(&local_dir, &self.ref_name, progress)?;
         } else {
             tokio::fs::create_dir_all(&local_dir).await?;
-            progress.report(&format!(
-                "cloning {} (ref: {})...",
-                self.url, self.ref_name
-            ));
+            progress.report(&format!("cloning {} (ref: {})...", self.url, self.ref_name));
             let clone_url = maybe_inject_auth(&self.url, self.auth.as_deref());
             clone_repo(&clone_url, &local_dir, &self.ref_name, progress)?;
         }
@@ -70,7 +67,9 @@ fn clone_repo(
     cmd.args(["clone", "--depth", "1", "--branch", ref_name, url])
         .arg(dir);
 
-    let output = cmd.output().map_err(|e| format!("git clone failed: {}", e))?;
+    let output = cmd
+        .output()
+        .map_err(|e| format!("git clone failed: {}", e))?;
 
     if !output.status.success() {
         let _stderr = String::from_utf8_lossy(&output.stderr);
@@ -154,10 +153,7 @@ fn fetch_and_checkout(
         Ok(o) if o.status.success() => progress.report("pulled latest"),
         Ok(o) => {
             let stderr = String::from_utf8_lossy(&o.stderr);
-            progress.report(&format!(
-                "git pull skipped ({}): {}",
-                o.status, stderr
-            ));
+            progress.report(&format!("git pull skipped ({}): {}", o.status, stderr));
             // Shallow depth may prevent ff-only pull. Attempt to reset to
             // the remote tracking branch to pick up new commits.
             progress.report("attempting fetch --unshallow + reset...");

--- a/src/sources/git.rs
+++ b/src/sources/git.rs
@@ -158,6 +158,32 @@ fn fetch_and_checkout(
                 "git pull skipped ({}): {}",
                 o.status, stderr
             ));
+            // Shallow depth may prevent ff-only pull. Attempt to reset to
+            // the remote tracking branch to pick up new commits.
+            progress.report("attempting fetch --unshallow + reset...");
+            let _ = Command::new("git")
+                .current_dir(repo_dir)
+                .args(["fetch", "--unshallow"])
+                .output();
+            let rebase = Command::new("git")
+                .current_dir(repo_dir)
+                .args(["merge", "--ff-only", &format!("origin/{}", ref_name)])
+                .output();
+            match rebase {
+                Ok(r) if r.status.success() => progress.report("fast-forward after unshallow"),
+                _ => {
+                    progress.report("reset to origin/HEAD as fallback");
+                    let reset = Command::new("git")
+                        .current_dir(repo_dir)
+                        .args(["reset", "--hard", &format!("origin/{}", ref_name)])
+                        .output();
+                    if let Ok(r) = reset {
+                        if r.status.success() {
+                            progress.report("reset to origin/HEAD OK");
+                        }
+                    }
+                }
+            }
         }
         Err(e) => progress.report(&format!("git pull error (non-fatal): {}", e)),
     }

--- a/src/sources/local.rs
+++ b/src/sources/local.rs
@@ -1,0 +1,33 @@
+use super::{ProgressReporter, Source};
+use std::path::{Path, PathBuf};
+
+/// Passthrough source for local filesystem paths.
+pub struct LocalSource {
+    pub path: String,
+}
+
+#[async_trait::async_trait]
+impl Source for LocalSource {
+    async fn sync_to_local(
+        &self,
+        _staging_root: &Path,
+        progress: &mut dyn ProgressReporter,
+    ) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>> {
+        let p = Path::new(&self.path);
+        let resolved = if p.is_absolute() {
+            p.to_path_buf()
+        } else {
+            std::env::current_dir()?.join(p)
+        };
+        let canonical = std::fs::canonicalize(&resolved).unwrap_or(resolved);
+        progress.report(&format!(
+            "local source at {}",
+            canonical.display()
+        ));
+        Ok(canonical)
+    }
+
+    fn name(&self) -> &str {
+        "local"
+    }
+}

--- a/src/sources/local.rs
+++ b/src/sources/local.rs
@@ -20,10 +20,7 @@ impl Source for LocalSource {
             std::env::current_dir()?.join(p)
         };
         let canonical = std::fs::canonicalize(&resolved).unwrap_or(resolved);
-        progress.report(&format!(
-            "local source at {}",
-            canonical.display()
-        ));
+        progress.report(&format!("local source at {}", canonical.display()));
         Ok(canonical)
     }
 

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -35,12 +35,29 @@ pub trait Source: Send + Sync {
 /// Parsed representation of a `--source` URI.
 #[derive(Debug, Clone, PartialEq)]
 pub enum SourceUri {
-    Local { path: String },
-    Gcs { bucket: String, prefix: String },
-    S3 { bucket: String, prefix: String },
-    Git { url: String },
-    Sftp { user: String, host: String, port: u16, path: String },
-    GoogleDrive { folder_id: String },
+    Local {
+        path: String,
+    },
+    Gcs {
+        bucket: String,
+        prefix: String,
+    },
+    S3 {
+        bucket: String,
+        prefix: String,
+    },
+    Git {
+        url: String,
+    },
+    Sftp {
+        user: String,
+        host: String,
+        port: u16,
+        path: String,
+    },
+    GoogleDrive {
+        folder_id: String,
+    },
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -66,22 +83,20 @@ pub enum SourceError {
 /// | `sftp://user@host:port/path` | `Sftp` |
 /// | `gdrive://folder-id` | `GoogleDrive` |
 pub fn parse_source_uri(uri: &str) -> Result<SourceUri, SourceError> {
-    if uri.starts_with("gs://") {
-        let rest = &uri[5..];
+    if let Some(rest) = uri.strip_prefix("gs://") {
         let (bucket, prefix) = split_bucket_prefix(rest);
         Ok(SourceUri::Gcs { bucket, prefix })
-    } else if uri.starts_with("s3://") {
-        let rest = &uri[5..];
+    } else if let Some(rest) = uri.strip_prefix("s3://") {
         let (bucket, prefix) = split_bucket_prefix(rest);
         Ok(SourceUri::S3 { bucket, prefix })
-    } else if uri.starts_with("git+") {
-        let git_url = uri.strip_prefix("git+").unwrap_or(uri).to_string();
-        if git_url.is_empty() {
+    } else if let Some(rest) = uri.strip_prefix("git+") {
+        if rest.is_empty() {
             return Err(SourceError::InvalidUri(uri.to_string()));
         }
-        Ok(SourceUri::Git { url: git_url })
-    } else if uri.starts_with("sftp://") {
-        let rest = &uri[7..];
+        Ok(SourceUri::Git {
+            url: rest.to_string(),
+        })
+    } else if let Some(rest) = uri.strip_prefix("sftp://") {
         let (user_host_port, path) = match rest.find('/') {
             Some(idx) => (&rest[..idx], rest[idx..].to_string()),
             None => (rest, "/".to_string()),
@@ -104,8 +119,7 @@ pub fn parse_source_uri(uri: &str) -> Result<SourceUri, SourceError> {
             port,
             path,
         })
-    } else if uri.starts_with("gdrive://") {
-        let folder_id = &uri[9..];
+    } else if let Some(folder_id) = uri.strip_prefix("gdrive://") {
         Ok(SourceUri::GoogleDrive {
             folder_id: folder_id.to_string(),
         })
@@ -134,15 +148,16 @@ impl SourceFactory {
         ref_name: Option<&str>,
     ) -> Result<Box<dyn Source>, SourceError> {
         match uri {
-            SourceUri::Local { path } => Ok(Box::new(local::LocalSource {
-                path: path.clone(),
-            })),
+            SourceUri::Local { path } => Ok(Box::new(local::LocalSource { path: path.clone() })),
             SourceUri::Gcs { bucket, prefix } => Ok(Box::new(gcs::GcsSource {
                 bucket: bucket.clone(),
                 prefix: prefix.clone(),
                 auth: auth.map(|s| s.to_string()),
             })),
-            SourceUri::S3 { bucket: _, prefix: _ } => {
+            SourceUri::S3 {
+                bucket: _,
+                prefix: _,
+            } => {
                 // ponytail: S3Source is planned for Phase 5, not yet implemented.
                 // For now, return auth-required error until the implementation lands.
                 Err(SourceError::UnsupportedScheme(
@@ -152,7 +167,9 @@ impl SourceFactory {
             SourceUri::Git { url } => Ok(Box::new(git::GitSource {
                 url: url.clone(),
                 auth: auth.map(|s| s.to_string()),
-                ref_name: ref_name.map(|s| s.to_string()).unwrap_or_else(|| "main".to_string()),
+                ref_name: ref_name
+                    .map(|s| s.to_string())
+                    .unwrap_or_else(|| "main".to_string()),
             })),
             SourceUri::Sftp { .. } => {
                 // ponytail: SftpSource is Phase 6.
@@ -183,7 +200,12 @@ pub fn uri_staging_dir(uri: &SourceUri) -> String {
         }
         SourceUri::S3 { bucket, prefix } => format!("s3_{}_{}", bucket, prefix),
         SourceUri::Git { url } => format!("git_{}", url),
-        SourceUri::Sftp { user, host, port, path } => {
+        SourceUri::Sftp {
+            user,
+            host,
+            port,
+            path,
+        } => {
             format!("sftp_{}@{}:{}{}", user, host, port, path)
         }
         SourceUri::GoogleDrive { folder_id } => format!("gdrive_{}", folder_id),

--- a/src/sources/mod.rs
+++ b/src/sources/mod.rs
@@ -1,0 +1,400 @@
+pub mod gcs;
+pub mod git;
+pub mod local;
+
+use std::path::{Path, PathBuf};
+
+#[async_trait::async_trait]
+pub trait ProgressReporter: Send {
+    fn report(&mut self, message: &str);
+}
+
+/// A simple CLI progress reporter that prints to stderr.
+pub struct CliProgress;
+
+impl ProgressReporter for CliProgress {
+    fn report(&mut self, message: &str) {
+        eprintln!("[source] {}", message);
+    }
+}
+
+#[async_trait::async_trait]
+pub trait Source: Send + Sync {
+    /// Sync remote content to a local staging directory.
+    /// Returns the path to the synced local directory.
+    async fn sync_to_local(
+        &self,
+        staging_root: &Path,
+        progress: &mut dyn ProgressReporter,
+    ) -> Result<PathBuf, Box<dyn std::error::Error + Send + Sync>>;
+
+    /// Human-readable label for logging.
+    fn name(&self) -> &str;
+}
+
+/// Parsed representation of a `--source` URI.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SourceUri {
+    Local { path: String },
+    Gcs { bucket: String, prefix: String },
+    S3 { bucket: String, prefix: String },
+    Git { url: String },
+    Sftp { user: String, host: String, port: u16, path: String },
+    GoogleDrive { folder_id: String },
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum SourceError {
+    #[error("unsupported source URI scheme: {0}")]
+    UnsupportedScheme(String),
+    #[error("invalid source URI: {0}")]
+    InvalidUri(String),
+    #[error("auth required but not provided for source type: {0}")]
+    AuthRequired(String),
+}
+
+/// Parse a source URI string into a `SourceUri`.
+///
+/// ## Supported schemes
+///
+/// | Pattern | Variant |
+/// |---------|---------|
+/// | `./path` or `/abs/path` (no scheme) | `Local` |
+/// | `gs://bucket` or `gs://bucket/prefix` | `Gcs` |
+/// | `s3://bucket/prefix` | `S3` |
+/// | `git+https://host/owner/repo.git` or `git+ssh://...` | `Git` |
+/// | `sftp://user@host:port/path` | `Sftp` |
+/// | `gdrive://folder-id` | `GoogleDrive` |
+pub fn parse_source_uri(uri: &str) -> Result<SourceUri, SourceError> {
+    if uri.starts_with("gs://") {
+        let rest = &uri[5..];
+        let (bucket, prefix) = split_bucket_prefix(rest);
+        Ok(SourceUri::Gcs { bucket, prefix })
+    } else if uri.starts_with("s3://") {
+        let rest = &uri[5..];
+        let (bucket, prefix) = split_bucket_prefix(rest);
+        Ok(SourceUri::S3 { bucket, prefix })
+    } else if uri.starts_with("git+") {
+        let git_url = uri.strip_prefix("git+").unwrap_or(uri).to_string();
+        if git_url.is_empty() {
+            return Err(SourceError::InvalidUri(uri.to_string()));
+        }
+        Ok(SourceUri::Git { url: git_url })
+    } else if uri.starts_with("sftp://") {
+        let rest = &uri[7..];
+        let (user_host_port, path) = match rest.find('/') {
+            Some(idx) => (&rest[..idx], rest[idx..].to_string()),
+            None => (rest, "/".to_string()),
+        };
+        let (user, host_port) = match user_host_port.find('@') {
+            Some(idx) => (&user_host_port[..idx], &user_host_port[idx + 1..]),
+            None => return Err(SourceError::InvalidUri(uri.to_string())),
+        };
+        let (host, port) = if let Some(idx) = host_port.find(':') {
+            let p: u16 = host_port[idx + 1..]
+                .parse()
+                .map_err(|_| SourceError::InvalidUri(uri.to_string()))?;
+            (host_port[..idx].to_string(), p)
+        } else {
+            (host_port.to_string(), 22u16)
+        };
+        Ok(SourceUri::Sftp {
+            user: user.to_string(),
+            host,
+            port,
+            path,
+        })
+    } else if uri.starts_with("gdrive://") {
+        let folder_id = &uri[9..];
+        Ok(SourceUri::GoogleDrive {
+            folder_id: folder_id.to_string(),
+        })
+    } else {
+        // Local path (no scheme or file://)
+        Ok(SourceUri::Local {
+            path: uri.to_string(),
+        })
+    }
+}
+
+fn split_bucket_prefix(rest: &str) -> (String, String) {
+    match rest.find('/') {
+        Some(idx) => (rest[..idx].to_string(), rest[idx + 1..].to_string()),
+        None => (rest.to_string(), String::new()),
+    }
+}
+
+/// Create a `Source` implementation from a parsed URI.
+pub struct SourceFactory;
+
+impl SourceFactory {
+    pub fn create(
+        uri: &SourceUri,
+        auth: Option<&str>,
+        ref_name: Option<&str>,
+    ) -> Result<Box<dyn Source>, SourceError> {
+        match uri {
+            SourceUri::Local { path } => Ok(Box::new(local::LocalSource {
+                path: path.clone(),
+            })),
+            SourceUri::Gcs { bucket, prefix } => Ok(Box::new(gcs::GcsSource {
+                bucket: bucket.clone(),
+                prefix: prefix.clone(),
+                auth: auth.map(|s| s.to_string()),
+            })),
+            SourceUri::S3 { bucket: _, prefix: _ } => {
+                // ponytail: S3Source is planned for Phase 5, not yet implemented.
+                // For now, return auth-required error until the implementation lands.
+                Err(SourceError::UnsupportedScheme(
+                    "s3 requires aws-sigv4 dependency (Phase 5)".to_string(),
+                ))
+            }
+            SourceUri::Git { url } => Ok(Box::new(git::GitSource {
+                url: url.clone(),
+                auth: auth.map(|s| s.to_string()),
+                ref_name: ref_name.map(|s| s.to_string()).unwrap_or_else(|| "main".to_string()),
+            })),
+            SourceUri::Sftp { .. } => {
+                // ponytail: SftpSource is Phase 6.
+                Err(SourceError::UnsupportedScheme(
+                    "sftp requires ssh2 dependency (Phase 6)".to_string(),
+                ))
+            }
+            SourceUri::GoogleDrive { .. } => {
+                // ponytail: GoogleDriveSource is Phase 7.
+                Err(SourceError::UnsupportedScheme(
+                    "gdrive requires OAuth + Drive API (Phase 7)".to_string(),
+                ))
+            }
+        }
+    }
+}
+
+/// Compute a staging directory name from a URI by replacing non-filesystem-safe chars.
+pub fn uri_staging_dir(uri: &SourceUri) -> String {
+    let raw = match uri {
+        SourceUri::Local { path } => format!("local_{}", path),
+        SourceUri::Gcs { bucket, prefix } => {
+            if prefix.is_empty() {
+                format!("gs_{}", bucket)
+            } else {
+                format!("gs_{}_{}", bucket, prefix)
+            }
+        }
+        SourceUri::S3 { bucket, prefix } => format!("s3_{}_{}", bucket, prefix),
+        SourceUri::Git { url } => format!("git_{}", url),
+        SourceUri::Sftp { user, host, port, path } => {
+            format!("sftp_{}@{}:{}{}", user, host, port, path)
+        }
+        SourceUri::GoogleDrive { folder_id } => format!("gdrive_{}", folder_id),
+    };
+    sanitize_dir_name(&raw)
+}
+
+fn sanitize_dir_name(raw: &str) -> String {
+    raw.chars()
+        .map(|c| {
+            if c.is_alphanumeric() || c == '-' || c == '_' || c == '.' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect()
+}
+
+/// Maximum file size for source downloads (same as the indexer default: 2 MiB).
+/// Override with `LEANKG_MAX_FILE_SIZE` env var (in bytes).
+pub fn max_file_size_bytes() -> u64 {
+    std::env::var("LEANKG_MAX_FILE_SIZE")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(2 * 1024 * 1024)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_gs_uri_bucket_only() {
+        assert_eq!(
+            parse_source_uri("gs://my-bucket").unwrap(),
+            SourceUri::Gcs {
+                bucket: "my-bucket".into(),
+                prefix: String::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_gs_uri_with_prefix() {
+        assert_eq!(
+            parse_source_uri("gs://my-bucket/path/to/code").unwrap(),
+            SourceUri::Gcs {
+                bucket: "my-bucket".into(),
+                prefix: "path/to/code".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_s3_uri() {
+        assert_eq!(
+            parse_source_uri("s3://my-bucket/prefix").unwrap(),
+            SourceUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: "prefix".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_git_https() {
+        assert_eq!(
+            parse_source_uri("git+https://github.com/user/repo.git").unwrap(),
+            SourceUri::Git {
+                url: "https://github.com/user/repo.git".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_git_ssh() {
+        assert_eq!(
+            parse_source_uri("git+ssh://git@github.com/user/repo.git").unwrap(),
+            SourceUri::Git {
+                url: "ssh://git@github.com/user/repo.git".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_sftp_uri() {
+        assert_eq!(
+            parse_source_uri("sftp://user@host:2222/path").unwrap(),
+            SourceUri::Sftp {
+                user: "user".into(),
+                host: "host".into(),
+                port: 2222,
+                path: "/path".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_sftp_uri_default_port() {
+        assert_eq!(
+            parse_source_uri("sftp://user@host/path").unwrap(),
+            SourceUri::Sftp {
+                user: "user".into(),
+                host: "host".into(),
+                port: 22,
+                path: "/path".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_gdrive_uri() {
+        assert_eq!(
+            parse_source_uri("gdrive://abc123folder").unwrap(),
+            SourceUri::GoogleDrive {
+                folder_id: "abc123folder".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn parse_local_path() {
+        assert_eq!(
+            parse_source_uri("./my-code").unwrap(),
+            SourceUri::Local {
+                path: "./my-code".into(),
+            }
+        );
+        assert_eq!(
+            parse_source_uri("/abs/path").unwrap(),
+            SourceUri::Local {
+                path: "/abs/path".into(),
+            }
+        );
+    }
+
+    #[test]
+    fn factory_creates_local_source() {
+        let uri = SourceUri::Local {
+            path: "./src".into(),
+        };
+        let source = SourceFactory::create(&uri, None, None).unwrap();
+        assert_eq!(source.name(), "local");
+    }
+
+    #[test]
+    fn factory_creates_gcs_source() {
+        let uri = SourceUri::Gcs {
+            bucket: "bkt".into(),
+            prefix: "pre".into(),
+        };
+        let source = SourceFactory::create(&uri, Some("token"), None).unwrap();
+        assert_eq!(source.name(), "gcs");
+    }
+
+    #[test]
+    fn factory_creates_git_source() {
+        let uri = SourceUri::Git {
+            url: "https://example.com/repo.git".into(),
+        };
+        let source = SourceFactory::create(&uri, Some("token"), Some("develop")).unwrap();
+        assert_eq!(source.name(), "git");
+    }
+
+    #[test]
+    fn factory_rejects_unimplemented_sources() {
+        assert!(SourceFactory::create(
+            &SourceUri::S3 {
+                bucket: "b".into(),
+                prefix: "p".into()
+            },
+            None,
+            None
+        )
+        .is_err());
+        assert!(SourceFactory::create(
+            &SourceUri::Sftp {
+                user: "u".into(),
+                host: "h".into(),
+                port: 22,
+                path: "/".into()
+            },
+            None,
+            None
+        )
+        .is_err());
+        assert!(SourceFactory::create(
+            &SourceUri::GoogleDrive {
+                folder_id: "f".into()
+            },
+            None,
+            None
+        )
+        .is_err());
+    }
+
+    #[test]
+    fn uri_staging_dir_sanitizes_special_chars() {
+        let uri = SourceUri::Git {
+            url: "https://github.com/user/repo.git".into(),
+        };
+        let dir = uri_staging_dir(&uri);
+        assert!(!dir.contains('/'));
+        assert!(!dir.contains(':'));
+        assert!(dir.starts_with("git_"));
+    }
+
+    #[test]
+    fn cli_progress_does_not_panic() {
+        let mut p = CliProgress;
+        p.report("testing 1-2-3");
+    }
+}

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -656,7 +656,10 @@ fn test_cli_index_with_source_flag() {
             auth,
             ..
         } => {
-            assert_eq!(source.as_deref(), Some("git+https://github.com/user/repo.git"));
+            assert_eq!(
+                source.as_deref(),
+                Some("git+https://github.com/user/repo.git")
+            );
             assert_eq!(ref_name, None);
             assert_eq!(auth, None);
         }

--- a/tests/cli_tests.rs
+++ b/tests/cli_tests.rs
@@ -639,3 +639,78 @@ fn test_cli_export_custom_output() {
         _ => panic!("expected Export command"),
     }
 }
+
+#[test]
+fn test_cli_index_with_source_flag() {
+    let args = TestArgs::try_parse_from([
+        "leankg",
+        "index",
+        "--source",
+        "git+https://github.com/user/repo.git",
+    ])
+    .unwrap();
+    match args.command {
+        CLICommand::Index {
+            source,
+            ref_name,
+            auth,
+            ..
+        } => {
+            assert_eq!(source.as_deref(), Some("git+https://github.com/user/repo.git"));
+            assert_eq!(ref_name, None);
+            assert_eq!(auth, None);
+        }
+        _ => panic!("expected Index command"),
+    }
+}
+
+#[test]
+fn test_cli_index_with_source_and_ref_and_auth() {
+    let args = TestArgs::try_parse_from([
+        "leankg",
+        "index",
+        "--source",
+        "git+https://github.com/user/repo.git",
+        "--ref-name",
+        "develop",
+        "--auth",
+        "ghp_token123",
+    ])
+    .unwrap();
+    match args.command {
+        CLICommand::Index {
+            source,
+            ref_name,
+            auth,
+            ..
+        } => {
+            assert_eq!(
+                source.as_deref(),
+                Some("git+https://github.com/user/repo.git")
+            );
+            assert_eq!(ref_name.as_deref(), Some("develop"));
+            assert_eq!(auth.as_deref(), Some("ghp_token123"));
+        }
+        _ => panic!("expected Index command"),
+    }
+}
+
+#[test]
+fn test_cli_index_with_gcs_source() {
+    let args = TestArgs::try_parse_from([
+        "leankg",
+        "index",
+        "--source",
+        "gs://my-bucket/code",
+        "--auth",
+        "ya29.token",
+    ])
+    .unwrap();
+    match args.command {
+        CLICommand::Index { source, auth, .. } => {
+            assert_eq!(source.as_deref(), Some("gs://my-bucket/code"));
+            assert_eq!(auth.as_deref(), Some("ya29.token"));
+        }
+        _ => panic!("expected Index command"),
+    }
+}

--- a/tests/sources_gcs_e2e_tests.rs
+++ b/tests/sources_gcs_e2e_tests.rs
@@ -1,0 +1,401 @@
+//! End-to-end Docker-backed tests for the GCS source using
+//! [`fsouza/fake-gcs-server`](https://github.com/fsouza/fake-gcs-server).
+//!
+//! These tests require Docker on the host. They auto-skip when:
+//! - Docker CLI is missing (`which docker` returns nothing), or
+//! - `LEANKG_GCS_E2E=0` is set explicitly.
+//!
+//! Two modes:
+//! - **Local**: when `STORAGE_EMULATOR_HOST` is unset, the test starts the
+//!   emulator as a one-shot docker container on a random local port.
+//! - **External**: when `STORAGE_EMULATOR_HOST` is set (e.g. the CI service
+//!   container, or a developer already running the emulator), the test
+//!   reuses that endpoint and skips the Docker boot path. The caller is
+//!   responsible for keeping the emulator alive (CI service containers
+//!   satisfy this).
+
+use std::io::Read;
+use std::net::TcpListener;
+use std::process::{Command, Stdio};
+use std::sync::Mutex;
+use std::thread;
+use std::time::Duration;
+
+use leankg::sources::gcs::GcsSource;
+use leankg::sources::{ProgressReporter, Source};
+use tempfile::TempDir;
+
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+struct CollectingProgress {
+    messages: Vec<String>,
+}
+
+impl ProgressReporter for CollectingProgress {
+    fn report(&mut self, message: &str) {
+        self.messages.push(message.to_string());
+    }
+}
+
+fn docker_available() -> bool {
+    Command::new("docker")
+        .args(["version"])
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .map(|s| s.success())
+        .unwrap_or(false)
+}
+
+fn is_explicit_skip() -> bool {
+    std::env::var("LEANKG_GCS_E2E")
+        .map(|v| v == "0")
+        .unwrap_or(false)
+}
+
+fn pick_free_port() -> u16 {
+    let listener = TcpListener::bind("127.0.0.1:0").expect("bind ephemeral port");
+    let port = listener.local_addr().expect("local_addr").port();
+    drop(listener);
+    port
+}
+
+struct DockerGuard {
+    container: String,
+}
+
+impl Drop for DockerGuard {
+    fn drop(&mut self) {
+        let _ = Command::new("docker")
+            .args(["rm", "-f", &self.container])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status();
+    }
+}
+
+fn start_fake_gcs_server(host: &str, port: u16) -> Result<DockerGuard, String> {
+    let container = format!("leankg-fake-gcs-{}-{}", std::process::id(), port);
+    let addr = format!("http://{}:{}", host, port);
+
+    let mut child = Command::new("docker")
+        .args([
+            "run",
+            "-d",
+            "--rm",
+            "--name",
+            &container,
+            "-p",
+            &format!("{}:{}", port, port),
+            "fsouza/fake-gcs-server",
+            "-scheme",
+            "http",
+            "-port",
+            &port.to_string(),
+            "-external-url",
+            &addr,
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("docker run failed to spawn: {}", e))?;
+
+    let mut stdout = String::new();
+    child
+        .stdout
+        .as_mut()
+        .unwrap()
+        .read_to_string(&mut stdout)
+        .map_err(|e| format!("read docker run stdout: {}", e))?;
+    let mut stderr = String::new();
+    child
+        .stderr
+        .as_mut()
+        .unwrap()
+        .read_to_string(&mut stderr)
+        .ok();
+    let status = child
+        .wait()
+        .map_err(|e| format!("docker run wait: {}", e))?;
+    if !status.success() {
+        return Err(format!(
+            "docker run failed ({}): stdout={} stderr={}",
+            status, stdout, stderr
+        ));
+    }
+    let container_id = stdout.trim().to_string();
+    if container_id.is_empty() {
+        return Err(format!(
+            "docker run returned empty container id: {}",
+            stderr
+        ));
+    }
+
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    loop {
+        if std::time::Instant::now() >= deadline {
+            return Err(format!(
+                "fake-gcs-server did not become ready at {} within 15s",
+                addr
+            ));
+        }
+        if let Ok(child) = Command::new("curl")
+            .args(["-fsS", "--max-time", "2", &format!("{}/storage/v1/b", addr)])
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .status()
+        {
+            if child.success() {
+                break;
+            }
+        }
+        thread::sleep(Duration::from_millis(250));
+    }
+
+    Ok(DockerGuard {
+        container: container_id,
+    })
+}
+
+fn create_bucket(addr: &str, bucket: &str, project: &str) -> Result<(), String> {
+    let url = format!("{}/storage/v1/b?project={}", addr, project);
+    let body = format!("{{\"name\":\"{}\"}}", bucket);
+    let status = Command::new("curl")
+        .args([
+            "-fsS",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: application/json",
+            "-d",
+            &body,
+            &url,
+        ])
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .status()
+        .map_err(|e| format!("create_bucket curl failed: {}", e))?;
+    if !status.success() {
+        return Err(format!("create_bucket returned {}", status));
+    }
+    Ok(())
+}
+
+fn upload_object(addr: &str, bucket: &str, name: &str, body: &[u8]) -> Result<(), String> {
+    use std::io::Write;
+    let url = format!(
+        "{}/upload/storage/v1/b/{}/o?uploadType=media&name={}",
+        addr,
+        bucket,
+        name.replace('/', "%2F")
+    );
+    let mut child = Command::new("curl")
+        .args([
+            "-fsS",
+            "-X",
+            "POST",
+            "-H",
+            "Content-Type: text/plain",
+            "--data-binary",
+            "@-",
+            &url,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::null())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("upload_object curl spawn: {}", e))?;
+    child
+        .stdin
+        .as_mut()
+        .unwrap()
+        .write_all(body)
+        .map_err(|e| format!("upload_object stdin: {}", e))?;
+    let status = child
+        .wait()
+        .map_err(|e| format!("upload_object wait: {}", e))?;
+    if !status.success() {
+        return Err(format!("upload_object {} returned {}", name, status));
+    }
+    Ok(())
+}
+
+/// Parse `http://host:port` into `(host, port)`.
+fn parse_emulator_addr(addr: &str) -> Option<(String, u16)> {
+    let trimmed = addr
+        .strip_prefix("http://")
+        .or_else(|| addr.strip_prefix("https://"))?;
+    let (host_port, _path) = match trimmed.find('/') {
+        Some(idx) => (&trimmed[..idx], &trimmed[idx..]),
+        None => (trimmed, ""),
+    };
+    let (host, port_str) = match host_port.rfind(':') {
+        Some(idx) => (&host_port[..idx], &host_port[idx + 1..]),
+        None => return None,
+    };
+    if host.is_empty() || port_str.is_empty() {
+        return None;
+    }
+    port_str.parse::<u16>().ok().map(|p| (host.to_string(), p))
+}
+
+struct EmulatorHandle {
+    /// `http://host:port` address used to talk to fake-gcs-server.
+    addr: String,
+    /// Cleanup guard. `None` when the emulator is owned externally (CI).
+    guard: Option<DockerGuard>,
+}
+
+/// Resolve which emulator address the test should hit. Spawns a fresh
+/// docker container when `STORAGE_EMULATOR_HOST` is unset.
+fn resolve_or_start_emulator() -> Option<EmulatorHandle> {
+    if let Ok(existing) = std::env::var("STORAGE_EMULATOR_HOST") {
+        let trimmed = existing.trim_end_matches('/').to_string();
+        let parsed =
+            parse_emulator_addr(&trimmed).expect("STORAGE_EMULATOR_HOST must be http://host:port");
+        eprintln!(
+            "[e2e] using pre-configured STORAGE_EMULATOR_HOST={}",
+            trimmed
+        );
+        return Some(EmulatorHandle {
+            addr: trimmed,
+            guard: None,
+        });
+    }
+    if !docker_available() {
+        eprintln!("[e2e] docker not available and STORAGE_EMULATOR_HOST unset; skipping");
+        return None;
+    }
+    let host = "127.0.0.1".to_string();
+    let port = pick_free_port();
+    let addr = format!("http://{}:{}", host, port);
+    std::env::set_var("STORAGE_EMULATOR_HOST", &addr);
+    match start_fake_gcs_server(&host, port) {
+        Ok(g) => {
+            eprintln!("[e2e] emulator ready on {}:{}", host, port);
+            Some(EmulatorHandle {
+                addr,
+                guard: Some(g),
+            })
+        }
+        Err(e) => {
+            eprintln!("[e2e] skipping gcs e2e: {}", e);
+            std::env::remove_var("STORAGE_EMULATOR_HOST");
+            None
+        }
+    }
+}
+
+#[tokio::test]
+async fn gcs_source_syncs_objects_from_fake_emulator() {
+    if is_explicit_skip() {
+        eprintln!("LEANKG_GCS_E2E=0 set; skipping");
+        return;
+    }
+    let _env_guard = ENV_LOCK.lock().unwrap();
+    let emulator = match resolve_or_start_emulator() {
+        Some(e) => e,
+        None => return,
+    };
+    let addr = emulator.addr.clone();
+
+    let bucket = "leankg-e2e-bucket";
+    let project = "leankg-e2e";
+    create_bucket(&addr, bucket, project).expect("create_bucket");
+    upload_object(&addr, bucket, "hello.go", b"package main\nfunc main() {}\n")
+        .expect("upload hello.go");
+    upload_object(
+        &addr,
+        bucket,
+        "internal/lib.go",
+        b"package internal\nfunc Add(a, b int) int { return a + b }\n",
+    )
+    .expect("upload lib.go");
+
+    let src = GcsSource {
+        bucket: bucket.to_string(),
+        prefix: String::new(),
+        auth: None,
+    };
+    let staging = TempDir::new().expect("staging tmpdir");
+    let mut progress = CollectingProgress { messages: vec![] };
+
+    let synced = src
+        .sync_to_local(staging.path(), &mut progress)
+        .await
+        .expect("sync_to_local");
+
+    assert!(synced.join("hello.go").is_file(), "hello.go missing");
+    assert!(
+        synced.join("internal/lib.go").is_file(),
+        "internal/lib.go missing"
+    );
+
+    let hello = std::fs::read_to_string(synced.join("hello.go")).unwrap();
+    assert_eq!(hello, "package main\nfunc main() {}\n");
+
+    let lib = std::fs::read_to_string(synced.join("internal/lib.go")).unwrap();
+    assert_eq!(
+        lib,
+        "package internal\nfunc Add(a, b int) int { return a + b }\n"
+    );
+
+    assert!(
+        progress
+            .messages
+            .iter()
+            .any(|m| m.contains("found 2 objects")),
+        "missing expected progress message, got: {:?}",
+        progress.messages
+    );
+
+    let we_started_emulator = emulator.guard.is_some();
+    drop(emulator);
+    if we_started_emulator {
+        std::env::remove_var("STORAGE_EMULATOR_HOST");
+    }
+}
+
+#[tokio::test]
+async fn gcs_source_with_prefix_filters_objects() {
+    if is_explicit_skip() {
+        return;
+    }
+    let _env_guard = ENV_LOCK.lock().unwrap();
+    let emulator = match resolve_or_start_emulator() {
+        Some(e) => e,
+        None => return,
+    };
+    let addr = emulator.addr.clone();
+
+    let bucket = "leankg-prefix-bucket";
+    let project = "leankg-prefix";
+    create_bucket(&addr, bucket, project).expect("create_bucket");
+    upload_object(&addr, bucket, "keep/a.go", b"package keep\n").expect("upload a");
+    upload_object(&addr, bucket, "skip/b.go", b"package skip\n").expect("upload b");
+
+    let src = GcsSource {
+        bucket: bucket.to_string(),
+        prefix: "keep/".to_string(),
+        auth: None,
+    };
+    let staging = TempDir::new().expect("staging");
+    let mut progress = CollectingProgress { messages: vec![] };
+
+    let synced = src
+        .sync_to_local(staging.path(), &mut progress)
+        .await
+        .expect("sync_to_local");
+
+    assert!(synced.join("a.go").is_file(), "keep/a.go missing");
+    assert!(
+        !synced.join("skip").exists() && !synced.join("skip/b.go").exists(),
+        "skip/* should be filtered out"
+    );
+
+    let we_started_emulator = emulator.guard.is_some();
+    drop(emulator);
+    if we_started_emulator {
+        std::env::remove_var("STORAGE_EMULATOR_HOST");
+    }
+}

--- a/tests/sources_integration_tests.rs
+++ b/tests/sources_integration_tests.rs
@@ -1,0 +1,371 @@
+//! End-to-end integration tests for the sources module.
+//!
+//! Covers:
+//! - `LocalSource` resolves a real filesystem path through canonicalize.
+//! - `GitSource` clones a real local bare git repo and indexes its files.
+//! - `parse_source_uri` round-trips for every supported scheme.
+
+use leankg::sources::git::GitSource;
+use leankg::sources::local::LocalSource;
+use leankg::sources::{
+    parse_source_uri, ProgressReporter, Source, SourceFactory, SourceUri,
+};
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+struct CollectingProgress {
+    messages: Vec<String>,
+}
+
+impl ProgressReporter for CollectingProgress {
+    fn report(&mut self, message: &str) {
+        self.messages.push(message.to_string());
+    }
+}
+
+fn init_git_repo(path: &Path) {
+    std::fs::create_dir_all(path).unwrap();
+    let run = |args: &[&str]| {
+        Command::new("git")
+            .args(args)
+            .current_dir(path)
+            .output()
+            .unwrap_or_else(|e| panic!("git {:?} failed: {}", args, e))
+    };
+    assert!(
+        run(&["init", "--initial-branch=main"]).status.success(),
+        "git init failed"
+    );
+    run(&["config", "user.email", "test@example.com"]);
+    run(&["config", "user.name", "test"]);
+    std::fs::write(path.join("main.go"), "package main\nfunc main() {}\n").unwrap();
+    run(&["add", "main.go"]);
+    assert!(run(&["commit", "-m", "init"]).status.success());
+}
+
+/// Build a `file://` URL from a local path so git treats it as a remote
+/// source (avoiding "warning: --depth is ignored in local clones").
+fn file_url(path: &Path) -> String {
+    format!("file://{}", path.to_string_lossy())
+}
+
+#[tokio::test]
+async fn local_source_resolves_existing_path() {
+    let tmp = TempDir::new().unwrap();
+    let src_dir = tmp.path().join("my-code");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    std::fs::write(src_dir.join("hello.go"), "package main\n").unwrap();
+
+    let src = LocalSource {
+        path: src_dir.to_string_lossy().to_string(),
+    };
+    let mut progress = CollectingProgress { messages: vec![] };
+    let resolved = src
+        .sync_to_local(tmp.path(), &mut progress)
+        .await
+        .expect("local sync failed");
+
+    assert!(resolved.is_dir());
+    assert!(resolved.join("hello.go").exists());
+    assert!(progress
+        .messages
+        .iter()
+        .any(|m| m.contains("local source")));
+    assert_eq!(src.name(), "local");
+}
+
+#[tokio::test]
+async fn local_source_resolves_relative_path() {
+    let tmp = TempDir::new().unwrap();
+    let src_dir = tmp.path().join("rel-code");
+    std::fs::create_dir_all(&src_dir).unwrap();
+    let rel_name = src_dir.file_name().unwrap().to_str().unwrap();
+
+    // Run the test from the tmp dir so the relative path is resolvable.
+    let prev_cwd = std::env::current_dir().unwrap();
+    std::env::set_current_dir(tmp.path()).unwrap();
+
+    let src = LocalSource {
+        path: rel_name.to_string(),
+    };
+    let mut progress = CollectingProgress { messages: vec![] };
+    let resolved = src.sync_to_local(tmp.path(), &mut progress).await.unwrap();
+    assert!(resolved.is_dir());
+
+    std::env::set_current_dir(prev_cwd).unwrap();
+}
+
+#[tokio::test]
+async fn git_source_clones_local_repo_into_staging() {
+    let tmp = TempDir::new().unwrap();
+    let repo_dir = tmp.path().join("source-repo");
+    init_git_repo(&repo_dir);
+
+    let workdir = tmp.path().join("workdir");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let src = GitSource {
+        url: file_url(&repo_dir),
+        auth: None,
+        ref_name: "main".to_string(),
+    };
+    let mut progress = CollectingProgress { messages: vec![] };
+    let synced = src
+        .sync_to_local(&workdir, &mut progress)
+        .await
+        .expect("git sync failed");
+
+    assert!(synced.is_dir(), "synced dir does not exist");
+    assert!(
+        synced.join("main.go").exists(),
+        "expected main.go in synced dir, got: {:?}",
+        std::fs::read_dir(&synced).unwrap().flatten().collect::<Vec<_>>()
+    );
+    assert!(
+        synced.join(".git").exists(),
+        "expected .git in synced dir (full clone)"
+    );
+    assert!(progress.messages.iter().any(|m| m.contains("cloning")));
+}
+
+#[tokio::test]
+async fn git_source_pulls_when_repo_already_exists() {
+    let tmp = TempDir::new().unwrap();
+    let repo_dir = tmp.path().join("source-repo");
+    init_git_repo(&repo_dir);
+
+    let workdir = tmp.path().join("workdir");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let src = GitSource {
+        url: file_url(&repo_dir),
+        auth: None,
+        ref_name: "main".to_string(),
+    };
+    let mut progress1 = CollectingProgress { messages: vec![] };
+    src.sync_to_local(&workdir, &mut progress1)
+        .await
+        .expect("first sync failed");
+
+    let mut progress2 = CollectingProgress { messages: vec![] };
+    let synced2 = src
+        .sync_to_local(&workdir, &mut progress2)
+        .await
+        .expect("second sync failed");
+
+    assert!(synced2.join("main.go").exists());
+    assert!(
+        progress2.messages.iter().any(|m| m.contains("pulling")),
+        "expected a 'pulling' message on second sync, got: {:?}",
+        progress2.messages
+    );
+}
+
+#[tokio::test]
+async fn factory_returns_unimplemented_for_s3_sftp_gdrive() {
+    let progress = CollectingProgress { messages: vec![] };
+    let s3 = SourceFactory::create(
+        &SourceUri::S3 {
+            bucket: "b".into(),
+            prefix: "p".into(),
+        },
+        None,
+        None,
+    );
+    assert!(s3.is_err());
+    let sftp = SourceFactory::create(
+        &SourceUri::Sftp {
+            user: "u".into(),
+            host: "h".into(),
+            port: 22,
+            path: "/".into(),
+        },
+        None,
+        None,
+    );
+    assert!(sftp.is_err());
+    let gdrive = SourceFactory::create(
+        &SourceUri::GoogleDrive {
+            folder_id: "f".into(),
+        },
+        None,
+        None,
+    );
+    assert!(gdrive.is_err());
+
+    let _ = progress;
+}
+
+#[test]
+fn parse_source_uri_round_trips_all_schemes() {
+    let cases = vec![
+        (
+            "gs://my-bucket/path/to/code",
+            SourceUri::Gcs {
+                bucket: "my-bucket".into(),
+                prefix: "path/to/code".into(),
+            },
+        ),
+        (
+            "s3://my-bucket/prefix",
+            SourceUri::S3 {
+                bucket: "my-bucket".into(),
+                prefix: "prefix".into(),
+            },
+        ),
+        (
+            "git+https://github.com/user/repo.git",
+            SourceUri::Git {
+                url: "https://github.com/user/repo.git".into(),
+            },
+        ),
+        (
+            "sftp://user@host:2222/path",
+            SourceUri::Sftp {
+                user: "user".into(),
+                host: "host".into(),
+                port: 2222,
+                path: "/path".into(),
+            },
+        ),
+        (
+            "gdrive://abc123",
+            SourceUri::GoogleDrive {
+                folder_id: "abc123".into(),
+            },
+        ),
+        (
+            "/abs/path",
+            SourceUri::Local {
+                path: "/abs/path".into(),
+            },
+        ),
+    ];
+
+    for (input, expected) in cases {
+        let parsed = parse_source_uri(input).expect(input);
+        assert_eq!(parsed, expected, "round-trip failed for {}", input);
+    }
+}
+
+#[tokio::test]
+async fn staged_repo_files_match_local_indexing_input() {
+    // The whole point of the sources layer: a staged git repo should be
+    // indexable by the existing indexer pipeline without any change.
+    let tmp = TempDir::new().unwrap();
+    let repo_dir = tmp.path().join("real-repo");
+    init_git_repo(&repo_dir);
+
+    // Write a few more files so a full file walk yields > 1 hit.
+    std::fs::create_dir_all(repo_dir.join("internal")).unwrap();
+    std::fs::write(
+        repo_dir.join("internal").join("lib.go"),
+        "package internal\nfunc Add(a, b int) int { return a + b }\n",
+    )
+    .unwrap();
+    let _ = Command::new("git")
+        .current_dir(&repo_dir)
+        .args(["add", "."])
+        .output();
+    let _ = Command::new("git")
+        .current_dir(&repo_dir)
+        .args(["commit", "-m", "more files"])
+        .output();
+
+    let workdir = tmp.path().join("workdir");
+    std::fs::create_dir_all(&workdir).unwrap();
+
+    let src = GitSource {
+        url: file_url(&repo_dir),
+        auth: None,
+        ref_name: "main".to_string(),
+    };
+    let mut progress = CollectingProgress { messages: vec![] };
+    let synced = src.sync_to_local(&workdir, &mut progress).await.unwrap();
+
+    // Use the indexer's own file walker to verify the staged tree is well-formed.
+    let files = leankg::indexer::find_files_sync(synced.to_str().unwrap())
+        .expect("find_files_sync failed on staged dir");
+    assert!(
+        files.iter().any(|p| p.ends_with("main.go")),
+        "main.go missing from staged index, files: {:?}",
+        files
+    );
+    assert!(
+        files.iter().any(|p| p.ends_with("lib.go")),
+        "lib.go missing from staged index, files: {:?}",
+        files
+    );
+}
+
+/// Mutex for tests that mutate process-wide env vars (GCS_ACCESS_TOKEN).
+/// tokio tests run in parallel; env var mutations are not thread-safe.
+static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[tokio::test]
+async fn gcs_source_requires_auth_token() {
+    use leankg::sources::gcs::GcsSource;
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::remove_var("GCS_ACCESS_TOKEN");
+
+    let src = GcsSource {
+        bucket: "my-bucket".into(),
+        prefix: String::new(),
+        auth: None,
+    };
+    let tmp = TempDir::new().unwrap();
+    let mut progress = CollectingProgress { messages: vec![] };
+    let result = src.sync_to_local(tmp.path(), &mut progress).await;
+    let err = result.expect_err("expected auth error");
+    let msg = err.to_string();
+    assert!(
+        msg.contains("GCS source requires auth"),
+        "unexpected error: {}",
+        msg
+    );
+}
+
+#[tokio::test]
+async fn gcs_source_accepts_auth_via_env() {
+    use leankg::sources::gcs::GcsSource;
+
+    let _guard = ENV_LOCK.lock().unwrap();
+    // We cannot actually contact GCS in unit tests, but we can verify
+    // that the auth path is reached and produces a network error (not
+    // an auth error) when a token is provided via env.
+    std::env::set_var("GCS_ACCESS_TOKEN", "fake-test-token");
+    let src = GcsSource {
+        bucket: "fake-bucket".into(),
+        prefix: String::new(),
+        auth: None,
+    };
+    let tmp = TempDir::new().unwrap();
+    let mut progress = CollectingProgress { messages: vec![] };
+    let result = src.sync_to_local(tmp.path(), &mut progress).await;
+    std::env::remove_var("GCS_ACCESS_TOKEN");
+    // Must fail (fake token), but for a network/auth reason, not "no auth".
+    if let Err(e) = result {
+        let msg = e.to_string();
+        assert!(
+            !msg.contains("GCS source requires auth"),
+            "auth should have been satisfied via env var, but got: {}",
+            msg
+        );
+    }
+}
+
+#[tokio::test]
+async fn local_source_with_missing_path_fails() {
+    let src = LocalSource {
+        path: "/this/path/does/not/exist/anywhere".to_string(),
+    };
+    let tmp = TempDir::new().unwrap();
+    let mut progress = CollectingProgress { messages: vec![] };
+    // canonicalize on a missing path will return the input; we expect
+    // the resulting path to NOT be a directory of files.
+    let resolved = src.sync_to_local(tmp.path(), &mut progress).await.unwrap();
+    // The path is returned, but it doesn't lead to a real dir.
+    assert!(!resolved.exists() || !resolved.is_dir());
+}

--- a/tests/sources_integration_tests.rs
+++ b/tests/sources_integration_tests.rs
@@ -7,9 +7,7 @@
 
 use leankg::sources::git::GitSource;
 use leankg::sources::local::LocalSource;
-use leankg::sources::{
-    parse_source_uri, ProgressReporter, Source, SourceFactory, SourceUri,
-};
+use leankg::sources::{parse_source_uri, ProgressReporter, Source, SourceFactory, SourceUri};
 use std::path::Path;
 use std::process::Command;
 use tempfile::TempDir;
@@ -68,10 +66,7 @@ async fn local_source_resolves_existing_path() {
 
     assert!(resolved.is_dir());
     assert!(resolved.join("hello.go").exists());
-    assert!(progress
-        .messages
-        .iter()
-        .any(|m| m.contains("local source")));
+    assert!(progress.messages.iter().any(|m| m.contains("local source")));
     assert_eq!(src.name(), "local");
 }
 
@@ -120,7 +115,10 @@ async fn git_source_clones_local_repo_into_staging() {
     assert!(
         synced.join("main.go").exists(),
         "expected main.go in synced dir, got: {:?}",
-        std::fs::read_dir(&synced).unwrap().flatten().collect::<Vec<_>>()
+        std::fs::read_dir(&synced)
+            .unwrap()
+            .flatten()
+            .collect::<Vec<_>>()
     );
     assert!(
         synced.join(".git").exists(),


### PR DESCRIPTION
## Summary

Add a `Source` trait that syncs remote content to a local staging directory before running the existing indexing pipeline. This keeps the indexer code (file walking, parsing, DB writes) untouched — the only change is what path gets fed to `find_files_sync()`.

## Motivation

LeanKG's indexing pipeline reads files exclusively from the local filesystem. There is no way today to index code that lives in a GCS bucket, a private git repo, an S3 archive, an SFTP server, or a shared Google Drive. This PR adds a pluggable source layer that handles the most common cases first (GCS + git), with the architecture in place to add the rest.

## What ships (Phases 1-4)

| Component | File | Notes |
|-----------|------|-------|
| `Source` trait | `src/sources/mod.rs` | `async fn sync_to_local(&self, staging_root, progress) -> PathBuf` |
| `SourceUri` parser | `src/sources/mod.rs` | Parses `gs://`, `s3://`, `git+https://`, `git+ssh://`, `sftp://`, `gdrive://`, plus local paths |
| `SourceFactory` | `src/sources/mod.rs` | Dispatches URI to concrete source; unimplemented schemes return a clear error |
| `LocalSource` | `src/sources/local.rs` | Passthrough — canonicalize and return |
| `GcsSource` | `src/sources/gcs.rs` | List + download via existing `reqwest` dep. Auth via `GCS_ACCESS_TOKEN` env or `--auth` |
| `GitSource` | `src/sources/git.rs` | Shells out to `git clone --depth 1 --branch <ref>`, falls back to full clone + checkout. HTTPS token injection via `--auth` |
| CLI flags | `src/cli/mod.rs` | `--source`, `--ref-name`, `--auth` on the `Index` command |
| Config | `src/config/project.rs` | New optional `source:` block in `leankg.yaml` (CLI flags take precedence) |
| Pipeline | `src/main.rs` | Both `index_codebase` and `incremental_index_codebase` resolve source before indexing |

## Deferred (Phases 5-7)

`S3Source`, `SftpSource`, `GoogleDriveSource` are intentionally stubbed: the `SourceFactory` returns an `UnsupportedScheme` error explaining the missing dep (`aws-sigv4`, `ssh2`, OAuth). Each stub has a `ponytail:` comment naming the upgrade path. This keeps the default binary slim — no new deps unless those sources are actually needed.

## Usage

```bash
# Local git repo (HTTPS)
leankg index --source "git+https://github.com/user/repo.git" --ref-name main

# Private git repo via token
leankg index --source "git+https://github.com/user/private.git" --auth ghp_xxxx

# GCS bucket
GCS_ACCESS_TOKEN=$(gcloud auth print-access-token) \
  leankg index --source "gs://my-bucket/code-prefix"

# Local path (passthrough)
leankg index --source ./my-code
```

`leankg.yaml` form:
```yaml
source:
  uri: "gs://my-bucket/code"
  auth: "${GCS_ACCESS_TOKEN}"
  ref_name: main
```

## Tests

- **15 sources unit tests** (URI parsing, factory dispatch, factory rejection of unimplemented schemes, staging dir sanitization)
- **10 sources integration tests** (real `git clone` from a local `file://` repo, re-pull, staged tree passes through `find_files_sync`, GCS auth-via-env)
- **3 new CLI tests** (`--source` / `--ref-name` / `--auth` flag combinations)
- **Regression**: existing `config::project` tests and 212 `indexer::` tests still pass

## Live tests (real binary, real data)

- Full index from local git repo → cloned, 3 files indexed, 13 elements + 12 relationships
- Incremental re-sync + index → "No changes detected" on clean tree
- Edit + commit + incremental → change detection works
- Local path via `--source` → 2 files, 8 elements
- `--source "s3://..."` → clean error: `unsupported source URI scheme: s3 requires aws-sigv4 dependency (Phase 5)`

## Out of scope / known limitations

- **Large repos**: GCS sync downloads everything. For very large buckets, add a `.leankgignore`-like exclusion list before this scales.
- **Auth via CLI**: `--auth` appears in process listings. Prefer env vars (`GCS_ACCESS_TOKEN`) — the docstring on `--auth` says so.
- **Incremental + non-git remote**: For GCS, every `incremental` run re-downloads all objects. Add a freshness check (etag, listing timestamp) when the second-best UX beats the simplicity.
- **Service-account JSON for GCS**: Today the GCS source takes a pre-fetched OAuth access token. JWT signing from a service account JSON would need `rsa` + `pkcs8` deps — deferred. Documented in the `GcsSource` doc comment as a `ponytail:` note.

## Files changed

```
src/cli/mod.rs                  (modified: +3 args on Index)
src/config/project.rs           (modified: +SourceConfig + default)
src/lib.rs                      (modified: +pub mod sources)
src/main.rs                     (modified: source resolution + 3 new params on both index fns)
src/sources/mod.rs              (new: ~430 lines)
src/sources/local.rs            (new: ~33 lines)
src/sources/gcs.rs              (new: ~240 lines)
src/sources/git.rs              (new: ~165 lines)
tests/cli_tests.rs              (modified: +3 tests)
tests/sources_integration_tests.rs (new: ~360 lines)
```

Total: 10 files, +1401 / -4

Made with [Cursor](https://cursor.com)