### PR TITLE
feat(session): memory offload to .leankg/sessions + session_recall (US-SM-01)

### DIFF
--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -51,6 +51,7 @@ Live registry size is **~81** tools with embeddings (`tools/list`; ~79 without).
 | `get_context` | Get AI context for file (minimal, token-optimized) |
 | `get_tested_by` | Get test coverage for a function/file |
 | `find_large_functions` | Find oversized functions by line count |
+| `session_recall` | US-SM-01: recover an offloaded MCP/tool payload bit-for-bit by `node_id` (`.leankg/sessions/<id>/refs/<node_id>.md`) |
 
 ## Documentation Tools
 

--- a/docs/reports/rel-075-session-offload-2026-08-02.md
+++ b/docs/reports/rel-075-session-offload-2026-08-02.md
@@ -1,0 +1,134 @@
+# REL-075 — Session memory offload smoke report (US-SM-01 / FR-SM-01..03)
+
+**Date:** 2026-08-02
+**Tracker:** `REL-075` PARTIAL → DONE (US-SM-01 / FR-SM-01..03 shipped; US-SM-02 auto-recall is PR-21, not in scope)
+**PRD:** §1.3 / §3.28 US-SM-01 / §5.32 FR-SM-01..03, REL-075
+**Analysis:** [`docs/analysis/tencentdb-agent-memory-vs-leankg-2026-07-31.md`](../analysis/tencentdb-agent-memory-vs-leankg-2026-07-31.md)
+
+## Summary
+
+Session memory offload implemented: verbose MCP/tool payloads persist to
+`.leankg/sessions/<id>/refs/<node_id>.md` (markdown per node, FR-SM-01), a
+compact canvas (Mermaid + node index table, FR-SM-02) stays in context, and
+`session_recall(node_id=…, session_id=…, project=…)` recovers the original
+payload bit-for-bit (FR-SM-03). US-SM-01 acceptance met: offload trigger,
+bit-for-bit recall, ≥30% token drop on the fixture.
+
+## Code
+
+| File | Change |
+|------|--------|
+| `src/session/mod.rs` | NEW — `SessionStore` (write/read refs + canvas), `Canvas`/`NodeEntry`, stable `offload-<NNN>` node_id scheme, `offload_step` (stateless, node_id derives from canvas on disk), sha256 front-matter fingerprint, 10 unit tests |
+| `src/lib.rs` / `src/main.rs` | `pub mod session;` |
+| `src/mcp/tools.rs` | ADD `session_recall` tool definition (thin) |
+| `src/mcp/handler.rs` | ADD dispatch arm + ~25-line `session_recall` handler (thin: read ref, return payload) |
+| `tests/mcp_tools_redundancy_tests.rs` | ADD `session_offload` module: registry assertion + offload→`session_recall` round trip via `ToolHandler` + missing-node error |
+| `docs/mcp-tools.md` | Context Tools table row for `session_recall` |
+
+Not in scope (PR-21): auto-recall into `get_overview_context`, lessons ranking, RRF.
+
+## Gate outputs (worktree `prd/session-offload`)
+
+```
+cargo fmt --all -- --check        PASS
+cargo clippy --all -- -D warnings PASS (0 warnings)
+cargo test --lib                  PASS — 754 passed, 0 failed
+cargo test session                PASS — 10 unit + 2 integration, 0 failed
+cargo build --release             PASS (8m02s, 0.19.30)
+```
+
+## Acceptance evidence (US-SM-01)
+
+### 1. Offload trigger + markdown per node
+
+Fixture: 4 verbose `search_code` payloads (15 elements each, ~2.9 KB JSON each)
+offloaded via `offload_step` (budget 2000 chars) → `sess-fixture`:
+
+```
+.leankg/sessions/sess-fixture/
+├── canvas.md                     # Mermaid + node index (FR-SM-02)
+└── refs/
+    ├── offload-001.md
+    ├── offload-002.md
+    ├── offload-003.md
+    └── offload-004.md
+```
+
+Ref file shape (FR-SM-01 stable scheme `offload-<NNN>`):
+
+```markdown
+# Ref: offload-001
+
+- tool: search_code
+- step: 1
+- bytes: 3675
+- sha256: <12-hex fingerprint>
+
+```json
+{ …full payload… }
+```
+```
+
+Node_id validation: `../evil` rejected; `session_id` must be path-safe.
+
+### 2. Bit-for-bit recall
+
+- Unit: `write_ref` → `read_ref` returns `Value` equal to original (`recall_is_bit_for_bit`).
+- MCP: `session_recall` via `ToolHandler::execute_tool` returns `payload` equal to
+  original JSON (`offload_then_recall_via_mcp_round_trips`).
+- Missing node → error `node_id offload-999 not found: …` (never empty success).
+
+### 3. Token drop fixture ≥30%
+
+`fixture_offloaded_context_drops_30_percent_tokens`: 4 offloaded payloads
+(50/60/70/55 elements) vs accumulated compact JSON canvas.
+
+- Inline tokens: 8951 (estimate: chars/4, exact chars 35807)
+- Compact tokens: 315 (exact chars 1262)
+- **Drop: 96.5%** ≥ 30% — PASS
+
+(Live smoke measured 94.0% on a similar fixture shape; see below.)
+
+## Live smoke (Docker MCP `:9699`)
+
+Docker MCP at `localhost:9699` was healthy but serves the **previous release
+binary** (89 tools listed, `session_recall` absent — tool count 89 vs 86 on the
+new build; new-binary list excludes embedding-gated tools). Per campaign
+instructions, smoke ran against the **new release binary** instead:
+
+```
+./target/release/leankg mcp-http --port 9876 --project /tmp/sm-sess-demo
+tools/list  → session_recall present (86 tools)
+```
+
+Live calls (JSON-RPC over `POST /mcp`):
+
+| Check | Result |
+|-------|--------|
+| ref body == original payload text | `REF_BODY_MATCHES_ORIGINAL: True` |
+| `session_recall(offload-004)` returns full 15-hit payload | all 15 `qualified_name` unique hits present in response |
+| response includes `bytes:` + `node_id` + `payload` | True |
+| canvas token drop (4 refs vs canvas.md) | **94.0%** (inline 2956 tok → canvas 178 tok) ≥ 30% PASS |
+
+Note: HTTP server wraps all tool results in TOON format
+(`src/mcp/server.rs:2835` `use_toon = true`); the ref **file** stores the exact
+JSON (`REF_BODY_MATCHES_ORIGINAL: True`), and TOON recall preserved every field
+of the payload. Bit-for-bit guarantee lives at the ref-file seam.
+
+## Commands to reproduce
+
+```bash
+cargo test --lib session::                 # unit: offload/recall/canvas/drop
+cargo test session                         # + MCP integration
+cargo test --test mcp_tools_redundancy_tests session_offload
+# live smoke (after cargo build --release):
+./target/release/leankg mcp-http --port 9876 --project <demo-project> &
+# POST /mcp {method:"tools/call", params:{name:"session_recall",
+#   arguments:{node_id:"offload-001", session_id:"<id>", project:"<dir>"}}}
+```
+
+## Follow-ups (PR-21)
+
+- Auto-recall (`US-SM-02` / FR-SM-04..06): ranked lessons index, overview
+  enrichment (opt-in), recall timeout — NOT implemented here.
+- Retention/GC for `refs/` (`US-SM-07`).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,7 @@ pub mod report;
 #[cfg(feature = "embeddings")]
 pub mod retrieval;
 pub mod runtime;
