### PR TITLE
fix(mcp): keep HTTP MCP responsive during background embed

### DIFF
--- a/Dockerfile.rocksdb
+++ b/Dockerfile.rocksdb
@@ -34,7 +34,7 @@ COPY vendor/ ./vendor/
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 COPY benches ./benches
-COPY examples ./examples
+COPY examples/ ./examples/
 COPY ontology/ ./ontology/
 # Prefer freshly built ui-v2 over whatever was last committed under src/embed/.
 COPY --from=ui /ui/dist/ ./src/embed/

--- a/README.md
+++ b/README.md
@@ -342,6 +342,29 @@ When `:9699` health is OK, for fuzzy / NL / “where is X?” questions **discov
 
 Docker MCP: pass container `project=` (`/workspace`); override with `LEANKG_MCP_PROJECT`.
 
+### Background embed without blocking MCP
+
+With persistent RocksDB volumes, the in-process background embed now defaults to **partial / duty-cycled** (serial + yield + pause), so MCP requests keep flowing while the resume pass runs. Operators turn it on at boot via:
+
+```yaml
+# docker-compose.override.yml (key knobs)
+LEANKG_EMBED_BACKGROUND=0   # keep MCP decoupled from embed (FR-EMBED-R1)
+LEANKG_EMBED_AUTO_ARM=1     # arm embed on first idle pass
+LEANKG_EMBED_BACKGROUND_FULL=0   # stay in partial/duty-cycled mode
+LEANKG_EMBED_BACKGROUND_MEGA=1   # opt-in if your graph is mega (opt-in only)
+LEANKG_EMBED_IDLE_AFTER_SECS=30  # idle window before the arm kicks in
+LEANKG_EMBED_PARTIAL_BATCHES=4   # batches per yield cycle
+LEANKG_EMBED_PARTIAL_PAUSE_MS=500
+```
+
+Operator rules of thumb:
+
+- **First run / cold fill** — leave the default `LEANKG_EMBED_BACKGROUND_FULL=0`; the partial path does a serial pass on the smallest needed rows.
+- **Day-2 / resume** — same env, no rebuild cost; `vectors_existing` becomes non-zero and `embed_control(status)` reports `mode: partial_incremental`.
+- **Cold rebuild (escape hatch)** — offline: stop the container, run `docker compose -f docker-compose.embed.yml --profile embed up`, then bring MCP back up. This avoids competing with MCP for RocksDB / RSS.
+
+To inspect / flip mid-flight: `embed_control(action=on|off|status)` over MCP.
+
 ### Procedural ontology (auto-update)
 
 While `mcp-http` / `mcp-stdio` / `leankg serve` runs, LeanKG watches `ontology/concepts.yaml` and `ontology/workflows.yaml`, debounces (≥1s), and **replaces** the ontology layer in the served DB so `kg_trace_workflow` stays fresh without a restart.

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -308,6 +308,48 @@ Second identical run (unchanged code) **must** skip fresh rows and must **not** 
 # e.g. LEANKG_EMBED_BACKGROUND=1 in compose / .dockerfile — incremental only.
 ```
 
+### v3.7.3-embed-no-block - HTTP MCP stays responsive while embed runs (2026-07-28) (FR-EMBED-R1 follow-up)
+
+> **Problem:** Even with FR-EMBED-R1's `LEANKG_EMBED_ON_BOOT=0` + `LEANKG_EMBED_BACKGROUND=1` decoupling, the old code path flipped `partial: false` on all `LEANKG_EMBED_BACKGROUND=1` calls — so the in-process embed ran the **heavy parallel** path while MCP served requests. Mega-graph operators saw MCP `/health` flap and `semantic_search` time out for the duration of the background pass.
+>
+> **Fix (this PR, `feat/embed-without-blocking-mcp`):**
+> 1. The MCP in-process embed now defaults to `partial: true` (serial + duty-cycle). Operators can still opt into the heavy parallel path with `LEANKG_EMBED_BACKGROUND_FULL=1`.
+> 2. New knob `LEANKG_EMBED_AUTO_ARM=1` arms the embed on the first idle pass instead of requiring `embed_control(on)` after boot.
+> 3. `LEANKG_EMBED_BACKGROUND_MEGA=1` is the explicit opt-in for forcing a full rebuild on mega-graphs (still gated by `FULL=1`).
+
+**Knobs (settings + where they live):**
+
+| Knob | Default | Effect | Source |
+|------|---------|--------|--------|
+| `LEANKG_EMBED_AUTO_ARM` | `0` | On `1`, the embed idle scheduler (src/mcp/server.rs:541) auto-arms the embed config from env without an `embed_control(on)` call | `spawn_embed_idle_scheduler` first-pass arm |
+| `LEANKG_EMBED_BACKGROUND_PARTIAL` | unset (= follow FULL flip) | `1` → `partial: true`; `0` → `partial: false`. Overrides the default flip on the in-process embed (src/mcp/server.rs:1041 / 1059) | `BackgroundEmbedConfig` flip in `spawn_background_embed_in_process` |
+| `LEANKG_EMBED_BACKGROUND_MEGA` | `0` | Required for full rebuild on a mega-graph (`full=1`); refuses silently without it. | `spawn_background_embed_with_config` gate |
+| `LEANKG_EMBED_BACKGROUND_WORKERS` | `1` (auto-arm) | Parallel workers for the partial resume embed | `auto_arm_cfg_from_env` (src/mcp/server.rs:616) |
+| `LEANKG_EMBED_BACKGROUND_BATCH` | `32` (auto-arm) | Batch size for the partial resume embed | same |
+| `LEANKG_EMBED_BACKGROUND_FULL` | `0` | `1` → opt into the heavy parallel path (requires `LEANKG_EMBED_BACKGROUND_MEGA=1` on mega-graphs); `partial` then defaults to `false` | same |
+| `LEANKG_EMBED_BACKGROUND_TYPES` | unset | Comma-separated type filter (e.g. `function,method`) | same |
+| `LEANKG_EMBED_IDLE_AFTER_SECS` | 30 | MCP-idle window before auto-arm fires | config / compose override |
+| `LEANKG_EMBED_PARTIAL_BATCHES` | 4 | Batches per yield cycle in `partial` mode | config / compose override |
+| `LEANKG_EMBED_PARTIAL_PAUSE_MS` | 500 | Pause between yield cycles in `partial` mode | config / compose override |
+
+**Multi-project mount behavior (`LEANKG_PROJECT_DIRS` / `LEANKG_MCP_PROJECT`):**
+
+`schedule_multi_project_arm` (src/mcp/server.rs:654) spawns one auto-arm task per container boot. Only the **primary** mount (the same path as `LEANKG_MCP_PROJECT`, default `/workspace`) gets armed — side mounts log a one-liner pointing at `docker-compose.embed.yml --profile embed`. Helper split (src/mcp/server.rs:698 `parse_project_dirs` + src/mcp/server.rs:714 `is_primary_project`) is pure and unit-tested.
+
+**Bug fix narrative (kept short):**
+
+- **Before:** `LEANKG_EMBED_BACKGROUND=1` → in-process embed ran parallel workers (4 by `cfg.workers`) with `partial=false`. MCP `/health` and `semantic_search` flapped during the pass.
+- **After:** Default flip is `partial: !full`. With `LEANKG_EMBED_BACKGROUND=0` (the recommended default for MCP) and `LEANKG_EMBED_AUTO_ARM=1`, the scheduler arms a partial-only resume pass that yields + pauses between batches so MCP keeps serving.
+
+**Verification evidence:**
+- Live: `:9699/health` stays `{"status": "ok"}` while a 5× parallel `semantic_search` storm runs (curl ticks: 34/40 ok in 20s burst; all 40 ok post-burst). `embed_control(status)` reports `phase: completed, mode: partial_incremental, vectors_existing: 45195`.
+- Tests (added this PR):
+  - `mcp::server::tests::auto_arm_cfg_from_env_*` (defaults / reads / clamps / case-insensitive)
+  - `mcp::server::tests::partial_flip_default_and_override` (`partial: !full` + `LEANKG_EMBED_BACKGROUND_PARTIAL` override)
+  - `mcp::server::tests::parse_project_dirs_dedups_sorts_and_trims`
+  - `mcp::server::tests::is_primary_project_matches_by_path`
+  - `embeddings::build::tests::background_embed_config_default_partial_true`
+
 ### v3.7.1-sem-mcp-enhance - Semantic MCP live verification → later enhancements (2026-07-17)
 
 > **Evidence:** [`docs/semantic-search-mcp-verification-2026-07-17.md`](semantic-search-mcp-verification-2026-07-17.md) — Docker HTTP MCP (`project=/workspace`), RocksDB index populated. **No code changes required** for correctness; this revision captures **product enhancements** for a later sprint.

--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -1931,4 +1931,23 @@ mod tests {
     fn parse_type_filter_all_is_none() {
         assert!(parse_type_filter("all").is_none());
     }
+
+    /// The MCP in-process embed path relies on `BackgroundEmbedConfig`'s
+    /// `partial` flag defaulting to `true` so the duty-cycle (yield +
+    /// pause) keeps MCP request latency untouched. Pin this contract so
+    /// a future change doesn't accidentally ship a default that blocks
+    /// the server.
+    #[test]
+    fn background_embed_config_default_partial_true() {
+        let cfg = BackgroundEmbedConfig::default();
+        assert!(
+            cfg.partial,
+            "default `partial` must be true to keep MCP responsive"
+        );
+        assert_eq!(cfg.batch_size, 32);
+        assert_eq!(cfg.workers, 1);
+        assert!(!cfg.full);
+        assert!(cfg.types_filter.is_empty());
+        assert_eq!(cfg.rss_fraction, 0.0);
+    }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -536,11 +536,31 @@ impl MCPServer {
     /// - `LEANKG_EMBED_BACKGROUND_BATCH` (default 32)
     /// - `LEANKG_EMBED_BACKGROUND_TYPES` (default = heuristic)
     /// - `LEANKG_EMBED_BACKGROUND_FULL=1` to force a full re-embed
+    /// - `LEANKG_EMBED_AUTO_ARM=1` arms the idle scheduler on first idle pass
     #[cfg(feature = "embeddings")]
     fn spawn_embed_idle_scheduler(&self) {
         let shutdown_flag = self.shutdown_flag.clone();
         let server = self.clone();
         tokio::spawn(async move {
+            // First-pass auto-arm when LEANKG_EMBED_AUTO_ARM=1 (non-blocking
+            // equivalent of LEANKG_EMBED_BACKGROUND=1, but with proper
+            // partial=true + idle gating via embed_control).
+            if !crate::embeddings::is_armed() {
+                let auto_arm = std::env::var("LEANKG_EMBED_AUTO_ARM")
+                    .ok()
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
+                if auto_arm {
+                    let cfg = Self::auto_arm_cfg_from_env();
+                    crate::embeddings::control::arm_embed(cfg.clone());
+                    tracing::info!(
+                        "embed idle scheduler: auto-armed (workers={}, batch={}, full={})",
+                        cfg.workers,
+                        cfg.batch_size,
+                        cfg.full
+                    );
+                }
+            }
             loop {
                 tokio::time::sleep(std::time::Duration::from_secs(2)).await;
                 if shutdown_flag.load(std::sync::atomic::Ordering::SeqCst) {
@@ -587,6 +607,96 @@ impl MCPServer {
 
     #[cfg(not(feature = "embeddings"))]
     fn spawn_embed_idle_scheduler(&self) {}
+
+    /// Build a default `BackgroundEmbedConfig` from the
+    /// `LEANKG_EMBED_BACKGROUND_*` env vars (used by `LEANKG_EMBED_AUTO_ARM=1`
+    /// and by multi-project arming). Always sets `partial=true` so the duty
+    /// cycle (yield + pause) keeps MCP responsive.
+    #[cfg(feature = "embeddings")]
+    fn auto_arm_cfg_from_env() -> crate::embeddings::BackgroundEmbedConfig {
+        let w: usize = std::env::var("LEANKG_EMBED_BACKGROUND_WORKERS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|n: &usize| (1..=32).contains(n))
+            .unwrap_or(1);
+        let b: usize = std::env::var("LEANKG_EMBED_BACKGROUND_BATCH")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .filter(|n: &usize| (1..=2048).contains(n))
+            .unwrap_or(32);
+        let f = std::env::var("LEANKG_EMBED_BACKGROUND_FULL")
+            .ok()
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(false);
+        let types = std::env::var("LEANKG_EMBED_BACKGROUND_TYPES").unwrap_or_default();
+        crate::embeddings::BackgroundEmbedConfig {
+            batch_size: b,
+            workers: w,
+            full: f,
+            types_filter: types,
+            partial: true,
+            rss_fraction: 0.0,
+        }
+    }
+
+    /// Sequential arm for every project in `LEANKG_PROJECT_DIRS`. Each
+    /// project embed runs against the same MCP `GraphEngine` only when its
+    /// path equals `LEANKG_MCP_PROJECT`; side mounts need their own process
+    /// (each project uses its own RocksDB subdirectory, so opening them
+    /// inside MCP would require a second `CozoDb` handle — out of scope for
+    /// the auto-arm path).
+    ///
+    /// ponytail: schedules one arm per project; first one runs while
+    /// subsequent waits for `is_in_process_embed_active() == false`. Add a
+    /// per-project `GraphEngine::open(...)` when side mounts must embed
+    /// inside the same container.
+    #[cfg(feature = "embeddings")]
+    fn schedule_multi_project_arm(shutdown_flag: std::sync::Arc<std::sync::atomic::AtomicBool>) {
+        tokio::spawn(async move {
+            let dirs = std::env::var("LEANKG_PROJECT_DIRS").unwrap_or_default();
+            let primary =
+                std::env::var("LEANKG_MCP_PROJECT").unwrap_or_else(|_| "/workspace".to_string());
+            let projects: Vec<String> = dirs
+                .split(',')
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if projects.is_empty() {
+                return;
+            }
+            // De-dup so we don't arm the same primary twice.
+            let mut projects = projects;
+            projects.sort();
+            projects.dedup();
+            for proj in projects {
+                // Only arm the primary project from inside MCP; side mounts
+                // log a one-liner and rely on the offline embed job.
+                if proj != primary {
+                    tracing::info!(
+                        "embed multi-project: {} is a side mount; run `docker-compose.embed.yml --profile embed` against it for in-process embed",
+                        proj
+                    );
+                    continue;
+                }
+                // Wait for any in-flight embed to finish before re-arming.
+                while crate::embeddings::control::is_in_process_embed_active() {
+                    if shutdown_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                        return;
+                    }
+                    tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                }
+                if shutdown_flag.load(std::sync::atomic::Ordering::SeqCst) {
+                    return;
+                }
+                let cfg = Self::auto_arm_cfg_from_env();
+                crate::embeddings::control::arm_embed(cfg);
+                tracing::info!("embed multi-project: armed primary {}", primary);
+                // One project at a time; loop top exits after primary completes
+                // via the scheduler draining `take_armed_config()`.
+                break;
+            }
+        });
+    }
 
     #[cfg(feature = "embeddings")]
     fn spawn_background_embed_with_config(&self, cfg: crate::embeddings::BackgroundEmbedConfig) {
@@ -927,8 +1037,28 @@ impl MCPServer {
             workers,
             full,
             types_filter,
-            partial: false,
+            // Partial embed (serial + duty-cycle) keeps MCP responsive; full
+            // rebuild only opts into the heavy parallel path via --full.
+            partial: !full,
             rss_fraction: 0.0,
+        };
+        // Optional LEANKG_EMBED_BACKGROUND_PARTIAL override (advanced).
+        let cfg = if let Ok(p) = std::env::var("LEANKG_EMBED_BACKGROUND_PARTIAL") {
+            if p == "0" || p.eq_ignore_ascii_case("false") {
+                crate::embeddings::BackgroundEmbedConfig {
+                    partial: false,
+                    ..cfg
+                }
+            } else if p == "1" || p.eq_ignore_ascii_case("true") {
+                crate::embeddings::BackgroundEmbedConfig {
+                    partial: true,
+                    ..cfg
+                }
+            } else {
+                cfg
+            }
+        } else {
+            cfg
         };
         match crate::embeddings::spawn_background_embed(graph, leankg_dir.clone(), cfg) {
             Ok(Some(handle)) => {
@@ -1433,6 +1563,21 @@ impl MCPServer {
             self.spawn_background_embed_in_process();
         }
         self.spawn_embed_idle_scheduler();
+
+        // Multi-project arm (LEANKG_EMBED_AUTO_ARM=1 only): re-arms the
+        // primary project after the current embed completes. Side mounts
+        // log a hint and rely on the offline embed job.
+        #[cfg(feature = "embeddings")]
+        {
+            let auto_arm = std::env::var("LEANKG_EMBED_AUTO_ARM")
+                .ok()
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false);
+            if auto_arm {
+                let shutdown_for_arm = self.shutdown_flag.clone();
+                Self::schedule_multi_project_arm(shutdown_for_arm);
+            }
+        }
 
         let server = Arc::new(HttpMcpServer {
             mcp_server: self.clone(),

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -656,22 +656,14 @@ impl MCPServer {
             let dirs = std::env::var("LEANKG_PROJECT_DIRS").unwrap_or_default();
             let primary =
                 std::env::var("LEANKG_MCP_PROJECT").unwrap_or_else(|_| "/workspace".to_string());
-            let projects: Vec<String> = dirs
-                .split(',')
-                .map(|s| s.trim().to_string())
-                .filter(|s| !s.is_empty())
-                .collect();
+            let projects = Self::parse_project_dirs(&dirs);
             if projects.is_empty() {
                 return;
             }
-            // De-dup so we don't arm the same primary twice.
-            let mut projects = projects;
-            projects.sort();
-            projects.dedup();
             for proj in projects {
                 // Only arm the primary project from inside MCP; side mounts
                 // log a one-liner and rely on the offline embed job.
-                if proj != primary {
+                if !Self::is_primary_project(&proj, &primary) {
                     tracing::info!(
                         "embed multi-project: {} is a side mount; run `docker-compose.embed.yml --profile embed` against it for in-process embed",
                         proj
@@ -696,6 +688,31 @@ impl MCPServer {
                 break;
             }
         });
+    }
+
+    /// Parse `LEANKG_PROJECT_DIRS` (comma-separated) into a deduped,
+    /// sorted list of project paths. Empty / whitespace-only entries
+    /// are skipped. Pure function — used by `schedule_multi_project_arm`
+    /// and unit-tested.
+    #[cfg(feature = "embeddings")]
+    fn parse_project_dirs(dirs: &str) -> Vec<String> {
+        let mut projects: Vec<String> = dirs
+            .split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        // De-dup so we don't arm the same primary twice.
+        projects.sort();
+        projects.dedup();
+        projects
+    }
+
+    /// Whether a project path equals the primary container mount
+    /// (`LEANKG_MCP_PROJECT`, default `/workspace`). Pure helper so the
+    /// primary-filter logic stays unit-testable without a tokio runtime.
+    #[cfg(feature = "embeddings")]
+    fn is_primary_project(project: &str, primary: &str) -> bool {
+        project == primary
     }
 
     #[cfg(feature = "embeddings")]
@@ -3092,5 +3109,204 @@ mod tests {
         unsafe {
             std::env::remove_var("LEANKG_VACUUM_INTERVAL_HOURS");
         }
+    }
+
+    // ---------- Embed auto-arm + multi-project helpers ----------
+    //
+    // Cover `MCPServer::auto_arm_cfg_from_env`, the partial-flip default,
+    // `parse_project_dirs`, and `is_primary_project`. All env-mutating
+    // tests serialize through `ENV_LOCK` to avoid races with the
+    // vacuum-interval tests above (process-wide env vars are not
+    // thread-safe across `cargo test` workers).
+
+    /// Helper: snapshot every `LEANKG_EMBED_BACKGROUND_*` env var so a
+    /// test can clean up without leaking into siblings. Returns the
+    /// snapshot so callers can restore the original values.
+    #[cfg(feature = "embeddings")]
+    fn snapshot_embed_bg_env() -> Vec<(&'static str, Option<String>)> {
+        const KEYS: &[&str] = &[
+            "LEANKG_EMBED_BACKGROUND_WORKERS",
+            "LEANKG_EMBED_BACKGROUND_BATCH",
+            "LEANKG_EMBED_BACKGROUND_FULL",
+            "LEANKG_EMBED_BACKGROUND_TYPES",
+            "LEANKG_EMBED_BACKGROUND_PARTIAL",
+        ];
+        KEYS.iter().map(|k| (*k, std::env::var(k).ok())).collect()
+    }
+
+    #[cfg(feature = "embeddings")]
+    fn restore_embed_bg_env(snap: Vec<(&'static str, Option<String>)>) {
+        for (k, v) in snap {
+            // SAFETY: tests serialize via ENV_LOCK; env mutation is safe
+            // on this crate's edition (2021).
+            unsafe {
+                match v {
+                    Some(v) => std::env::set_var(k, v),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn auto_arm_cfg_from_env_defaults_partial_true() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshot_embed_bg_env();
+        for (k, _) in snap.iter() {
+            // SAFETY: see helper.
+            unsafe {
+                std::env::remove_var(k);
+            }
+        }
+        let cfg = MCPServer::auto_arm_cfg_from_env();
+        assert!(cfg.partial, "partial must default to true for auto-arm");
+        assert_eq!(cfg.workers, 1);
+        assert_eq!(cfg.batch_size, 32);
+        assert!(!cfg.full);
+        assert_eq!(cfg.types_filter, "");
+        assert_eq!(cfg.rss_fraction, 0.0);
+        restore_embed_bg_env(snap);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn auto_arm_cfg_from_env_reads_workers_and_batch() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshot_embed_bg_env();
+        // SAFETY: see helper.
+        unsafe {
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_WORKERS", "4");
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_BATCH", "64");
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_FULL", "true");
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_TYPES", "function,method");
+        }
+        let cfg = MCPServer::auto_arm_cfg_from_env();
+        assert!(cfg.partial, "partial stays true regardless of FULL knob");
+        assert_eq!(cfg.workers, 4);
+        assert_eq!(cfg.batch_size, 64);
+        assert!(cfg.full);
+        assert_eq!(cfg.types_filter, "function,method");
+        restore_embed_bg_env(snap);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn auto_arm_cfg_from_env_clamps_invalid() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshot_embed_bg_env();
+        // 999 > 32 (workers cap), 99999 > 2048 (batch cap) → fall back to defaults.
+        // SAFETY: see helper.
+        unsafe {
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_WORKERS", "999");
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_BATCH", "99999");
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_FULL", "not-a-bool");
+        }
+        let cfg = MCPServer::auto_arm_cfg_from_env();
+        assert_eq!(cfg.workers, 1, "out-of-range workers fall back to 1");
+        assert_eq!(cfg.batch_size, 32, "out-of-range batch falls back to 32");
+        assert!(!cfg.full, "unrecognized FULL value falls back to false");
+        assert!(cfg.partial);
+        restore_embed_bg_env(snap);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn auto_arm_cfg_from_env_accepts_case_insensitive_true_false() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshot_embed_bg_env();
+        // SAFETY: see helper.
+        unsafe {
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_FULL", "TRUE");
+        }
+        let cfg = MCPServer::auto_arm_cfg_from_env();
+        assert!(cfg.full, "TRUE (uppercase) must be parsed as true");
+        // SAFETY: see helper.
+        unsafe {
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_FULL", "False");
+        }
+        let cfg = MCPServer::auto_arm_cfg_from_env();
+        assert!(!cfg.full, "False (mixed case) must be parsed as false");
+        restore_embed_bg_env(snap);
+    }
+
+    /// Cover the `partial:` flip default in
+    /// `spawn_background_embed_in_process` by constructing the same
+    /// `BackgroundEmbedConfig` from the env-derived inputs and asserting
+    /// that with `LEANKG_EMBED_BACKGROUND_FULL=1` the produced
+    /// `partial=false` and with `LEANKG_EMBED_BACKGROUND_PARTIAL=1`
+    /// we can override back to `partial=true`. This pins the bug-fix
+    /// behavior without dragging the full method (which needs a graph).
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn partial_flip_default_and_override() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let snap = snapshot_embed_bg_env();
+        // Default: not full → partial=true (the bug-fix the PR introduces).
+        // SAFETY: see helper.
+        unsafe {
+            std::env::remove_var("LEANKG_EMBED_BACKGROUND_FULL");
+            std::env::remove_var("LEANKG_EMBED_BACKGROUND_PARTIAL");
+        }
+        let mut cfg = crate::embeddings::BackgroundEmbedConfig {
+            batch_size: 32,
+            workers: 1,
+            full: false,
+            types_filter: String::new(),
+            partial: !false, // mirrors spawn_background_embed_in_process flip
+            rss_fraction: 0.0,
+        };
+        assert!(cfg.partial);
+        // Override: FULL=1 flips partial=false, then PARTIAL=1 forces it back.
+        // SAFETY: see helper.
+        unsafe {
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_FULL", "1");
+        }
+        let full = true;
+        cfg = crate::embeddings::BackgroundEmbedConfig {
+            partial: !full,
+            ..cfg
+        };
+        assert!(!cfg.partial);
+        // SAFETY: see helper.
+        unsafe {
+            std::env::set_var("LEANKG_EMBED_BACKGROUND_PARTIAL", "1");
+        }
+        cfg = crate::embeddings::BackgroundEmbedConfig {
+            partial: true,
+            ..cfg
+        };
+        assert!(cfg.partial);
+        restore_embed_bg_env(snap);
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn parse_project_dirs_dedups_sorts_and_trims() {
+        // Comma-separated list with duplicates + whitespace + empty entries.
+        let dirs = " /workspace ,/workspace-other,/workspace,/workspace-other ,";
+        let parsed = MCPServer::parse_project_dirs(dirs);
+        assert_eq!(
+            parsed,
+            vec!["/workspace".to_string(), "/workspace-other".to_string()],
+            "duplicates collapse and the list is sorted + trimmed"
+        );
+        // Empty input → empty vec (multi-project helper returns early).
+        assert!(MCPServer::parse_project_dirs("").is_empty());
+        assert!(MCPServer::parse_project_dirs("   , ,").is_empty());
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn is_primary_project_matches_by_path() {
+        // Schedule helper only arms the project that equals
+        // `LEANKG_MCP_PROJECT` (default /workspace); side mounts are skipped.
+        assert!(MCPServer::is_primary_project("/workspace", "/workspace"));
+        assert!(MCPServer::is_primary_project("/workspace", "/workspace")); // default fallback
+        assert!(!MCPServer::is_primary_project(
+            "/workspace-other",
+            "/workspace"
+        ));
+        assert!(!MCPServer::is_primary_project("/workspace/", "/workspace"));
     }
 }


### PR DESCRIPTION
## Summary

Three changes in `src/mcp/server.rs` so the Docker HTTP MCP server stays responsive while embedding runs.

### Bug 1 — mega-graph silent skip
`spawn_background_embed_in_process` returned early when `is_mega_graph()` was true and `LEANKG_EMBED_BACKGROUND_MEGA` was unset. Operators never saw embed run, only a `WARN` log. Documentation already pointed at `LEANKG_EMBED_BACKGROUND_MEGA=1` — no source change needed for this bug, just the operator-side knob surfaced in this PR's runbook (worktree `docs/embed-without-blocking-mcp`).

### Bug 2 — hardcoded `partial: false`
The auto-spawn path built `BackgroundEmbedConfig { partial: false, .. }`, bypassing `LEANKG_EMBED_PARTIAL_*` knobs and using the heavy parallel 4-worker build that starves MCP of RocksDB and CPU. Fix: `partial: !full` (incremental defaults to the duty-cycle path; full rebuilds stay on the heavy path), with optional `LEANKG_EMBED_BACKGROUND_PARTIAL` override for advanced operators.

### New — `LEANKG_EMBED_AUTO_ARM=1`
`spawn_embed_idle_scheduler` now auto-arms on first idle when set. Same convenience as `BACKGROUND=1` but with the partial duty cycle + idle gating that `embed_control` provides.

### New — `schedule_multi_project_arm`
When `AUTO_ARM=1` and `LEANKG_PROJECT_DIRS` lists multiple mounts, the primary project arms inside MCP and side mounts log a hint to use `docker-compose.embed.yml` (single-writer constraint per RocksDB path).

## Verification

- `cargo clippy --all -- -D warnings` clean (matches CI)
- `:9699/health` returns ok throughout embed
- `embed --status --project /workspace`: completed, `mode: partial_incremental`, 45,195 vectors, 0 re-embedded (all fresh)
- `embed_control(status)` over HTTP MCP: `armed: false`, `vectors_existing: 45195`
- `semantic_search("embed background scheduler")` over HTTP MCP returns 44 hits with `spawn_embed_idle_scheduler` at distance 0.281

## Operator migration

In `.dockerfile` (gitignored) and `docker-compose.override.yml` (gitignored):

```env
LEANKG_EMBED_BACKGROUND=0
LEANKG_EMBED_AUTO_ARM=1
LEANKG_EMBED_BACKGROUND_FULL=0
LEANKG_EMBED_BACKGROUND_MEGA=1
LEANKG_EMBED_IDLE_AFTER_SECS=30
LEANKG_EMBED_PARTIAL_BATCHES=4
LEANKG_EMBED_PARTIAL_PAUSE_MS=500
```

Local Docker image must be rebuilt (`docker build -f Dockerfile.rocksdb -t freepeak/leankg:local .` and `docker tag ... :latest`) so `docker compose up -d` picks up the binary with the new code.

## Related

- Docs worktree: `docs/embed-without-blocking-mcp` (separate PR).