### PR TITLE
Set up Cursor Cloud dev environment for LeanKG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -97,6 +97,19 @@ Never paste personal host paths into commits.
 
 For 3+ independent tasks: dispatch to `.worktree/<feature>/` worktrees with feature branches. Verify isolation (`.gitignore` covers `.worktrees/`). Merge all feature branches after completion.
 
+## Cursor Cloud specific instructions
+
+Single Rust binary (`leankg`); all modes are subcommands. No external DB service in the default dev path — CozoDB is embedded (SQLite under `.leankg/`). The VM snapshot already has the toolchain and system libs below; the startup update script only runs `cargo fetch`.
+
+- **Toolchain**: build requires Rust **stable ≥ 1.85** (transitive deps use edition2024). The base image's 1.83 is too old; the snapshot ships `rustup default stable`. README's "Rust 1.75+" badge is outdated for building from source.
+- **Native build deps**: `cozo` (RocksDB via the `cxx`/C++ toolchain) needs C++ stdlib headers. `clang`/`cc` select GCC 14, so `libstdc++-14-dev` (plus `g++`) must be present or the build fails with `fatal error: 'algorithm' file not found`. These are installed in the snapshot.
+- **Always `--release`**: the debug profile sets `debug=false`; use `cargo build --release` / `cargo run --release --` per `Makefile`. First release build ≈ 4–5 min; `cargo clippy --all -- -D warnings` ≈ 3 min.
+- **Verify commands** (all pass): `cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings` (CI gate; `make lint` adds `--all-features` which pulls the heavy `embeddings`/ONNX stack), `cargo test --lib` (734 tests, ~4s). See `AGENTS.md` Build & Test and `.github/workflows/ci.yml`.
+- **Index step is slow**: `leankg index ./src` inserts ~8k elements / ~50k relationships into SQLite and takes ~4–5 min; it is not hung. Run `leankg init` first.
+- **CLI quirk**: `impact` takes `--depth N` (a flag), not a positional depth arg as some docs show, e.g. `leankg impact src/main.rs --depth 2`.
+- **MCP HTTP**: `leankg mcp-http --port 9699 --project /workspace`; health `GET /health`, JSON-RPC `POST /mcp?project=/workspace`. Pass the container path `/workspace` as `project` (see MANDATORY section above).
+- **Embeddings/semantic search** need `--features embeddings` (downloads ONNX models at runtime); off by default — `semantic_search` returns "no vectors" without them.
+
 ---
 
-*Last updated: 2026-07-27*
+*Last updated: 2026-08-01*


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies a working Cloud dev environment for LeanKG (Rust + CozoDB + tree-sitter + MCP) and documents the non-obvious setup caveats for future agents.

The only code change is an added `## Cursor Cloud specific instructions` section in `AGENTS.md`. No application code was modified.

## Environment setup performed (persisted in VM snapshot)

- Installed Rust **stable 1.97.1** via `rustup` (base image shipped 1.83, too old — transitive deps require edition2024 / Rust ≥ 1.85).
- Installed system C++ deps for the `cozo`/RocksDB `cxx` build: `g++`, `libstdc++-13-dev`, `libstdc++-14-dev` (clang selects GCC 14; without its headers the build fails with `fatal error: 'algorithm' file not found`).

## Update script (startup dependency refresh)

```
cargo fetch
```

## Verification (all green)

| Check | Command | Result |
|-------|---------|--------|
| Build | `cargo build --release` | binary built (~4.5 min) |
| Format | `cargo fmt --all -- --check` | clean |
| Lint | `cargo clippy --all -- -D warnings` | clean |
| Tests | `cargo test --lib` | 734 passed, 0 failed, 3 ignored |

## Hello-world E2E

- CLI: `leankg init` → `index ./src` (8,381 elements / 50,413 relationships / 136 docs) → `status` → `impact src/main.rs --depth 2` → `query "GraphEngine"`.
- MCP HTTP server on `:9699`: `GET /health` → `{"status":"ok"}`, JSON-RPC `initialize`, `tools/call mcp_status`, and `tools/call search_code` all return live graph data.

[LeanKG E2E verification](https://cursor.com/agents/bc-4b95872e-244d-49c1-bdb8-5f39dd4d507e/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fleankg_e2e_verification.txt)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4b95872e-244d-49c1-bdb8-5f39dd4d507e?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4b95872e-244d-49c1-bdb8-5f39dd4d507e&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

