### PR TITLE
feat: Docker reload without image rebuild

### DIFF
--- a/.dockerfile.example
+++ b/.dockerfile.example
@@ -17,6 +17,22 @@
 # All variables below are optional. When unset, `entrypoint.sh` falls back to:
 #   LEANKG_MCP_PROJECT   -> /workspace
 #   LEANKG_PROJECT_DIRS  -> /workspace* glob (auto-discovery)
+#
+# === Image selection ===
+# Hub image tag to pull. Default: freepeak/leankg:latest
+# Override to pin a specific version (e.g., 0.19.6) or use a local build.
+# LEANKG_IMAGE=freepeak/leankg:latest
+#
+# Pull policy for Compose: always | missing | never | build
+# Default: missing (pull if not present locally). Use 'always' for CI freshness.
+# LEANKG_PULL_POLICY=missing
+#
+# To build a new image instead of pulling, use the optional build compose file:
+#   docker compose -f docker-compose.build.yml build
+#   docker compose -f docker-compose.build.yml push  # after build
+# Do NOT pass --build to the main compose up; it triggers local builds.
+#
+# === Project paths ===
 
 # Absolute path to the LeanKG source tree on the host. Used as the primary
 # project mount and the container's working directory.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -235,8 +235,8 @@ Hub: https://hub.docker.com/r/freepeak/leankg (`linux/arm64` tags `:latest` / `:
 ### Single-project (build from source)
 
 ```bash
-# Start with RocksDB in Docker
-docker compose -f docker-compose.rocksdb.yml --env-file .dockerfile up --build
+# Start from Hub image (no local build)
+docker compose -f docker-compose.rocksdb.yml --env-file .dockerfile up -d
 
 # Stop
 docker compose -f docker-compose.rocksdb.yml down
@@ -252,6 +252,30 @@ Environment variables for RocksDB (defaults are built into compose):
 - `LEANKG_SERVE_PORT=8080` -- REST listen port inside the container
 
 The MCP server selects its project via `LEANKG_MCP_PROJECT`; the entrypoint scans and auto-indexes any directory listed in `LEANKG_PROJECT_DIRS` (comma-separated, e.g. `/workspace,/workspace-other`).
+
+### Reload without rebuild (primary path)
+
+The base compose file (`docker-compose.rocksdb.yml`) pulls a Hub image — no local Rust build. Use these scripts instead of `docker compose up --build`:
+
+| Scenario | Command |
+|----------|---------|
+| New Hub version available | `scripts/docker-reload.sh` |
+| Local source change, no Hub tag yet | `scripts/docker-sync-binary.sh` |
+
+Both keep RocksDB + model volumes; only the container runtime changes.
+
+`scripts/docker-reload.sh` — pulls `$LEANKG_IMAGE` (default `freepeak/leankg:latest`) and recreates the container with `up -d --no-build --force-recreate`. Pin a version via env:
+```bash
+LEANKG_IMAGE=freepeak/leankg:0.19.4 scripts/docker-reload.sh
+```
+
+`scripts/docker-sync-binary.sh` — builds the Linux `leankg` binary in a cached `rust:1-bookworm` builder (incremental, no image layers) and bind-mounts it over the Hub runtime image. Use when your local `Cargo.toml` version is not yet published to Hub.
+
+To publish a new Hub image (intentional build, not day-to-day):
+```bash
+docker compose -f docker-compose.build.yml build
+docker compose -f docker-compose.build.yml push
+```
 
 ### Multi-repo workspace roots (nested git)
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LeanKG Makefile
 
-.PHONY: help build test lint run clean mcp-stdio mcp-http mcp-http-auth mcp-http-watch kill docker-build docker-push docker-run
+.PHONY: help build test lint run clean mcp-stdio mcp-http mcp-http-auth mcp-http-watch kill docker-build docker-push docker-run docker-reload docker-reload-tag docker-sync-binary docker-pull
 
 DOCKER_IMAGE ?= freepeak/leankg
 DOCKER_TAG ?= $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -19,6 +19,9 @@ help:
 	@echo "  kill            Kill all leankg MCP processes"
 	@echo ""
 	@echo "Docker targets:"
+	@echo "  docker-reload    Pull latest Hub image + recreate container (no build)"
+	@echo "  docker-reload-tag Pull pinned version tag + recreate (interactive)"
+	@echo "  docker-sync-binary  Build Linux binary + bind-mount onto Hub runtime"
 	@echo "  docker-build    Build freepeak/leankg image (Dockerfile.rocksdb)"
 	@echo "  docker-push     Push freepeak/leankg:VERSION and :latest"
 	@echo "  docker-run      Run with HOST_DIR mounted at /workspace (default: \$$PWD)"
@@ -108,6 +111,20 @@ docker-run:
 		$(DOCKER_IMAGE):latest
 	@echo "LeanKG MCP listening on http://localhost:9699 (project: $(HOST_DIR))"
 	@echo "Health: curl http://localhost:9699/health"
+
+# Docker reload (no rebuild) — prefer these for version upgrades
+docker-reload:
+	./scripts/docker-reload.sh
+
+docker-reload-tag:
+	@read -p "Image tag (e.g., 0.19.4): " tag; \
+	LEANKG_IMAGE=freepeak/leankg:$$tag ./scripts/docker-reload.sh
+
+docker-sync-binary:
+	./scripts/docker-sync-binary.sh
+
+docker-pull:
+	docker pull $(DOCKER_IMAGE):latest
 
 # === Installation ===
 

--- a/docker-compose.build.yml
+++ b/docker-compose.build.yml
@@ -1,0 +1,15 @@
+# Optional compose file: build a new image from source.
+# Only use this when you intend to publish a new Hub image.
+# For day-to-day reloads, use scripts/docker-reload.sh (Hub pull).
+#
+# Usage:
+#   docker compose -f docker-compose.build.yml build
+#   docker compose -f docker-compose.build.yml push   # after build
+
+services:
+  leankg:
+    build:
+      context: .
+      dockerfile: Dockerfile.rocksdb
+    # No image: pin here — the build file is for publish workflows;
+    # the base docker-compose.rocksdb.yml already selects the Hub image.

--- a/docker-compose.override.yml.example
+++ b/docker-compose.override.yml.example
@@ -8,7 +8,7 @@
 #   docker compose \
 #     -f docker-compose.rocksdb.yml \
 #     -f docker-compose.override.yml \
-#     --env-file .dockerfile up -d
+#     --env-file .dockerfile up -d --no-build
 #
 # The `services.leankg.volumes` list below is APPENDED to the volumes in
 # docker-compose.rocksdb.yml. The named `leankg-rocksdb` volume is still
@@ -17,9 +17,15 @@
 # Important: any container path you bind-mount here MUST also appear in
 # `.dockerfile`'s `LEANKG_PROJECT_DIRS` (comma-separated) so the entrypoint
 # can find and index it on startup. See `.dockerfile.example`.
+#
+# To pin a specific image tag, uncomment the image: line below.
+# The base compose already pulls ${LEANKG_IMAGE:-freepeak/leankg:latest}
+# from Hub; no local build needed.
 
 services:
   leankg:
+    # Pin a specific version tag for reproducible reloads.
+    # image: freepeak/leankg:0.19.4
     volumes:
       # Example: serve a second repo at /workspace-other
       # (replace the host path with your actual repo location).

--- a/docker-compose.rocksdb.yml
+++ b/docker-compose.rocksdb.yml
@@ -1,8 +1,9 @@
 services:
   leankg:
-    build:
-      context: .
-      dockerfile: Dockerfile.rocksdb
+    # Pull from Docker Hub by default — no local rebuild.
+    # To publish a new image: docker compose -f docker-compose.build.yml build
+    image: ${LEANKG_IMAGE:-freepeak/leankg:latest}
+    pull_policy: ${LEANKG_PULL_POLICY:-missing}
     env_file:
       # Local-only configuration that overrides the defaults below. This file
       # is .gitignored so user-specific host paths and project locations never

--- a/scripts/docker-reload.sh
+++ b/scripts/docker-reload.sh
@@ -1,0 +1,97 @@
+#!/usr/bin/env bash
+# Reload LeanKG Docker container from Hub image — no local rebuild.
+# Pulls the configured image tag and recreates the container.
+# Keeps RocksDB / model volumes intact.
+#
+# Usage:
+#   LEANKG_IMAGE=freepeak/leankg:latest scripts/docker-reload.sh
+#   LEANKG_IMAGE=freepeak/leankg:0.19.4 scripts/docker-reload.sh
+#
+# Env overrides (also in .dockerfile / docker-compose.override.yml):
+#   LEANKG_IMAGE        Hub image tag (default: freepeak/leankg:latest)
+#   LEANKG_PULL_POLICY  Compose pull_policy (default: always — force fresh pull)
+#   MCP_HTTP_PORT       Host MCP port (default: 9699)
+#   LEANKG_SERVE_PORT   Host REST/UI port (default: 8080)
+
+set -euo pipefail
+
+IMAGE="${LEANKG_IMAGE:-freepeak/leankg:latest}"
+PULL_POLICY="${LEANKG_PULL_POLICY:-always}"
+PORT="${MCP_HTTP_PORT:-9699}"
+SERVE_PORT="${LEANKG_SERVE_PORT:-8080}"
+SERVE_HTTP="${LEANKG_SERVE_HTTP:-1}"
+NAME="leankg"
+
+echo "=== LeanKG Docker Reload (no rebuild) ==="
+echo "  image:          $IMAGE"
+echo "  pull_policy:    $PULL_POLICY"
+echo "  mcp port:       $PORT"
+if [[ "$SERVE_HTTP" == "1" || "$SERVE_HTTP" == "true" ]]; then
+  echo "  serve port:     $SERVE_PORT"
+fi
+echo ""
+
+# Compose files to merge
+COMPOSE_BASE="docker-compose.rocksdb.yml"
+COMPOSE_OVERRIDE="docker-compose.override.yml"
+ENV_FILE=".dockerfile"
+
+# Resolve full paths (script may be run from anywhere)
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+if [[ ! -f "$COMPOSE_BASE" ]]; then
+  echo "ERROR: $COMPOSE_BASE not found in $REPO_ROOT" >&2
+  exit 1
+fi
+
+# Verify Hub image exists (pull)
+echo "=== Pulling image: $IMAGE ==="
+docker pull "$IMAGE"
+
+# Build compose command
+COMPOSE_CMD=(docker compose -f "$COMPOSE_BASE")
+if [[ -f "$COMPOSE_OVERRIDE" ]]; then
+  COMPOSE_CMD+=(-f "$COMPOSE_OVERRIDE")
+fi
+if [[ -f "$ENV_FILE" ]]; then
+  COMPOSE_CMD+=(--env-file "$ENV_FILE")
+fi
+
+# Override pull_policy for this run to force a fresh pull
+COMPOSE_CMD+=(-p leankg up -d --no-build --force-recreate)
+# Note: pull_policy is set via env LEANKG_PULL_POLICY in .dockerfile / env
+# The main compose file uses ${LEANKG_PULL_POLICY:-missing}, so we pass it via env
+
+export LEANKG_IMAGE="$IMAGE"
+export LEANKG_PULL_POLICY="$PULL_POLICY"
+
+echo "=== Recreating container (no build) ==="
+"${COMPOSE_CMD[@]}"
+
+echo "=== Waiting for health on :$PORT ==="
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "healthy"
+    ok=1
+    break
+  fi
+  sleep 2
+done
+
+if [[ "$ok" -ne 1 ]]; then
+  echo "ERROR: health check failed. Logs:" >&2
+  docker logs "$NAME" 2>&1 | tail -40 >&2
+  exit 1
+fi
+
+echo ""
+echo "LeanKG MCP reloaded — no rebuild."
+echo "  Health:  curl http://127.0.0.1:${PORT}/health"
+echo "  MCP URL: http://127.0.0.1:${PORT}/mcp"
+if [[ "$SERVE_HTTP" == "1" || "$SERVE_HTTP" == "true" ]]; then
+  echo "  REST UI: http://127.0.0.1:${SERVE_PORT}/  (ui-v2 proxies /api here)"
+fi
+echo "  Stop:    docker rm -f ${NAME}"

--- a/scripts/docker-sync-binary.sh
+++ b/scripts/docker-sync-binary.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# Build LeanKG Linux binary in a cached Docker builder, then bind-mount it
+# onto a Hub runtime image and recreate the MCP container.
+# No multi-stage image rebuild — only the binary changes.
+#
+# Use when you have local unpublished source changes (e.g., bumped to a
+# version not yet on Docker Hub) and want a fast reload.
+#
+# Usage:
+#   scripts/docker-sync-binary.sh
+#
+# Env overrides:
+#   LEANKG_IMAGE        Hub runtime base (default: freepeak/leankg:latest)
+#   LEANKG_BUILDER      Build image (default: rust:1-bookworm)
+#   LEANKG_BUILD_JOBS   Parallel cargo jobs (default: 4 — safe for Docker Desktop)
+#   LEANKG_BINARY_HOST  Host-side path for the built binary (default: target/release-linux/leankg)
+#   LEANKG_SKIP_BUILD   Set to 1 to reuse existing binary at LEANKG_BINARY_HOST
+
+set -euo pipefail
+
+IMAGE="${LEANKG_IMAGE:-freepeak/leankg:latest}"
+BUILDER="${LEANKG_BUILDER:-rust:1-bookworm}"
+BUILD_JOBS="${LEANKG_BUILD_JOBS:-4}"
+BINARY_HOST="${LEANKG_BINARY_HOST:-target/release-linux/leankg}"
+SKIP_BUILD="${LEANKG_SKIP_BUILD:-0}"
+PORT="${MCP_HTTP_PORT:-9699}"
+SERVE_PORT="${LEANKG_SERVE_PORT:-8080}"
+SERVE_HTTP="${LEANKG_SERVE_HTTP:-1}"
+NAME="leankg"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== LeanKG Binary Sync (no image rebuild) ==="
+echo "  runtime image:  $IMAGE"
+echo "  binary host:    $BINARY_HOST"
+echo "  builder:        $BUILDER"
+echo ""
+
+BINARY_DIR="$(dirname "$BINARY_HOST")"
+BINARY_FILE="$(basename "$BINARY_HOST")"
+
+# ========== Step 1: Build the Linux binary ==========
+if [[ "$SKIP_BUILD" == "1" ]]; then
+  if [[ ! -f "$BINARY_HOST" ]]; then
+    echo "ERROR: LEANKG_SKIP_BUILD=1 but $BINARY_HOST not found." >&2
+    exit 1
+  fi
+  echo "=== Skipping build, reusing: $BINARY_HOST ==="
+else
+  echo "=== Building Linux binary (cargo, incremental) ==="
+  mkdir -p "$BINARY_DIR"
+
+  # One-shot builder with cached registry + incremental target.
+  # Registry volume avoids re-downloading crates; target volume keeps
+  # incremental build artifacts so only changed source files recompile.
+  docker run --rm \
+    --platform linux/arm64 \
+    -v "$REPO_ROOT:/app" \
+    -v cargo-registry:/root/.cargo/registry \
+    -v cargo-target-linux:/app/target \
+    -w /app \
+    -e CARGO_BUILD_JOBS="$BUILD_JOBS" \
+    -e CARGO_PROFILE_RELEASE_LTO=false \
+    -e CARGO_TERM_COLOR=always \
+    "$BUILDER" \
+    bash -c "
+      apt-get update -qq && apt-get install -y -qq clang libclang-dev && rm -rf /var/lib/apt/lists/* && \
+      cargo build --release --features embeddings && \
+      strip target/release/leankg
+    "
+
+  # Copy the Linux binary to the host so we can bind-mount it
+  docker run --rm \
+    --platform linux/arm64 \
+    -v cargo-target-linux:/app/target \
+    -v "$(realpath "$BINARY_DIR"):/out" \
+    --entrypoint cp \
+    "$BUILDER" \
+    /app/target/release/leankg "/out/$BINARY_FILE"
+
+  echo "  Built: $BINARY_HOST"
+fi
+
+file "$BINARY_HOST" 2>/dev/null | head -1
+
+# ========== Step 2: Recreate MCP container with binary bind ==========
+echo ""
+echo "=== Recreating MCP with bind-mounted binary ==="
+
+COMPOSE_BASE="docker-compose.rocksdb.yml"
+COMPOSE_OVERRIDE="docker-compose.override.yml"
+ENV_FILE=".dockerfile"
+
+COMPOSE_CMD=(docker compose -f "$COMPOSE_BASE")
+if [[ -f "$COMPOSE_OVERRIDE" ]]; then
+  COMPOSE_CMD+=(-f "$COMPOSE_OVERRIDE")
+fi
+if [[ -f "$ENV_FILE" ]]; then
+  COMPOSE_CMD+=(--env-file "$ENV_FILE")
+fi
+
+export LEANKG_IMAGE="$IMAGE"
+
+# Merge: use the base + override compose files, but add a temporary
+# override for the binary bind-mount. We do this by writing a one-shot
+# override fragment that Compose merges last.
+BINARY_OVERRIDE="/tmp/leankg-binary-override.yml"
+cat > "$BINARY_OVERRIDE" <<YAML
+services:
+  leankg:
+    volumes:
+      - $(realpath "$BINARY_HOST"):/usr/local/bin/leankg:ro
+YAML
+
+COMPOSE_CMD+=(-f "$BINARY_OVERRIDE")
+COMPOSE_CMD+=(-p leankg up -d --no-build --force-recreate)
+
+"${COMPOSE_CMD[@]}"
+rm -f "$BINARY_OVERRIDE"
+
+# ========== Step 3: Health check ==========
+echo ""
+echo "=== Waiting for health on :$PORT ==="
+ok=0
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:${PORT}/health" >/dev/null 2>&1; then
+    echo "healthy"
+    ok=1
+    break
+  fi
+  sleep 2
+done
+
+if [[ "$ok" -ne 1 ]]; then
+  echo "ERROR: health check failed. Logs:" >&2
+  docker logs "$NAME" 2>&1 | tail -40 >&2
+  exit 1
+fi
+
+echo ""
+echo "LeanKG MCP running with bind-mounted local binary."
+echo "  binary:   $(realpath "$BINARY_HOST") → /usr/local/bin/leankg:ro"
+echo "  Health:   curl http://127.0.0.1:${PORT}/health"
+echo "  MCP URL:  http://127.0.0.1:${PORT}/mcp"
+if [[ "$SERVE_HTTP" == "1" || "$SERVE_HTTP" == "true" ]]; then
+  echo "  REST UI:  http://127.0.0.1:${SERVE_PORT}/  (ui-v2 proxies /api here)"
+fi
+echo "  Stop:     docker compose -f $COMPOSE_BASE down"
+echo ""
+echo "To revert to the baked Hub binary (after publishing the new tag):"
+echo "  LEANKG_IMAGE=freepeak/leankg:latest scripts/docker-reload.sh"


### PR DESCRIPTION
## Summary
Make compose image-first (Hub pull + recreate) and add helper scripts so users don't rebuild the Docker image on every version bump.

## Changes
- **docker-compose.rocksdb.yml**: Switch to `image:` + `pull_policy:`; move `build:` to optional `docker-compose.build.yml`
- **docker-compose.build.yml** (new): Optional compose file for intentional image publishes
- **scripts/docker-reload.sh** (new): Pull Hub tag + recreate container (`--no-build --force-recreate`), health-check
- **scripts/docker-sync-binary.sh** (new): Build Linux binary in cached `rust:1-bookworm` builder, bind-mount onto Hub runtime image
- **AGENTS.md**: Replace build-from-source section with reload workflow; add publish instructions
- **.dockerfile.example**: Document `LEANKG_IMAGE` / `LEANKG_PULL_POLICY`
- **docker-compose.override.yml.example**: Show pinning image tag via `image:`
- **Makefile**: Add `docker-reload` target; keep `docker-build` for Hub publish only

## Usage
```bash
# Default: pull latest and reload
./scripts/docker-reload.sh

# Pin specific version
LEANKG_IMAGE=freepeak/leankg:0.19.4 ./scripts/docker-reload.sh

# Local unpublished changes (builds only the binary)
./scripts/docker-sync-binary.sh

# Makefile targets
make docker-reload
make docker-build    # for Hub publish only
```

RocksDB and model volumes persist; only container process/image changes.

Made with [Cursor](https://cursor.com)