### PR TITLE
fix(mcp): preserve ?project= in SSE endpoint discovery

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2444,7 +2444,7 @@ checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
 name = "leankg"
-version = "0.19.24"
+version = "0.19.25"
 dependencies = [
  "argon2",
  "async-trait",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "leankg"
-version = "0.19.24"
+version = "0.19.25"
 edition = "2021"
 description = "Lightweight Knowledge Graph for AI-Assisted Development"
 license = "Apache-2.0"

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -10,7 +10,7 @@ use crate::mcp::watcher::start_watcher;
 use crate::orchestrator::intent::IntentParser;
 use axum::{
     body::Body,
-    extract::State,
+    extract::{Query, State},
     http::{header, HeaderMap, Method, StatusCode},
     response::Response,
     routing::get,
@@ -3251,10 +3251,92 @@ async fn process_jsonrpc_request(
     }
 }
 
+/// Build the SSE endpoint URL advertised to the client during the SSE
+/// discovery handshake. Preserves the `?project=` query string from the
+/// incoming GET request so that Cursor's streamable-HTTP MCP transport
+/// POSTs subsequent JSON-RPC calls to the correct project instead of
+/// falling back to the CLI default project.
+///
+/// `project = None` and `project = Some("")` both produce the bare path,
+/// matching the original (buggy) behavior for clients that did not pass
+/// the query string.
+pub(crate) fn discovery_endpoint_url(project: Option<&str>) -> String {
+    match project.filter(|p| !p.is_empty()) {
+        Some(p) => format!("/mcp?project={}", percent_encode_path(p)),
+        None => "/mcp".to_string(),
+    }
+}
+
+/// Percent-encode a path/query value using RFC 3986 unreserved set
+/// (`A-Z a-z 0-9 - . _ ~`). UTF-8 is preserved byte-by-byte so the result
+/// is safe to round-trip through `percent_decode_path` for any string.
+fn percent_encode_path(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for &b in s.as_bytes() {
+        match b {
+            b'A'..=b'Z' | b'a'..=b'z' | b'0'..=b'9' | b'-' | b'.' | b'_' | b'~' => {
+                out.push(b as char);
+            }
+            _ => {
+                out.push('%');
+                out.push_str(&format!("{:02X}", b));
+            }
+        }
+    }
+    out
+}
+
+/// Percent-decode a previously-encoded path/query value. Operates on bytes
+/// to preserve UTF-8 sequences; invalid UTF-8 falls back to lossy decoding
+/// so callers always receive a valid `String`.
+fn percent_decode_path(s: &str) -> String {
+    let bytes = s.as_bytes();
+    let mut out: Vec<u8> = Vec::with_capacity(bytes.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'%' && i + 2 < bytes.len() {
+            if let (Some(h), Some(l)) = (hex_value(bytes[i + 1]), hex_value(bytes[i + 2])) {
+                out.push((h << 4) | l);
+                i += 3;
+                continue;
+            }
+        }
+        out.push(bytes[i]);
+        i += 1;
+    }
+    String::from_utf8_lossy(&out).into_owned()
+}
+
+fn hex_value(b: u8) -> Option<u8> {
+    match b {
+        b'0'..=b'9' => Some(b - b'0'),
+        b'a'..=b'f' => Some(b - b'a' + 10),
+        b'A'..=b'F' => Some(b - b'A' + 10),
+        _ => None,
+    }
+}
+
+/// Build the SSE endpoint-discovery response. Pure helper so the wire
+/// format is unit-testable without standing up a full Router / State.
+fn build_sse_endpoint_response(project_query: Option<&str>) -> Response {
+    let sse_data = format!(
+        "event: endpoint\ndata: {}\n\n",
+        discovery_endpoint_url(project_query)
+    );
+    Response::builder()
+        .status(StatusCode::OK)
+        .header(header::CONTENT_TYPE, "text/event-stream")
+        .header(header::CACHE_CONTROL, "no-cache")
+        .header(header::CONNECTION, "keep-alive")
+        .body(Body::from(sse_data))
+        .unwrap()
+}
+
 /// Handle GET /mcp/stream - SSE endpoint for server-initiated messages
 async fn handle_sse_stream(
     State(server): State<Arc<HttpMcpServer>>,
     headers: HeaderMap,
+    Query(query): Query<HashMap<String, String>>,
 ) -> Response {
     // Extract Authorization header
     let auth_value = headers
@@ -3272,18 +3354,12 @@ async fn handle_sse_stream(
         }
     };
 
-    // For now, return an SSE stream that sends an endpoint message
-    // In a full implementation, this would maintain a persistent connection
-    // for server-initiated notifications
-    let sse_data = "event: endpoint\ndata: /mcp\n\n";
-
-    Response::builder()
-        .status(StatusCode::OK)
-        .header(header::CONTENT_TYPE, "text/event-stream")
-        .header(header::CACHE_CONTROL, "no-cache")
-        .header(header::CONNECTION, "keep-alive")
-        .body(Body::from(sse_data))
-        .unwrap()
+    // Preserve the `?project=` query string from the incoming GET so that
+    // Cursor's streamable-HTTP MCP transport routes subsequent JSON-RPC
+    // calls to the correct project instead of falling back to the CLI
+    // default. See docs/analysis/fix-mcp-sse-discovery-preserve-project-2026-07-30.md
+    let project_query = query.get("project").map(String::as_str);
+    build_sse_endpoint_response(project_query)
 }
 
 /// Health check endpoint