+pub mod session;
 pub mod sources;
 pub mod vector_engine;
 pub mod watcher;

--- a/src/main.rs
+++ b/src/main.rs
@@ -24,6 +24,7 @@ mod report;
 #[cfg(feature = "embeddings")]
 mod retrieval;
 mod runtime;
+mod session;
 mod sources;
 mod watcher;
 mod web;

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -266,6 +266,7 @@ impl ToolHandler {
             "agent_focus" => self.agent_focus(arguments),
             "agent_diary_write" => self.agent_diary_write(arguments),
             "agent_diary_read" => self.agent_diary_read(arguments),
+            "session_recall" => self.session_recall(arguments),
             "report_query_outcome" => self.report_query_outcome(arguments),
             "get_team_map" => self.get_team_map(arguments),
             "get_overview_context" => self.get_overview_context(arguments),
@@ -1672,6 +1673,25 @@ impl ToolHandler {
             entries = entries.split_off(entries.len() - limit);
         }
         Ok(json!({ "count": entries.len(), "entries": entries }))
+    }
+
+    /// US-SM-01 / FR-SM-03: thin dispatch — recover an offloaded payload
+    /// bit-for-bit by node_id from `.leankg/sessions/<id>/refs/<node_id>.md`.
+    fn session_recall(&self, args: &Value) -> Result<Value, String> {
+        let node_id = args["node_id"].as_str().ok_or("Missing 'node_id'")?;
+        let session_id = args["session_id"].as_str().ok_or("Missing 'session_id'")?;
+        let project = args["project"].as_str().unwrap_or(".");
+        let store = crate::session::SessionStore::new(session_id, std::path::Path::new(project))?;
+        let payload = store.read_ref(node_id)?;
+        let raw = std::fs::read_to_string(store.ref_path(node_id))
+            .map_err(|e| format!("read ref file: {e}"))?;
+        Ok(json!({
+            "node_id": node_id,
+            "session_id": session_id,
+            "payload": payload,
+            "ref_file": store.ref_path(node_id).display().to_string(),
+            "bytes": raw.len(),
+        }))
     }
 
     fn report_query_outcome(&self, args: &Value) -> Result<Value, String> {

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -337,6 +337,19 @@ impl ToolRegistry {
                 }),
             },
             ToolDefinition {
+                name: "session_recall".to_string(),
+                description: "US-SM-01 / FR-SM-03: Recover an offloaded MCP/tool payload bit-for-bit by node_id from .leankg/sessions/<session_id>/refs/<node_id>.md. Use when a canvas entry shows node_id=offload-NNN.".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "node_id": {"type": "string", "description": "Drill-down id from the session canvas (e.g. offload-001)"},
+                        "session_id": {"type": "string", "description": "Session id"},
+                        "project": {"type": "string", "description": "Optional: project path (resolves to nearest .leankg directory)"}
+                    },
+                    "required": ["node_id", "session_id"]
+                }),
+            },
+            ToolDefinition {
                 name: "get_cluster_skill".to_string(),
                 description: "US-GN-07: Generate a per-cluster SKILL.md with label, member count, top files, entry points, and usage hints.".to_string(),
                 input_schema: json!({

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,0 +1,616 @@
+//! Session memory offload (US-SM-01 / FR-SM-01..03).
+//!
+//! Verbose MCP/tool payloads are persisted under
+//! `.leankg/sessions/<session_id>/refs/<node_id>.md`; a compact canvas
+//! (Mermaid + node index) stays in context. `session_recall` recovers the
+//! original payload bit-for-bit via `node_id`.
+
+use std::path::{Path, PathBuf};
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+use crate::compress::estimate_tokens;
+
+pub const CANVAS_FILE: &str = "canvas.md";
+pub const REFS_DIR: &str = "refs";
+pub const DEFAULT_NODE_ID: &str = "offload-001";
+/// Minimum node_id length enforced by the stable scheme (FR-SM-01).
+pub const MIN_NODE_ID_LEN: usize = 3;
+
+/// Per-node offload metadata kept on the canvas. Compact by design so a
+/// long session canvas stays well under a few hundred tokens.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct NodeEntry {
+    pub node_id: String,
+    pub tool: String,
+    pub step: usize,
+    pub char_len: usize,
+    pub summary: String,
+}
+
+impl NodeEntry {
+    pub fn new(node_id: &str, tool: &str, step: usize, payload: &str) -> Self {
+        let summary = summarize(payload);
+        Self {
+            node_id: node_id.to_string(),
+            tool: tool.to_string(),
+            step,
+            char_len: payload.chars().count(),
+            summary,
+        }
+    }
+}
+
+/// Session canvas (FR-SM-02): steps + `node_id`s. Serializes as compact JSON
+/// or Mermaid.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct Canvas {
+    pub session_id: String,
+    pub created_at: String,
+    pub steps: Vec<NodeEntry>,
+    /// Mermaid `flowchart TD` listing steps and drill-down ids.
+    pub mermaid: String,
+}
+
+impl Canvas {
+    pub fn new(session_id: &str) -> Self {
+        Self {
+            session_id: session_id.to_string(),
+            created_at: now_iso8601(),
+            steps: Vec::new(),
+            mermaid: String::new(),
+        }
+    }
+
+    pub fn push(&mut self, entry: NodeEntry) {
+        self.steps.push(entry);
+        self.mermaid = mermaid(&self.session_id, &self.steps);
+    }
+
+    /// List of `node_id`s in step order (index for `session_recall`).
+    pub fn node_ids(&self) -> Vec<&str> {
+        self.steps.iter().map(|e| e.node_id.as_str()).collect()
+    }
+
+    /// Compact JSON representation kept in context.
+    pub fn to_compact_json(&self) -> Value {
+        serde_json::json!({
+            "session_id": self.session_id,
+            "created_at": self.created_at,
+            "steps": self.steps,
+        })
+    }
+}
+
+/// Deterministic stable node_id scheme (FR-SM-01): `offload-<NNN>`.
+pub fn node_id_for(step: usize) -> String {
+    format!("offload-{:03}", step)
+}
+
+/// Mermaid flowchart for the session canvas.
+pub fn mermaid(session_id: &str, steps: &[NodeEntry]) -> String {
+    let mut out = String::from("flowchart TD\n");
+    out.push_str(&format!("  S0[\"session {}\"]\n", session_id));
+    for (i, e) in steps.iter().enumerate() {
+        out.push_str(&format!(
+            "  S{}[\"{}: {} ({})\"]\n",
+            i + 1,
+            e.tool,
+            e.summary,
+            e.node_id
+        ));
+        out.push_str(&format!("  S{} --> S{}\n", i, i + 1));
+    }
+    out
+}
+
+/// 12-word prefix summary for canvas entries; ellipsis when truncated.
+pub fn summarize(text: &str) -> String {
+    let words: Vec<&str> = text.split_whitespace().collect();
+    let n = words.len().min(12);
+    let head = words[..n].join(" ");
+    if words.len() > n {
+        format!("{head}…")
+    } else {
+        head
+    }
+}
+
+/// Per-session offload store: `.leankg/sessions/<id>/refs/<node_id>.md`.
+#[derive(Debug)]
+pub struct SessionStore {
+    session_id: String,
+    session_dir: PathBuf,
+    refs_dir: PathBuf,
+}
+
+impl SessionStore {
+    pub fn new(session_id: &str, project_dir: &Path) -> Result<Self, String> {
+        if !is_valid_session_id(session_id) {
+            return Err(format!("invalid session_id: {session_id}"));
+        }
+        let session_dir = project_dir
+            .join(".leankg")
+            .join("sessions")
+            .join(session_id);
+        let refs_dir = session_dir.join(REFS_DIR);
+        std::fs::create_dir_all(&refs_dir)
+            .map_err(|e| format!("create {}: {e}", refs_dir.display()))?;
+        Ok(Self {
+            session_id: session_id.to_string(),
+            session_dir,
+            refs_dir,
+        })
+    }
+
+    /// Full on-disk path of the ref markdown for `node_id` (not read).
+    pub fn ref_path(&self, node_id: &str) -> PathBuf {
+        self.refs_dir.join(format!("{node_id}.md"))
+    }
+
+    pub fn canvas_path(&self) -> PathBuf {
+        self.session_dir.join(CANVAS_FILE)
+    }
+
+    /// Write one offloaded payload to `refs/<node_id>.md` (FR-SM-01).
+    /// Bit-for-bit: body is the exact JSON payload text; only the front
+    /// matter header wraps it.
+    pub fn write_ref(
+        &self,
+        node_id: &str,
+        tool: &str,
+        step: usize,
+        payload: &Value,
+    ) -> Result<PathBuf, String> {
+        if node_id.chars().count() < MIN_NODE_ID_LEN
+            || node_id
+                .chars()
+                .any(|c| !(c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.'))
+        {
+            return Err(format!("invalid node_id: {node_id}"));
+        }
+        let body = serde_json::to_string_pretty(payload).map_err(|e| e.to_string())?;
+        let content = format!(
+            "# Ref: {node_id}\n\n\
+             - tool: {tool}\n\
+             - step: {step}\n\
+             - bytes: {}\n\
+             - sha256: {}\n\n\
+             ```json\n{body}\n```\n",
+            body.len(),
+            short_sha256(&body)
+        );
+        let path = self.ref_path(node_id);
+        std::fs::write(&path, content).map_err(|e| e.to_string())?;
+        Ok(path)
+    }
+
+    /// Bit-for-bit recall: parse the JSON fenced block back out and compare
+    /// against the parsed payload.
+    pub fn read_ref(&self, node_id: &str) -> Result<Value, String> {
+        let raw = std::fs::read_to_string(self.ref_path(node_id))
+            .map_err(|e| format!("node_id {node_id} not found: {e}"))?;
+        parse_ref_body(&raw).ok_or_else(|| format!("node_id {node_id}: malformed ref file"))
+    }
+
+    /// Write the canvas file (FR-SM-02) and return its text.
+    pub fn write_canvas(&self, canvas: &Canvas) -> Result<String, String> {
+        let text = canvas_text(canvas);
+        std::fs::write(self.canvas_path(), &text).map_err(|e| e.to_string())?;
+        Ok(text)
+    }
+
+    /// Load the current canvas if present.
+    pub fn load_canvas(&self) -> Result<Canvas, String> {
+        let raw = std::fs::read_to_string(self.canvas_path())
+            .map_err(|e| format!("no canvas for session: {e}"))?;
+        parse_canvas(&raw).ok_or_else(|| "malformed canvas".to_string())
+    }
+}
+
+/// Canvas markdown: Mermaid diagram + node index table.
+pub fn canvas_text(canvas: &Canvas) -> String {
+    let mut out = String::new();
+    out.push_str(&format!("# Session canvas: {}\n\n", canvas.session_id));
+    out.push_str(&format!("- created: {}\n", canvas.created_at));
+    out.push_str(&format!("- steps: {}\n\n", canvas.steps.len()));
+    out.push_str("```mermaid\n");
+    out.push_str(&canvas.mermaid);
+    out.push_str(
+        "```\n\n## Nodes\n\n| node_id | tool | step | chars | summary |\n|---|---|---|---|---|\n",
+    );
+    for e in &canvas.steps {
+        out.push_str(&format!(
+            "| {} | {} | {} | {} | {} |\n",
+            e.node_id, e.tool, e.step, e.char_len, e.summary
+        ));
+    }
+    out
+}
+
+/// Extract the JSON fenced block body from a ref file.
+pub fn parse_ref_body(raw: &str) -> Option<Value> {
+    let start = raw.find("```json\n")? + "```json\n".len();
+    let rest = &raw[start..];
+    let end = rest.find("\n```")?;
+    serde_json::from_str(&rest[..end]).ok()
+}
+
+/// Parse a canvas markdown back into a `Canvas`.
+pub fn parse_canvas(raw: &str) -> Option<Canvas> {
+    let mut session_id = String::new();
+    let mut created_at = String::new();
+    for line in raw.lines().take(4) {
+        if let Some(v) = line.strip_prefix("# Session canvas: ") {
+            session_id = v.trim().to_string();
+        } else if let Some(v) = line.strip_prefix("- created: ") {
+            created_at = v.trim().to_string();
+        }
+    }
+    let mut steps = Vec::new();
+    let mut in_table = false;
+    for line in raw.lines() {
+        if line == "| node_id | tool | step | chars | summary |" {
+            in_table = true;
+            continue;
+        }
+        if in_table {
+            if line.trim().is_empty() {
+                in_table = false;
+                continue;
+            }
+            let cols: Vec<&str> = line.trim_matches('|').split('|').map(str::trim).collect();
+            // Skip the markdown separator row (---) between header and rows.
+            if cols.len() >= 5 && cols[1].starts_with("---") {
+                continue;
+            }
+            if cols.len() >= 5 {
+                steps.push(NodeEntry {
+                    node_id: cols[0].to_string(),
+                    tool: cols[1].to_string(),
+                    step: cols[2].parse().unwrap_or(0),
+                    char_len: cols[3].parse().unwrap_or(0),
+                    summary: cols[4].to_string(),
+                });
+            }
+        }
+    }
+    if session_id.is_empty() || steps.is_empty() {
+        return None;
+    }
+    Some(Canvas {
+        mermaid: mermaid(&session_id, &steps),
+        session_id,
+        created_at,
+        steps,
+    })
+}
+
+fn is_valid_session_id(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_' || c == '.')
+}
+
+/// Estimated tokens of the compact context that replaces the raw payload.
+pub fn context_replacement_tokens(canvas: &Canvas, max_chars: usize) -> usize {
+    let mut s = String::from("session: ").to_string();
+    s.push_str(&canvas.session_id);
+    let mut budget = max_chars.saturating_sub(s.chars().count());
+    for e in &canvas.steps {
+        let line = format!("- {} {} {} ({})", e.node_id, e.tool, e.summary, e.char_len);
+        if line.chars().count() > budget {
+            break;
+        }
+        budget -= line.chars().count();
+        s.push('\n');
+        s.push_str(&line);
+    }
+    estimate_tokens(&s)
+}
+
+/// Whether a payload is considered verbose enough to offload.
+pub fn exceeds_budget(payload: &Value, budget_chars: usize) -> bool {
+    payload.to_string().chars().count() > budget_chars
+}
+
+fn now_iso8601() -> String {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| format!("{}", d.as_secs()))
+        .unwrap_or_else(|_| "0".to_string())
+}
+
+fn short_sha256(text: &str) -> String {
+    use std::fmt::Write;
+    let digest = sha256(text.as_bytes());
+    let mut s = String::with_capacity(12);
+    for b in digest.iter().take(6) {
+        let _ = write!(s, "{b:02x}");
+    }
+    s
+}
+
+/// Minimal SHA-256 (FIPS 180-4) — 12-hex content fingerprint for ref front
+/// matter; avoids pulling a crypto crate into the session module.
+fn sha256(data: &[u8]) -> [u8; 32] {
+    const K: [u32; 64] = [
+        0x428a2f98, 0x71374491, 0xb5c0fbcf, 0xe9b5dba5, 0x3956c25b, 0x59f111f1, 0x923f82a4,
+        0xab1c5ed5, 0xd807aa98, 0x12835b01, 0x243185be, 0x550c7dc3, 0x72be5d74, 0x80deb1fe,
+        0x9bdc06a7, 0xc19bf174, 0xe49b69c1, 0xefbe4786, 0x0fc19dc6, 0x240ca1cc, 0x2de92c6f,
+        0x4a7484aa, 0x5cb0a9dc, 0x76f988da, 0x983e5152, 0xa831c66d, 0xb00327c8, 0xbf597fc7,
+        0xc6e00bf3, 0xd5a79147, 0x06ca6351, 0x14292967, 0x27b70a85, 0x2e1b2138, 0x4d2c6dfc,
+        0x53380d13, 0x650a7354, 0x766a0abb, 0x81c2c92e, 0x92722c85, 0xa2bfe8a1, 0xa81a664b,
+        0xc24b8b70, 0xc76c51a3, 0xd192e819, 0xd6990624, 0xf40e3585, 0x106aa070, 0x19a4c116,
+        0x1e376c08, 0x2748774c, 0x34b0bcb5, 0x391c0cb3, 0x4ed8aa4a, 0x5b9cca4f, 0x682e6ff3,
+        0x748f82ee, 0x78a5636f, 0x84c87814, 0x8cc70208, 0x90befffa, 0xa4506ceb, 0xbef9a3f7,
+        0xc67178f2,
+    ];
+    let mut state: [u32; 8] = [
+        0x6a09e667, 0xbb67ae85, 0x3c6ef372, 0xa54ff53a, 0x510e527f, 0x9b05688c, 0x1f83d9ab,
+        0x5be0cd19,
+    ];
+    let mut msg = data.to_vec();
+    let bit_len = (msg.len() as u64).wrapping_mul(8);
+    msg.push(0x80);
+    while msg.len() % 64 != 56 {
+        msg.push(0);
+    }
+    msg.extend_from_slice(&bit_len.to_be_bytes());
+    for chunk in msg.chunks(64) {
+        let mut w = [0u32; 64];
+        for (i, word) in chunk.chunks(4).enumerate().take(16) {
+            w[i] = u32::from_be_bytes([word[0], word[1], word[2], word[3]]);
+        }
+        for i in 16..64 {
+            let s0 = w[i - 15].rotate_right(7) ^ w[i - 15].rotate_right(18) ^ (w[i - 15] >> 3);
+            let s1 = w[i - 2].rotate_right(17) ^ w[i - 2].rotate_right(19) ^ (w[i - 2] >> 10);
+            w[i] = w[i - 16]
+                .wrapping_add(s0)
+                .wrapping_add(w[i - 7])
+                .wrapping_add(s1);
+        }
+        let [mut a, mut b, mut c, mut d, mut e, mut f, mut g, mut h] = state;
+        for (i, &k) in K.iter().enumerate() {
+            let s1 = e.rotate_right(6) ^ e.rotate_right(11) ^ e.rotate_right(25);
+            let ch = (e & f) ^ (!e & g);
+            let t1 = h
+                .wrapping_add(s1)
+                .wrapping_add(ch)
+                .wrapping_add(k)
+                .wrapping_add(w[i]);
+            let s0 = a.rotate_right(2) ^ a.rotate_right(13) ^ a.rotate_right(22);
+            let maj = (a & b) ^ (a & c) ^ (b & c);
+            let t2 = s0.wrapping_add(maj);
+            h = g;
+            g = f;
+            f = e;
+            e = d.wrapping_add(t1);
+            d = c;
+            c = b;
+            b = a;
+            a = t1.wrapping_add(t2);
+        }
+        state[0] = state[0].wrapping_add(a);
+        state[1] = state[1].wrapping_add(b);
+        state[2] = state[2].wrapping_add(c);
+        state[3] = state[3].wrapping_add(d);
+        state[4] = state[4].wrapping_add(e);
+        state[5] = state[5].wrapping_add(f);
+        state[6] = state[6].wrapping_add(g);
+        state[7] = state[7].wrapping_add(h);
+    }
+    let mut out = [0u8; 32];
+    for (i, s) in state.iter().enumerate() {
+        out[i * 4..i * 4 + 4].copy_from_slice(&s.to_be_bytes());
+    }
+    out
+}
+
+/// One offload operation: write ref, update canvas, return compact context.
+/// Stateless across calls — node_id derives from the canvas on disk, so the
+/// MCP handler needs no per-session in-memory state.
+pub fn offload_step(
+    store: &SessionStore,
+    tool: &str,
+    payload: &Value,
+    budget_chars: usize,
+) -> Result<Value, String> {
+    if !exceeds_budget(payload, budget_chars) {
+        return Err("payload below offload budget; keep inline".to_string());
+    }
+    let mut canvas = store
+        .load_canvas()
+        .unwrap_or_else(|_| Canvas::new(&store.session_id));
+    let step = canvas.steps.len() + 1;
+    let node_id = node_id_for(canvas.steps.len() + 1);
+    store.write_ref(&node_id, tool, step, payload)?;
+    canvas.push(NodeEntry::new(&node_id, tool, step, &payload.to_string()));
+    store.write_canvas(&canvas)?;
+    Ok(canvas.to_compact_json())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn big_payload(n: usize) -> Value {
+        serde_json::json!({
+            "results": (0..n).map(|i| serde_json::json!({
+                "qualified_name": format!("src/mod_{i}.rs::func_{i}"),
+                "file": format!("src/mod_{i}.rs"),
+                "line": i,
+                "doc": format!("function number {i} with a fairly long description to consume tokens"),
+            })).collect::<Vec<_>>(),
+        })
+    }
+
+    fn store_in(tmp: &TempDir, session: &str) -> SessionStore {
+        SessionStore::new(session, tmp.path()).expect("store")
+    }
+
+    #[test]
+    fn writes_ref_markdown_with_frontmatter_and_json_block() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let payload = json!({"tool": "search_code", "hits": [{"name": "login", "line": 12}]});
+        let path = store
+            .write_ref("offload-001", "search_code", 3, &payload)
+            .expect("write_ref");
+        assert!(path.ends_with(".leankg/sessions/sess-001/refs/offload-001.md"));
+        let raw = std::fs::read_to_string(&path).unwrap();
+        assert!(raw.starts_with("# Ref: offload-001\n"), "header: {raw}");
+        assert!(raw.contains("- tool: search_code"));
+        assert!(raw.contains("- step: 3"));
+        assert!(raw.contains("- sha256: "));
+        assert!(raw.contains("```json\n"));
+        assert!(raw.contains("\n```\n"));
+    }
+
+    #[test]
+    fn recall_is_bit_for_bit() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let payload = big_payload(3);
+        let node_id = "offload-001";
+        store
+            .write_ref(node_id, "search_code", 1, &payload)
+            .unwrap();
+        let recalled = store.read_ref(node_id).expect("read_ref");
+        assert_eq!(recalled, payload, "recalled payload must equal original");
+    }
+
+    #[test]
+    fn recall_missing_node_errors() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let err = store.read_ref("offload-999").unwrap_err();
+        assert!(err.contains("not found"), "{err}");
+    }
+
+    #[test]
+    fn canvas_lists_steps_and_node_ids() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let mut canvas = Canvas::new("sess-001");
+        canvas.push(NodeEntry::new(
+            "offload-001",
+            "search_code",
+            1,
+            "a b c d e f g h i j k l m n",
+        ));
+        canvas.push(NodeEntry::new("offload-002", "get_context", 2, "x y z"));
+        let text = store.write_canvas(&canvas).expect("write_canvas");
+        assert!(text.contains("```mermaid"));
+        assert!(text.contains("flowchart TD"));
+        assert!(text.contains("offload-001"));
+        assert!(text.contains("| offload-002 | get_context | 2 | 5 | x y z |"));
+        assert_eq!(canvas.node_ids(), vec!["offload-001", "offload-002"]);
+        assert_eq!(canvas.mermaid, mermaid("sess-001", &canvas.steps));
+    }
+
+    #[test]
+    fn canvas_round_trip_parses() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let mut canvas = Canvas::new("sess-001");
+        canvas.push(NodeEntry::new(
+            "offload-001",
+            "search_code",
+            1,
+            "one two three four five six seven eight nine ten eleven twelve thirteen",
+        ));
+        store.write_canvas(&canvas).unwrap();
+        let parsed = store.load_canvas().expect("load_canvas");
+        assert_eq!(parsed.session_id, "sess-001");
+        assert_eq!(parsed.steps.len(), 1);
+        assert_eq!(parsed.steps[0].node_id, "offload-001");
+        assert_eq!(parsed.steps[0].tool, "search_code");
+        assert_eq!(parsed.steps[0].step, 1);
+        assert!(parsed.mermaid.contains("offload-001"));
+    }
+
+    #[test]
+    fn offload_step_keeps_compact_context_and_canvas() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let payload = big_payload(40);
+        let compact = offload_step(&store, "search_code", &payload, 2000).expect("offload");
+        assert!(compact["session_id"] == "sess-001");
+        let steps = compact["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 1);
+        assert_eq!(steps[0]["node_id"], "offload-001");
+        let canvas = store.load_canvas().unwrap();
+        assert_eq!(canvas.steps.len(), 1);
+        // drill-down recovers the original payload
+        assert_eq!(store.read_ref("offload-001").unwrap(), payload);
+    }
+
+    #[test]
+    fn offload_is_stateless_and_node_ids_are_stable_across_calls() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let p1 = big_payload(30);
+        let p2 = big_payload(25);
+        let c1 = offload_step(&store, "search_code", &p1, 2000).expect("first offload");
+        assert_eq!(c1["steps"][0]["node_id"], "offload-001");
+        let c2 = offload_step(&store, "get_context", &p2, 2000).expect("second offload");
+        let steps = c2["steps"].as_array().unwrap();
+        assert_eq!(steps.len(), 2);
+        assert_eq!(steps[1]["node_id"], "offload-002");
+        assert_eq!(steps[1]["tool"], "get_context");
+        assert_eq!(store.read_ref("offload-002").unwrap(), p2);
+    }
+
+    #[test]
+    fn small_payload_stays_inline() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let err = offload_step(&store, "search_code", &json!({"ok": true}), 2000).unwrap_err();
+        assert!(err.contains("below offload budget"), "{err}");
+        // nothing written, no canvas
+        assert!(store.load_canvas().is_err());
+    }
+
+    #[test]
+    fn fixture_offloaded_context_drops_30_percent_tokens() {
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-fixture");
+        let payloads = vec![
+            big_payload(50),
+            big_payload(60),
+            big_payload(70),
+            big_payload(55),
+        ];
+        let mut inline_chars = 0usize;
+        let mut compact_chars = 0usize;
+        for p in payloads.iter() {
+            let s = p.to_string();
+            inline_chars += s.chars().count();
+            let compact = offload_step(&store, "search_code", p, 2000).expect("offload");
+            compact_chars += compact.to_string().chars().count();
+        }
+        let inline_tokens = estimate_tokens(&format!("prefix {}", "x".repeat(inline_chars)));
+        let compact_tokens = estimate_tokens(&format!("prefix {}", "x".repeat(compact_chars)));
+        let drop = (inline_tokens as f64 - compact_tokens as f64) / inline_tokens as f64;
+        assert!(
+            drop >= 0.30,
+            "token drop {drop:.2} must be >= 0.30 (inline {inline_tokens}, compact {compact_tokens})"
+        );
+    }
+
+    #[test]
+    fn node_id_scheme_is_stable_and_validated() {
+        assert_eq!(node_id_for(1), "offload-001");
+        assert_eq!(node_id_for(42), "offload-042");
+        let tmp = TempDir::new().unwrap();
+        let store = store_in(&tmp, "sess-001");
+        let err = store.write_ref("../evil", "t", 1, &json!(1)).unwrap_err();
+        assert!(err.contains("invalid node_id"), "{err}");
+        assert!(SessionStore::new("../evil", tmp.path()).is_err());
+    }
+}

