### PR TITLE
ci: skip duplicate Actions on release-please merges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,13 @@ name: CI
 on:
   push:
     branches: [main]
+    # Release Please merges only bump version metadata; the release PR
+    # already ran CI. Skipping avoids a duplicate ~5m suite on every release.
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'manifest.json'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     branches: [main]
 
@@ -83,4 +90,3 @@ jobs:
       - name: Install and build ui-v2
         working-directory: ui-v2
         run: npm ci && npm run build
-

--- a/.github/workflows/leankg-update.yml
+++ b/.github/workflows/leankg-update.yml
@@ -3,6 +3,11 @@ name: Update LeanKG on Release
 on:
   push:
     branches: [main]
+    # Indexes ./src only — skip version-only / docs / CI pushes.
+    # release:published rarely fires here (GITHUB_TOKEN-created releases
+    # do not re-trigger workflows); keep it for manually published releases.
+    paths:
+      - 'src/**'
   release:
     types: [published]
 


### PR DESCRIPTION
## Summary

Cuts duplicate GitHub Actions when a Release Please PR lands on `main` (today: same 3 workflows as the feature merge).

### Current (main push)

| Workflow | Trigger | Typical time |
|----------|---------|--------------|
| **CI** | every `push` to main | ~5m |
| **Release Please** | every `push` to main | ~20s |
| **Update LeanKG on Release** | every `push` to main | ~11–16m |

Feature merge → 3 runs. Release merge (`chore(main): release X`, only `CHANGELOG.md` / `Cargo.toml` / `Cargo.lock` / `manifest.json`) → same 3 again.

### Changes

1. **CI** — `paths-ignore` those four version files on `push` to main. Release PR already ran CI; merge does not need a second suite. `pull_request` unchanged.
2. **Update LeanKG on Release** — `paths: [src/**]` on push. Workflow indexes `./src` only; version-only / docs / CI commits skip the ~16m build+index. Kept `release: published` for manual releases (`GITHUB_TOKEN`-created releases do not re-trigger workflows).
3. **Release Please** — unchanged (still opens/updates release PRs; tag + `release.yml` dispatch still works).

### Before / after (feature → release cycle)

| | Feature merge | Release merge | Total |
|--|---------------|---------------|-------|
| Before | 3 | 3 | **6** |
| After | 3 | **1** (Release Please only) | **4** |

Also skips Update LeanKG on docs/CI-only main pushes (~16m saved each time).

### Tradeoffs

- A force-push / direct commit to main that only touches `Cargo.toml`/`Cargo.lock` (no PR) would skip CI on that push. Normal PR flow still runs CI.
- Graph update no longer runs on every main push—only when `src/**` changes (or a manually published release). That matches what it indexes.

## Test plan

- [ ] Merge this PR → CI + Release Please run; Update LeanKG should **not** (no `src/**` change)
- [ ] Next feature PR with `src/` changes → all three still run
- [ ] Next release PR merge → only Release Please; tag + `release.yml` dispatch still succeeds; CI and Update LeanKG skipped