@@ -3586,5 +3662,86 @@ mod tests {
             "/workspace"
         ));
         assert!(!MCPServer::is_primary_project("/workspace/", "/workspace"));
+    }
+
+    // --- SSE endpoint discovery: preserve ?project= query ----------------
+    // Bug: src/mcp/server.rs hardcodes the SSE "endpoint" event to
+    // `data: /mcp` regardless of the incoming ?project= query string, which
+    // causes Cursor's streamable-HTTP MCP transport to drop the project
+    // override and fall back to LEANKG_MCP_PROJECT (= /workspace).
+    // See docs/analysis/fix-mcp-sse-discovery-preserve-project-2026-07-30.md
+
+    #[test]
+    fn returns_just_mcp_when_project_is_none() {
+        assert_eq!(discovery_endpoint_url(None), "/mcp");
+    }
+
+    #[test]
+    fn returns_mcp_with_query_when_project_is_set() {
+        // The encoder escapes `/` per RFC 3986 so the receiver can never
+        // confuse the value with a path delimiter.
+        assert_eq!(
+            discovery_endpoint_url(Some("/workspace-be")),
+            "/mcp?project=%2Fworkspace-be"
+        );
+    }
+
+    #[test]
+    fn treats_empty_project_as_none() {
+        assert_eq!(discovery_endpoint_url(Some("")), "/mcp");
+    }
+
+    #[test]
+    fn encodes_spaces_and_special_chars() {
+        // '/' is reserved-as-safe and MUST be percent-encoded per RFC 3986,
+        // otherwise the receiving parser would see two `project=` segments.
+        // ' ' and '?' are reserved and MUST be percent-encoded.
+        assert_eq!(
+            discovery_endpoint_url(Some("/workspace foo?bar")),
+            "/mcp?project=%2Fworkspace%20foo%3Fbar"
+        );
+    }
+
+    #[test]
+    fn handles_unicode_path() {
+        // Non-ASCII bytes must round-trip through encode → server's existing
+        // query-string parser without data loss.
+        let original = "/workspace/дөлөө";
+        let url = discovery_endpoint_url(Some(original));
+        assert!(
+            url.starts_with("/mcp?project="),
+            "endpoint must keep /mcp?project= prefix, got {url}"
+        );
+        let encoded = url.trim_start_matches("/mcp?project=");
+        let decoded = percent_decode_path(encoded);
+        assert_eq!(decoded, original, "round-trip must preserve UTF-8");
+    }
+
+    #[tokio::test]
+    async fn sse_response_preserves_project_in_data_event() {
+        use axum::body::to_bytes;
+        let resp = build_sse_endpoint_response(Some("/workspace-be"));
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(
+            &body[..],
+            b"event: endpoint\ndata: /mcp?project=%2Fworkspace-be\n\n"
+        );
+    }
+
+    #[tokio::test]
+    async fn sse_response_omits_query_when_project_is_none() {
+        use axum::body::to_bytes;
+        let resp = build_sse_endpoint_response(None);
+        let body = to_bytes(resp.into_body(), 1024).await.unwrap();
+        assert_eq!(&body[..], b"event: endpoint\ndata: /mcp\n\n");
+    }
+
+    #[tokio::test]
+    async fn sse_response_uses_text_event_stream_content_type() {
+        // Cursor's streamable-HTTP transport rejects discovery responses
+        // that don't carry the SSE content type.
+        let resp = build_sse_endpoint_response(Some("/workspace-be"));
+        let ct = resp.headers().get(header::CONTENT_TYPE).unwrap();
+        assert_eq!(ct, "text/event-stream");
     }
 }