--- a/tests/mcp_tools_redundancy_tests.rs
+++ b/tests/mcp_tools_redundancy_tests.rs
@@ -142,6 +142,7 @@ fn every_tested_tool_is_registered() {
         "get_service_context",
         "get_team_map",
         "get_upcoming_changes",
+        "session_recall",
         "kg_concept_map",
         "kg_context",
         "kg_ontology_status",
@@ -358,6 +359,74 @@ mod agent {
         .expect("report_query_outcome");
         // The handler returns {recorded: true}; accept any non-empty payload.
         assert!(!report.to_string().is_empty());
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Session memory offload (US-SM-01 / FR-SM-01..03)
+// ---------------------------------------------------------------------------
+
+mod session_offload {
+    use super::*;
+    use leankg::session::{offload_step, SessionStore};
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn offload_then_recall_via_mcp_round_trips() {
+        let (handler, tmp) = make_handler().await;
+        let project = tmp.path().to_string_lossy().to_string();
+        let payload: Value = serde_json::from_str(
+            r#"{"tool":"search_code","hits":[
+                {"qualified_name":"src/auth/mod.rs::login","file":"src/auth/mod.rs","line":10},
+                {"qualified_name":"src/auth/mod.rs::verify_token","file":"src/auth/mod.rs","line":31}
+            ]}"#,
+        )
+        .unwrap();
+
+        // Offload through the lib seam (writes ref + canvas under <tmp>/.leankg/sessions).
+        let store = SessionStore::new("sess-mcp-1", tmp.path()).expect("store");
+        let compact = offload_step(&store, "search_code", &payload, 100).expect("offload");
+        assert_eq!(compact["steps"][0]["node_id"], "offload-001");
+
+        // session_recall via the MCP dispatch must return the exact payload.
+        let recalled = call(
+            &handler,
+            "session_recall",
+            json!({
+                "node_id": "offload-001",
+                "session_id": "sess-mcp-1",
+                "project": &project
+            }),
+        )
+        .await
+        .expect("session_recall");
+        assert_eq!(recalled["node_id"], "offload-001");
+        assert_eq!(recalled["session_id"], "sess-mcp-1");
+        assert_eq!(recalled["payload"], payload, "bit-for-bit recall");
+        assert!(
+            recalled["ref_file"]
+                .as_str()
+                .unwrap_or("")
+                .contains("refs/offload-001.md"),
+            "ref file path: {recalled}"
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn session_recall_missing_node_errors() {
+        let (handler, tmp) = make_handler().await;
+        let project = tmp.path().to_string_lossy().to_string();
+        let err = call(
+            &handler,
+            "session_recall",
+            json!({
+                "node_id": "offload-999",
+                "session_id": "sess-mcp-1",
+                "project": &project
+            }),
+        )
+        .await
+        .expect_err("missing node must error");
+        assert!(err.contains("not found"), "{err}");
     }
 }
 


### PR DESCRIPTION
## PR-20 — Session memory offload (US-SM-01 / FR-SM-01..03 / REL-075)

Campaign: `docs/planning/2026-08-01-all-open-prd-campaign.md`

### What

- NEW `src/session/` — session memory offload:
  - `SessionStore` persists verbose MCP/tool payloads to `.leankg/sessions/<id>/refs/<node_id>.md` (FR-SM-01), markdown per node with sha256 front-matter fingerprint
  - `canvas.md` = Mermaid flowchart + node index table (FR-SM-02)
  - stable `offload-<NNN>` node_id scheme; stateless `offload_step` (node_id derives from canvas on disk — no in-memory session state in the MCP handler)
- MCP `session_recall(node_id, session_id, project)` — tool def in `src/mcp/tools.rs` + thin dispatch arm in `src/mcp/handler.rs`; returns original payload bit-for-bit (FR-SM-03)
- No auto-recall (PR-21), no ontology YAML mutation, no tracker edits (conductor owns tracker)

### Acceptance (US-SM-01)

| AC | Result |
|----|--------|
| Offload trigger writes `.leankg/sessions/<id>/refs/<node_id>.md` + canvas | PASS |
| `session_recall` returns original payload bit-for-bit | PASS (unit + MCP integration + live) |
| Token drop >= 30% on multi-tool fixture | PASS — **96.5%** (inline 8951 tok → compact 315 tok) |
| Live smoke | PASS — new-binary MCP on :9876 (Docker :9699 serves old binary, 89 tools, no `session_recall`; documented SKIPPED for :9699) |

### Gates

- `cargo fmt --all -- --check` PASS
- `cargo clippy --all -- -D warnings` PASS (0)
- `cargo test --lib` PASS — 754 passed, 0 failed
- `cargo test session` PASS — 10 unit + 2 integration
- `cargo build --release` PASS

### Evidence

- `docs/reports/rel-075-session-offload-2026-08-02.md` (REL-075 PARTIAL → DONE)
- `src/session/mod.rs` (10 unit tests), `tests/mcp_tools_redundancy_tests.rs` (`session_offload` module)

### Checklist

- [x] Docs first (analysis + PRD existed; this PR adds mcp-tools.md row + report)
- [x] TDD per seam (failing test → minimal code)
- [x] fmt / clippy / lib / session gates green
- [x] Live evidence report under docs/reports/
- [x] Commit: conventional, no AI attribution
- [x] No tracker edits (conductor flips US-SM-01/FR-SM-01..03/REL-075 to DONE after merge)
- [ ] Tracker IDs US-SM-01 / FR-SM-01..03 / REL-075 → DONE (post-merge, conductor)