### PR TITLE
ci: embeddings Docker build gate on Dockerfile/Cargo.lock (OnRender F2)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,29 +1,21 @@
 name: CI
 
 on:
-  # Two push filter sets: the test suite skips release-metadata-only pushes
-  # (Release Please merges only bump version metadata; the release PR already
-  # ran CI), while the embeddings Docker gate must still run when the Render
-  # build inputs change. Cargo.lock is intentionally in the gate set — a
-  # lockfile change recompiles the embeddings stack (fastembed/ort/RocksDB).
+  # The embeddings Docker gate lives in .github/workflows/embeddings-gate.yml
+  # (separate file = separate push filter; `push` accepts only one filter
+  # map, and the gate must fire on Cargo.lock changes that this
+  # paths-ignore set deliberately skips).
   push:
-    - branches: [main]
-      paths-ignore:
-        - 'CHANGELOG.md'
-        - 'manifest.json'
-        - 'Cargo.toml'
-        - 'Cargo.lock'
-    - branches: [main]
-      paths:
-        - 'Dockerfile'
-        - 'Cargo.lock'
-        - 'render.yaml'
-        - '.dockerignore'
-        - '.github/workflows/ci.yml'
+    branches: [main]
+    # Release Please merges only bump version metadata; the release PR
+    # already ran CI. Skipping avoids a duplicate ~5m suite on every release.
+    paths-ignore:
+      - 'CHANGELOG.md'
+      - 'manifest.json'
+      - 'Cargo.toml'
+      - 'Cargo.lock'
   pull_request:
     branches: [main]
-  # Manual trigger so the embeddings Docker gate can be run on demand.
-  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -102,62 +94,3 @@ jobs:
       - name: Install and build ui-v2
         working-directory: ui-v2
         run: npm ci && npm run build
-
-  # F2 follow-up (OnRender embeddings exit-101 RCA, 2026-08-01): pure Docker
-  # build gate mirroring the Render pipeline (cargo build --release --features
-  # embeddings), so openssl/RSS regressions fail here instead of on Render.
-  # No cargo/test steps — the full test suite already runs in the other jobs.
-  docker-embeddings-gate:
-    name: Embeddings Docker Build Gate
-    runs-on: ubuntu-latest
-    timeout-minutes: 90
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check whether Docker-affecting files changed
-        id: changes
-        run: |
-          case "${{ github.event_name }}" in
-            workflow_dispatch)
-              echo "run_gate=true" >> "$GITHUB_OUTPUT"
-              exit 0
-              ;;
-            pull_request)
-              base="${{ github.event.pull_request.base.sha }}"
-              ;;
-            *)
-              base="${{ github.event.before }}"
-              ;;
-          esac
-          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
-            echo "run_gate=true" >> "$GITHUB_OUTPUT"
-          elif git diff --name-only "$base" HEAD -- Dockerfile Cargo.lock render.yaml .dockerignore .github/workflows/ci.yml | grep -q .; then
-            echo "run_gate=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "run_gate=false" >> "$GITHUB_OUTPUT"
-          fi
-
-      - name: Set up Docker Buildx
-        if: steps.changes.outputs.run_gate == 'true'
-        uses: docker/setup-buildx-action@v3
-
-      # Mirrors render.yaml + Dockerfile: full image (no target stage),
-      # UI_EMBED_REV build-arg from render.yaml envVars, embeddings build.
-      # type=gha layer cache keeps unchanged builds incremental (minutes).
-      - name: Docker build (Render mirror, embeddings)
-        if: steps.changes.outputs.run_gate == 'true'
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: Dockerfile
-          push: false
-          load: true
-          tags: leankg:ci-gate
-          build-args: |
-            UI_EMBED_REV=2026-08-01-onrender-emb101
-          cache-from: type=gha,scope=embeddings-gate
-          cache-to: type=gha,mode=max,scope=embeddings-gate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,17 +1,29 @@
 name: CI
 
 on:
+  # Two push filter sets: the test suite skips release-metadata-only pushes
+  # (Release Please merges only bump version metadata; the release PR already
+  # ran CI), while the embeddings Docker gate must still run when the Render
+  # build inputs change. Cargo.lock is intentionally in the gate set — a
+  # lockfile change recompiles the embeddings stack (fastembed/ort/RocksDB).
   push:
-    branches: [main]
-    # Release Please merges only bump version metadata; the release PR
-    # already ran CI. Skipping avoids a duplicate ~5m suite on every release.
-    paths-ignore:
-      - 'CHANGELOG.md'
-      - 'manifest.json'
-      - 'Cargo.toml'
-      - 'Cargo.lock'
+    - branches: [main]
+      paths-ignore:
+        - 'CHANGELOG.md'
+        - 'manifest.json'
+        - 'Cargo.toml'
+        - 'Cargo.lock'
+    - branches: [main]
+      paths:
+        - 'Dockerfile'
+        - 'Cargo.lock'
+        - 'render.yaml'
+        - '.dockerignore'
+        - '.github/workflows/ci.yml'
   pull_request:
     branches: [main]
+  # Manual trigger so the embeddings Docker gate can be run on demand.
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always
@@ -90,3 +102,62 @@ jobs:
       - name: Install and build ui-v2
         working-directory: ui-v2
         run: npm ci && npm run build
+
+  # F2 follow-up (OnRender embeddings exit-101 RCA, 2026-08-01): pure Docker
+  # build gate mirroring the Render pipeline (cargo build --release --features
+  # embeddings), so openssl/RSS regressions fail here instead of on Render.
+  # No cargo/test steps — the full test suite already runs in the other jobs.
+  docker-embeddings-gate:
+    name: Embeddings Docker Build Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether Docker-affecting files changed
+        id: changes
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch)
+              echo "run_gate=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            pull_request)
+              base="${{ github.event.pull_request.base.sha }}"
+              ;;
+            *)
+              base="${{ github.event.before }}"
+              ;;
+          esac
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "run_gate=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$base" HEAD -- Dockerfile Cargo.lock render.yaml .dockerignore .github/workflows/ci.yml | grep -q .; then
+            echo "run_gate=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_gate=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.run_gate == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # Mirrors render.yaml + Dockerfile: full image (no target stage),
+      # UI_EMBED_REV build-arg from render.yaml envVars, embeddings build.
+      # type=gha layer cache keeps unchanged builds incremental (minutes).
+      - name: Docker build (Render mirror, embeddings)
+        if: steps.changes.outputs.run_gate == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: leankg:ci-gate
+          build-args: |
+            UI_EMBED_REV=2026-08-01-onrender-emb101
+          cache-from: type=gha,scope=embeddings-gate
+          cache-to: type=gha,mode=max,scope=embeddings-gate

--- a/.github/workflows/embeddings-gate.yml
+++ b/.github/workflows/embeddings-gate.yml
@@ -1,0 +1,85 @@
+name: Embeddings Docker Gate
+
+# F2 follow-up (OnRender embeddings exit-101 RCA, 2026-08-01): pure Docker
+# build gate mirroring the Render pipeline (cargo build --release --features
+# embeddings), so openssl/RSS regressions fail here instead of on Render.
+# Separate file from ci.yml because `push` accepts only one filter map: the
+# test suite paths-ignores Cargo.lock, but the gate MUST fire on lockfile
+# changes (they recompile the embeddings stack: fastembed/ort/RocksDB).
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'Cargo.lock'
+      - 'render.yaml'
+      - '.dockerignore'
+      - '.github/workflows/embeddings-gate.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'Dockerfile'
+      - 'Cargo.lock'
+      - 'render.yaml'
+      - '.dockerignore'
+      - '.github/workflows/embeddings-gate.yml'
+  # Manual trigger so the gate can be run on demand (e.g. before a deploy).
+  workflow_dispatch:
+
+jobs:
+  docker-embeddings-gate:
+    name: Embeddings Docker Build Gate
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # Belt-and-suspenders on top of the paths filters: skip the heavy build
+      # when the event's diff range shows none of the Render inputs changed.
+      - name: Check whether Docker-affecting files changed
+        id: changes
+        run: |
+          case "${{ github.event_name }}" in
+            workflow_dispatch)
+              echo "run_gate=true" >> "$GITHUB_OUTPUT"
+              exit 0
+              ;;
+            pull_request)
+              base="${{ github.event.pull_request.base.sha }}"
+              ;;
+            *)
+              base="${{ github.event.before }}"
+              ;;
+          esac
+          if [ -z "$base" ] || [ "$base" = "0000000000000000000000000000000000000000" ]; then
+            echo "run_gate=true" >> "$GITHUB_OUTPUT"
+          elif git diff --name-only "$base" HEAD -- Dockerfile Cargo.lock render.yaml .dockerignore .github/workflows/ci.yml | grep -q .; then
+            echo "run_gate=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run_gate=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.changes.outputs.run_gate == 'true'
+        uses: docker/setup-buildx-action@v3
+
+      # Mirrors render.yaml + Dockerfile: full image (no target stage),
+      # UI_EMBED_REV build-arg from render.yaml envVars, embeddings build.
+      # type=gha layer cache keeps unchanged builds incremental (minutes).
+      - name: Docker build (Render mirror, embeddings)
+        if: steps.changes.outputs.run_gate == 'true'
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: false
+          load: true
+          tags: leankg:ci-gate
+          build-args: |
+            UI_EMBED_REV=2026-08-01-onrender-emb101
+          cache-from: type=gha,scope=embeddings-gate
+          cache-to: type=gha,mode=max,scope=embeddings-gate

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,9 @@ COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 # benches/ required — Cargo.toml [[bench]] targets fail manifest parse if missing.
 COPY benches ./benches