### PR DESCRIPTION
## Summary

Cursor's streamable-HTTP MCP transport does a `GET /mcp` SSE handshake to discover the JSON-RPC endpoint, then POSTs to whatever URL the server advertises in the SSE response. The previous `handle_sse_stream` hardcoded the advertised URL to `/mcp`, dropping the `?project=` query string. As a result, every Cursor session pointed at a side-mount (a project whose container path is configured in the user's gitignored `.dockerfile`) silently fell back to the CLI default project (`/workspace`, the leankg repo itself) for every tool call.

This made it look like the side-mount index was unreachable when, in fact, the configured project was never being targeted.

## Fix

Three pure helpers + one handler signature change in `src/mcp/server.rs`:

| New symbol | Purpose |
|---|---|
| `discovery_endpoint_url(project: Option<&str>) -> String` | Build the SSE endpoint URL. `None`/empty → `/mcp`; `Some(p)` → `/mcp?project=<encoded>`. |
| `percent_encode_path(s: &str) -> String` | RFC 3986 unreserved-set encoder (UTF-8 safe, byte-by-byte). |
| `percent_decode_path(s: &str) -> String` | UTF-8-safe decoder for round-trip tests. |
| `build_sse_endpoint_response(project_query: Option<&str>) -> Response` | Wire-format helper; testable without a Router. |

`handle_sse_stream` now takes `axum::extract::Query<HashMap<String, String>>` and forwards `?project=` into the helpers.

## Verification (against image `e2153ad7a658`, pushed as `:0.19.25` / `:latest`)

| Probe | Expected | Actual |
|---|---|---|
| `GET /mcp?project=<side-mount>` | `data: /mcp?project=%2F<encoded>` | ✓ |
| `GET /mcp/stream?project=<side-mount>` | `data: /mcp?project=%2F<encoded>` | ✓ |
| `GET /mcp` | `data: /mcp` | ✓ |
| `POST /mcp` (no query) | `database: /workspace/.leankg` | ✓ |
| `POST /mcp?project=<side-mount>` (via SSE URL) | `database: <side-mount>/.leankg` | ✓ |

Concretely, with the user's configured side-mount container path, all five probes now resolve to the project the user named in `~/.cursor/mcp.json` instead of `/workspace`.

## Tests

8 new unit tests in `src/mcp/server.rs::tests`:

- `returns_just_mcp_when_project_is_none` (S1)
- `returns_mcp_with_query_when_project_is_set` (S1, encoded form)
- `treats_empty_project_as_none` (S1)
- `encodes_spaces_and_special_chars` (S2)
- `handles_unicode_path` (S2 round-trip)
- `sse_response_preserves_project_in_data_event` (S3 wire format)
- `sse_response_omits_query_when_project_is_none` (S3)
- `sse_response_uses_text_event_stream_content_type` (S3)

Lib suite: 734 passed / 0 failed in the worktree.

## Files changed

- `src/mcp/server.rs` — helpers, handler wiring, 8 unit tests
- `Cargo.toml` — `0.19.24` → `0.19.25`
- `Cargo.lock` — auto-bumped

## Plan + reproducer

Full TDD plan and the original reproducer probes: `docs/analysis/fix-mcp-sse-discovery-preserve-project-2026-07-30.md`

## Out of scope (separate PRs)

- Byte-as-char decoder at `server.rs:2989` is still buggy for non-ASCII inbound values; the new encoder produces safe output today but the inbound parser should be rewritten to UTF-8-safe.
- Empty HNSW vector state for the side-mount project (separate investigation, now unblocked since this PR lets Cursor actually target the configured project).
- Zombie `leankg mcp-stdio --watch` processes cleanup.