### PR TITLE
fix(mcp): route embed_control 'on' to specific project

### DIFF
--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -1369,6 +1369,10 @@ pub struct BackgroundEmbedConfig {
     pub partial: bool,
     /// Soft RSS fraction of container budget (0.0 = use env default).
     pub rss_fraction: f64,
+    /// Optional non-primary project path; when set, the idle scheduler
+    /// opens the project's own GraphEngine + `.leankg` dir instead of the
+    /// primary MCP project. `None` = primary (existing behavior).
+    pub project_path: Option<String>,
 }
 
 impl Default for BackgroundEmbedConfig {
@@ -1381,6 +1385,7 @@ impl Default for BackgroundEmbedConfig {
             types_filter: String::new(),
             partial: true,
             rss_fraction: 0.0,
+            project_path: None,
         }
     }
 }
@@ -1431,6 +1436,7 @@ pub fn spawn_background_embed(
         types_filter: cfg.types_filter,
         partial: cfg.partial,
         rss_fraction: cfg.rss_fraction,
+        project_path: cfg.project_path,
     };
     if mem.max_rss_mb > 0 {
         tracing::info!(

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -636,6 +636,7 @@ impl MCPServer {
             types_filter: types,
             partial: true,
             rss_fraction: 0.0,
+            project_path: None,
         }
     }
 
@@ -717,13 +718,38 @@ impl MCPServer {
 
     #[cfg(feature = "embeddings")]
     fn spawn_background_embed_with_config(&self, cfg: crate::embeddings::BackgroundEmbedConfig) {
-        let graph = match self.get_graph_engine() {
-            Ok(g) => g,
-            Err(e) => {
-                tracing::warn!("embed_control spawn skipped; graph not ready ({})", e);
-                crate::embeddings::control::set_phase(crate::embeddings::control::PHASE_FAILED);
-                crate::embeddings::disarm_embed();
-                return;
+        // Resolve project-aware graph + .leankg dir before opening.
+        let (graph, leankg_dir, project_label) = if let Some(ref proj) = cfg.project_path {
+            match self.get_graph_engine_for_path(Some(proj)) {
+                Ok(g) => {
+                    let dir = Self::resolve_project_db_path(proj)
+                        .unwrap_or_else(|| self.get_db_path());
+                    (g, dir, proj.clone())
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        "embed_control spawn skipped; cannot open graph for {} ({})",
+                        proj,
+                        e
+                    );
+                    crate::embeddings::control::set_phase(
+                        crate::embeddings::control::PHASE_FAILED,
+                    );
+                    crate::embeddings::disarm_embed();
+                    return;
+                }
+            }
+        } else {
+            match self.get_graph_engine() {
+                Ok(g) => (g, self.get_db_path(), "<primary>".to_string()),
+                Err(e) => {
+                    tracing::warn!("embed_control spawn skipped; graph not ready ({})", e);
+                    crate::embeddings::control::set_phase(
+                        crate::embeddings::control::PHASE_FAILED,
+                    );
+                    crate::embeddings::disarm_embed();
+                    return;
+                }
             }
         };
         // Mega + full requires force (cfg.full already gated by tool).
@@ -732,14 +758,20 @@ impl MCPServer {
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
             .unwrap_or(false);
         if cfg.full && !force_mega && crate::ontology::safe_discover::is_mega_graph(&graph) {
-            tracing::warn!("embed_control: full rebuild refused on mega-graph without MEGA=1");
+            tracing::warn!(
+                "embed_control: full rebuild refused on mega-graph (project={}) without MEGA=1",
+                project_label
+            );
             crate::embeddings::control::set_phase(crate::embeddings::control::PHASE_FAILED);
             crate::embeddings::disarm_embed();
             return;
         }
-        let leankg_dir = self.get_db_path();
         match crate::embeddings::spawn_background_embed(graph, leankg_dir, cfg) {
-            Ok(Some(h)) => tracing::info!("embed_control spawned in-process embed pid={}", h.pid),
+            Ok(Some(h)) => tracing::info!(
+                "embed_control spawned in-process embed pid={} project={}",
+                h.pid,
+                project_label
+            ),
             Ok(None) => tracing::info!("embed_control: embed already running"),
             Err(e) => {
                 tracing::error!("embed_control spawn failed: {}", e);
@@ -826,9 +858,13 @@ impl MCPServer {
                     .get("force_full")
                     .and_then(|v| v.as_bool())
                     .unwrap_or(false);
-                if let Ok(graph) = self.get_graph_engine() {
-                    if full && crate::ontology::safe_discover::is_mega_graph(&graph) && !force_full
-                    {
+                let graph_for_check = if let Some(ref p) = project_path {
+                    self.get_graph_engine_for_path(Some(p))
+                } else {
+                    self.get_graph_engine()
+                };
+                if let Ok(ref g) = graph_for_check {
+                    if full && crate::ontology::safe_discover::is_mega_graph(g) && !force_full {
                         full = false;
                         tracing::warn!(
                             "embed_control on: cleared full on mega-graph (pass force_full=true to override)"
@@ -861,6 +897,7 @@ impl MCPServer {
                     types_filter,
                     partial: mode != "continuous",
                     rss_fraction,
+                    project_path: project_path.clone(),
                 };
                 crate::embeddings::control::clear_cancel();
                 crate::embeddings::arm_embed(cfg);
@@ -1058,6 +1095,7 @@ impl MCPServer {
             // rebuild only opts into the heavy parallel path via --full.
             partial: !full,
             rss_fraction: 0.0,
+            project_path: None,
         };
         // Optional LEANKG_EMBED_BACKGROUND_PARTIAL override (advanced).
         let cfg = if let Ok(p) = std::env::var("LEANKG_EMBED_BACKGROUND_PARTIAL") {
@@ -3255,6 +3293,7 @@ mod tests {
             types_filter: String::new(),
             partial: !false, // mirrors spawn_background_embed_in_process flip
             rss_fraction: 0.0,
+            project_path: None,
         };
         assert!(cfg.partial);
         // Override: FULL=1 flips partial=false, then PARTIAL=1 forces it back.

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -722,8 +722,8 @@ impl MCPServer {
         let (graph, leankg_dir, project_label) = if let Some(ref proj) = cfg.project_path {
             match self.get_graph_engine_for_path(Some(proj)) {
                 Ok(g) => {
-                    let dir = Self::resolve_project_db_path(proj)
-                        .unwrap_or_else(|| self.get_db_path());
+                    let dir =
+                        Self::resolve_project_db_path(proj).unwrap_or_else(|| self.get_db_path());
                     (g, dir, proj.clone())
                 }
                 Err(e) => {
@@ -732,9 +732,7 @@ impl MCPServer {
                         proj,
                         e
                     );
-                    crate::embeddings::control::set_phase(
-                        crate::embeddings::control::PHASE_FAILED,
-                    );
+                    crate::embeddings::control::set_phase(crate::embeddings::control::PHASE_FAILED);
                     crate::embeddings::disarm_embed();
                     return;
                 }
@@ -744,9 +742,7 @@ impl MCPServer {
                 Ok(g) => (g, self.get_db_path(), "<primary>".to_string()),
                 Err(e) => {
                     tracing::warn!("embed_control spawn skipped; graph not ready ({})", e);
-                    crate::embeddings::control::set_phase(
-                        crate::embeddings::control::PHASE_FAILED,
-                    );
+                    crate::embeddings::control::set_phase(crate::embeddings::control::PHASE_FAILED);
                     crate::embeddings::disarm_embed();
                     return;
                 }


### PR DESCRIPTION
## Problem

`embed_control { action: "on", project: "/workspace-other" }` accepted a
`project` parameter but ignored it on the `"on"` action. The idle
scheduler always opened the primary project's `GraphEngine` + `.leankg`
dir, so embedding ran against the wrong workspace.

## Fix

Thread an optional `project_path: Option<String>` through
`BackgroundEmbedConfig`. The MCP handler now:

1. **Mega-graph safety check** — resolves the project-specific graph via
   `get_graph_engine_for_path(Some(p))` instead of always primary.
2. **Scheduler dispatch** — `spawn_background_embed_with_config` opens
   the project-specific `GraphEngine` + `.leankg` dir when
   `cfg.project_path == Some(_)`, and falls back to primary when `None`.

`None` keeps the existing primary-only behavior identical.

## Modes now working with a specific project

```jsonc
// Incremental (default) — re-embed only stale/new
{ "action": "on", "project": "/workspace-other" }

// Full rebuild — re-embed everything from scratch
{ "action": "on", "project": "/workspace-other", "full": true }

// Full on mega-graph (overrides safety guard)
{ "action": "on", "project": "/workspace-other", "full": true, "force_full": true }

// Type filter
{ "action": "on", "project": "/workspace-other", "types": "function,method" }
```

## Files

- `src/embeddings/build.rs` — add `project_path` field to
  `BackgroundEmbedConfig` (+6)
- `src/mcp/server.rs` — project-aware graph resolution in
  `handle_embed_control` "on" and `spawn_background_embed_with_config`
  (+52 / -13)

## Verification

- `cargo check --features embeddings` — clean (only pre-existing warnings)
- `cargo test --lib --features embeddings embeddings::control` — 5/5 pass
- `cargo test --lib --features embeddings mcp::server::tests` — 14/14 pass