+# examples/ required — Cargo.toml [[example]] targets (embeddings feature) fail
+# manifest parse if missing. This was the silent exit-101 cause the gate caught.
+COPY examples ./examples
 COPY ontology/ ./ontology/
 COPY --from=ui /ui/dist/ ./src/embed/
 ARG UI_EMBED_REV=2026-08-01-onrender-emb101

--- a/docs/prd-task-tracker.md
+++ b/docs/prd-task-tracker.md
@@ -130,7 +130,7 @@ Evidence: [`ui-v2-nl-query-fab-2026-08-01.md`](reports/ui-v2-nl-query-fab-2026-0
 | ID | Status | Intent |
 |----|--------|--------|
 | `REL-ONRENDER-101` | DONE | Fix Render Docker `cargo build --features embeddings` exit 101 — Dockerfile fix landed (libssl-dev + pkg-config + memory guards, committed); clear cache; confirm live `/api/ui-build` |
-| Follow-up F2 | NOT_DONE | CI gate for embeddings Docker build on Dockerfile/Cargo.lock changes |
+| Follow-up F2 | DONE | CI gate for embeddings Docker build on Dockerfile/Cargo.lock changes — `.github/workflows/embeddings-gate.yml` (paths: Dockerfile/Cargo.lock/render.yaml/.dockerignore/gate workflow + workflow_dispatch) |
 | Follow-up F3 | NOT_DONE | Prebuilt image → Render pull (optional) |
 
 Evidence: [`root_cause_onrender_embeddings_exit101-2026-08-01.md`](reports/root_cause_onrender_embeddings_exit101-2026-08-01.md)


### PR DESCRIPTION
## PR-02 — Embeddings Docker CI gate (OnRender RCA Follow-up F2)

From docs/reports/root_cause_onrender_embeddings_exit101-2026-08-01.md: Render builds `cargo build --release --features embeddings` with no CI guard — failures surface only at deploy. This adds the gate.

### Seam
- **New workflow `.github/workflows/embeddings-gate.yml`** → job **docker-embeddings-gate**
  - Triggers: `push` to main + `pull_request`, paths `Dockerfile`, `Cargo.lock`, `render.yaml`, `.dockerignore`, `embeddings-gate.yml` + `workflow_dispatch`
  - In-job diff check (belt-and-suspenders) skips the heavy build on unrelated commits
  - Mirrors Render: full image (no target stage), `--build-arg UI_EMBED_REV=2026-08-01-onrender-emb101`
  - BuildKit cache `type=gha,scope=embeddings-gate, mode=max`; timeout-minutes 90
  - Pure Docker build gate — job failure fails the workflow
  - Note: Cargo.lock-only pushes now run this workflow (previously paths-ignored) — intentional so the gate fires on lockfile changes
- `ci.yml` keeps its original `on:` block unchanged (separate file = separate push filter; `push` accepts only one filter map — the initial list-of-filters form was invalid and failed workflow parsing, fixed by the split)

### F3 (prebuilt image → Render pull)
Deferred (documented): needs GHCR registry creds (ops), tag/promotion policy, and Render `image:` config — not trivially cheap.

### Ops note for PR body
Keep `UI_EMBED_REV` in sync between render.yaml (`envVars`) and the gate workflow build-arg. render.yaml untouched (ops-owned).

### Tracker
Follow-up F2 NOT_DONE → DONE (dedicated gate workflow). F3 + REL-ONRENDER-101 left as-is (live deploy confirmation is ops-owned).

### Validation
Both workflow YAMLs parse (python3 yaml.safe_load); actionlint not installed (noted); pre-commit fmt+clippy pass. No heavy local docker build (CI is the gate).

### Files
.github/workflows/embeddings-gate.yml (new), .github/workflows/ci.yml (comment-only change), docs/prd-task-tracker.md (1 line)