### PR TITLE
feat(mining): mine-conversations CLI for Claude/ChatGPT/Slack (US-MP-03)

### DIFF
--- a/docs/conversation-mining.md
+++ b/docs/conversation-mining.md
@@ -1,0 +1,85 @@
+# Conversation Mining (`mine-conversations`)
+
+**IDs:** US-MP-03 / FR-MP-09..13 — MemPalace-inspired conversation mining.
+
+Mines conversation exports (Claude, ChatGPT, Slack) into typed graph
+elements, then persists them into the project's LeanKG graph. Raw verbatim
+text is stored — no summarization.
+
+## Usage
+
+```bash
+leankg mine-conversations --format <claude|chatgpt|slack> --project <path> --input <file-or-dir>
+```
+
+| Flag | Meaning |
+|------|---------|
+| `--format` | Export format: `claude`, `chatgpt`, or `slack` (required) |
+| `--project` | Project root whose `.leankg/` graph receives the mined nodes (default `.`) |
+| `--input` | Single export JSON file or a directory of export JSON files |
+
+`--input` may be a file (one export) or a directory (every `*.json` in it
+is attempted; files whose shape doesn't match the format are skipped with a
+warning). Re-running on the same input is idempotent: nodes keyed by
+qualified name, so duplicates collapse.
+
+## What gets mined
+
+Each message is classified by a deterministic keyword classifier into one
+of:
+
+| Element type | Signals |
+|--------------|---------|
+| `decision` | "decision:", "we decided", "we will", "we should" |
+| `preference` | "preference:", "prefer", "preferred", "would like" |
+| `milestone` | "milestone:", "goal", "deadline", "by end of" |
+| `problem` | "problem:", "fails", "timeout", "broken", "error" |
+
+Unmatched messages are skipped (no noise nodes). Mined nodes use the
+qualified-name shape:
+
+```
+conversations/<project>/<kind>/<topic-slug>
+```
+
+with raw verbatim, source format, participants, and timestamp stored in
+`metadata.verbatim` / `.source` / `.participants` / `.timestamp`.
+
+## `decided_about` edges
+
+When a mined `decision` message names code targets — backtick-quoted
+paths, inline `file::symbol` (`src/gateway.rs::handle_auth`), or bare
+`src/...` paths — the decision node is linked to each target via a
+`decided_about` relationship (confidence 1.0, `confidence_label:
+EXTRACTED`).
+
+## Example
+
+```bash
+$ leankg mine-conversations --format claude --project . --input ~/chats/
+Mined 3 items from 1 source(s) [decision, preference]: 3 elements, 1 relationships
+  [decision] conversations/leankg/decision/rs256: Decision: adopt RS256 JWT in src/gateway.rs::handle_auth
+  [preference] conversations/leankg/preference/async: prefer async/await style in the new handlers
+Done.
+```
+
+## Supported export shapes
+
+- **Claude:** `{ "conversations": [ { "messages": [ { role, content:
+  string | [{ type: "text", text }] } ] } ] }`
+- **ChatGPT:** `{ "mapping": { "<id>": { "message": { author.role,
+  content.parts[] } } } }` (nested `mapping` subtrees walked recursively)
+- **Slack:** channel export `{ "channel": {...}, "messages": [ { user,
+  ts, text } ] }`
+
+## Module layout
+
+- `src/conversation_indexer/mod.rs` — mining orchestration + CLI entry
+- `src/conversation_indexer/parsers.rs` — per-format export JSON parsers
+- `src/conversation_indexer/types.rs` — `MinedItem` model, classifier,
+  `decided_about` edge building
+- `tests/conversation_mining_tests.rs` — TDD seams 1–4
+- `tests/fixtures/conversations/` — one fixture export per format
+
+Persistence reuses `GraphEngine::insert_elements` / `insert_relationships`;
+no new schema tables.

--- a/docs/reports/conversation-mining-2026-08-01.md
+++ b/docs/reports/conversation-mining-2026-08-01.md
@@ -1,0 +1,83 @@
+# Conversation mining live evidence — 2026-08-01
+
+## Environment
+
+- leankg: `prd/conversation-mining` branch (worktree), release build `cargo build --release`
+- Storage: CozoDB sqlite in a `mktemp -d` TempDir project (`.leankg/leankg.db`)
+- CLI: `./target/release/leankg mine-conversations`
+
+## Steps
+
+1. Built release binary with the new `MineConversations` subcommand.
+2. Created TempDir project `tmp.*/proj` with `.leankg/`.
+3. Copied one fixture export per format (`tests/fixtures/conversations/`).
+4. Ran `mine-conversations` for claude, slack, chatgpt (file + directory input).
+5. Mined a decision naming `src/gateway.rs::handle_auth` and verified the
+   `decided_about` edge in the exported graph and via `query --kind name`.
+
+## Results
+
+### Claude (single file)
+
+```
+Mined 3 items from 1 source(s) [decision, preference]: 3 elements, 0 relationships
+  [decision] conversations/proj/decision/recommend: I recommend JWT with refresh tokens. We should go with RS256 for signing.
+  [decision] conversations/proj/decision/rs256: OK, decision: we adopt RS256 JWT for the gateway auth service.
+  [preference] conversations/proj/preference/good: Good. Also noting a preference: prefer async/await style in the new handlers.
+Done.
+```
+
+### Slack (single file)
+
+```
+Mined 3 items from 1 source(s) [decision, preference, problem]: 3 elements, 0 relationships
+  [decision] conversations/proj/decision/will: Decision: we will use gRPC for inter-service communication.
+  [problem] conversations/proj/problem/batch: Problem: the batch job keeps timing out at 5 minutes.
+  [preference] conversations/proj/preference/protobuf: Preference: prefer protobuf over JSON for internal APIs.
+Done.
+```
+
+### ChatGPT (directory input, non-matching files skipped)
+
+```
+[mine-conversations] skipping .../claude_export.json: ...: not a ChatGPT export: missing field `mapping`
+[mine-conversations] skipping .../slack_export.json: ...: not a ChatGPT export: missing field `mapping`
+Mined 2 items from 1 source(s) [decision, milestone]: 2 elements, 0 relationships
+  [decision] conversations/proj/decision/should: We should migrate the storage layer to PostgreSQL.
+Done.
+```
+
+### decided_about edge (decision naming a code target)
+
+Mine output: `Mined 1 item from 1 source(s) [decision]: 1 elements, 2 relationships`
+
+Graph export (`leankg export --format json`):
+
+```
+decided_about edges: 1
+  conversations/proj/decision/rs256 -> src/gateway.rs::handle_auth
+```
+
+Query (`leankg query --kind name RS256`):
+
+```
+Found 2 element(s) with name 'RS256':
+  - RS256 (decision:1 1)
+    File: conversations/claude/decision
+```
+
+## Pass/Fail vs AC
+
+| AC | Result |
+|----|--------|
+| FR-MP-09 claude parser | PASS — 3 items mined from fixture |
+| FR-MP-10 chatgpt parser | PASS — 2 items mined, nested mapping walked |
+| FR-MP-11 slack parser | PASS — 3 items mined |
+| FR-MP-12 typed extraction | PASS — decision/preference/milestone/problem element types persisted |
+| FR-MP-13 CLI flags | PASS — `--format` / `--project` / `--input` all honored |
+| US-MP-03 decided_about | PASS — edge verified live `decision -> src/gateway.rs::handle_auth` |
+
+## Tracker
+
+- Mark `US-MP-03`, `FR-MP-09`, `FR-MP-10`, `FR-MP-11`, `FR-MP-12`, `FR-MP-13`
+  DONE after merge.

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -190,6 +190,21 @@ pub enum CLICommand {
         #[arg(long)]
         out: Option<String>,
     },
+    /// US-MP-03 / FR-MP-09..13: Mine conversation exports (Claude / ChatGPT
+    /// / Slack) into decisions, preferences, milestones, and problems, then
+    /// persist them into the project graph as typed elements with
+    /// `decided_about` edges.
+    MineConversations {
+        /// Export format: claude | chatgpt | slack
+        #[arg(long, value_parser = ["claude", "chatgpt", "slack"])]
+        format: String,
+        /// Project root whose `.leankg` graph receives the mined nodes
+        #[arg(long, default_value = ".")]
+        project: String,
+        /// Input file or directory of export JSON files
+        #[arg(long)]
+        input: String,
+    },
     /// US-MP-05: Check graph for broken / stale links
     CheckConsistency {
         /// Filter by severity: BROKEN | STALE | CURRENT

--- a/src/conversation_indexer/mod.rs
+++ b/src/conversation_indexer/mod.rs
@@ -1,0 +1,190 @@
+//! Conversation mining (US-MP-03 / FR-MP-09..13).
+//!
+//! Parses Claude / ChatGPT / Slack export JSON into typed `MinedItem`s
+//! (decision / preference / milestone / problem) and persists them into the
+//! graph as `decision` / `preference` / `milestone` / `problem` element
+//! types with a `decided_about` edge from decision nodes to code elements.
+//! Raw verbatim text is stored — no summarization.
+//!
+//! Design (ponytail): parsers stay format-local and produce a flat list of
+//! `RawMessage { participant, timestamp, text }`. A single shared
+//! `classify()` + keyword extractor turns messages into `MinedItem`s, so
+//! all three formats get identical mining semantics for free. Persistence
+//! reuses `GraphEngine::insert_elements` / `insert_relationships` — no new
+//! schema tables.
+
+mod parsers;
+mod types;
+
+use crate::graph::GraphEngine;
+use parsers::{parse_chatgpt_export, parse_claude_export, parse_slack_export, RawMessage};
+#[allow(unused_imports)] // re-exported for external callers (tests / CLI)
+pub use types::{MinedItem, MinedItemKind, MiningResult};
+
+use std::path::{Path, PathBuf};
+
+/// Export format selector for `leankg mine-conversations --format`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConversationFormat {
+    Claude,
+    ChatGpt,
+    Slack,
+    Unknown,
+}
+
+impl ConversationFormat {
+    /// Parse a `--format` CLI value ("claude" | "chatgpt" | "slack").
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Self {
+        match s.to_ascii_lowercase().as_str() {
+            "claude" => Self::Claude,
+            "chatgpt" => Self::ChatGpt,
+            "slack" => Self::Slack,
+            _ => Self::Unknown,
+        }
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Claude => "claude",
+            Self::ChatGpt => "chatgpt",
+            Self::Slack => "slack",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+/// Extract raw messages from a single export file in the given format.
+fn parse_file(path: &Path, format: ConversationFormat) -> Result<Vec<RawMessage>, String> {
+    let content = std::fs::read_to_string(path)
+        .map_err(|e| format!("cannot read {}: {}", path.display(), e))?;
+    let raw = match format {
+        ConversationFormat::Claude => parse_claude_export(&content),
+        ConversationFormat::ChatGpt => parse_chatgpt_export(&content),
+        ConversationFormat::Slack => parse_slack_export(&content),
+        ConversationFormat::Unknown => {
+            return Err("unknown format; use --format claude|chatgpt|slack".to_string());
+        }
+    }
+    .map_err(|e| format!("{}: {}", path.display(), e))?;
+    Ok(raw)
+}
+
+fn is_export_file(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("json")
+}
+
+/// Mine a single file (fixture / CLI --input file).
+pub fn mine_file(path: &Path, format: ConversationFormat) -> Result<Vec<MinedItem>, String> {
+    let messages = parse_file(path, format)?;
+    Ok(messages
+        .into_iter()
+        .filter_map(MinedItem::from_message)
+        .collect())
+}
+
+/// Mine a directory of exports (CLI --input dir). Only files whose shape
+/// matches the format's root keys are parsed; files of other formats are
+/// skipped with a warning. `sources` counts parsed files.
+pub fn mine_directory(dir: &Path, format: ConversationFormat) -> Result<MiningResult, String> {
+    let mut all_items = Vec::new();
+    let mut sources = 0usize;
+
+    if dir.is_file() {
+        let items = mine_file(dir, format)?;
+        sources = 1;
+        all_items.extend(items);
+        return Ok(MiningResult {
+            items: all_items,
+            sources,
+            elements_indexed: 0,
+            relationships_created: 0,
+        });
+    }
+
+    if !dir.exists() {
+        return Err(format!("input path not found: {}", dir.display()));
+    }
+
+    let mut entries: Vec<PathBuf> = std::fs::read_dir(dir)
+        .map_err(|e| format!("cannot read {}: {}", dir.display(), e))?
+        .filter_map(|e| e.ok().map(|e| e.path()))
+        .filter(|p| p.is_file() && is_export_file(p))
+        .collect();
+    entries.sort();
+
+    for path in entries {
+        match parse_file(&path, format) {
+            Ok(messages) => {
+                sources += 1;
+                all_items.extend(messages.into_iter().filter_map(MinedItem::from_message));
+            }
+            Err(e) => {
+                eprintln!("[mine-conversations] skipping {}: {}", path.display(), e);
+            }
+        }
+    }
+
+    Ok(MiningResult {
+        items: all_items,
+        sources,
+        elements_indexed: 0,
+        relationships_created: 0,
+    })
+}
+
+/// Persist mined items into the project's graph (CLI entry point).
+pub fn mine_into_project(
+    project: &Path,
+    input: &Path,
+    format: ConversationFormat,
+) -> Result<MiningResult, Box<dyn std::error::Error>> {
+    let mut result = mine_directory(input, format)?;
+    if result.items.is_empty() {
+        return Ok(result);
+    }
+    let persisted = index_items_into(project, result.items.clone())?;
+    result.elements_indexed = persisted.elements_indexed;
+    result.relationships_created = persisted.relationships_created;
+    Ok(result)
+}
+
+fn index_items_into(
+    project: &Path,
+    items: Vec<MinedItem>,
+) -> Result<MiningResult, Box<dyn std::error::Error>> {
+    let db_path = project.join(".leankg");
+    let db = crate::db::schema::init_db(&db_path)?;
+    let graph = GraphEngine::new(db);
+    index_items(&graph, project, items)
+}
+
+/// Public seam (tested directly): insert mined items into an open graph.
+pub fn index_items(
+    graph: &GraphEngine,
+    project: &Path,
+    items: Vec<MinedItem>,
+) -> Result<MiningResult, Box<dyn std::error::Error>> {
+    let mut elements = Vec::new();
+    let mut relationships = Vec::new();
+
+    for item in &items {
+        let (element, rels) = item.to_graph_elements(project);
+        elements.push(element);
+        relationships.extend(rels);
+    }
+
+    if !elements.is_empty() {
+        graph.insert_elements(&elements)?;
+    }
+    if !relationships.is_empty() {
+        graph.insert_relationships(&relationships)?;
+    }
+
+    Ok(MiningResult {
+        items,
+        sources: 0,
+        elements_indexed: elements.len(),
+        relationships_created: relationships.len(),
+    })
+}

--- a/src/conversation_indexer/parsers.rs
+++ b/src/conversation_indexer/parsers.rs
@@ -1,0 +1,198 @@
+//! Format-specific export JSON parsers (FR-MP-09 / FR-MP-10 / FR-MP-11).
+//!
+//! Each parser normalizes its format's shape into `RawMessage` records;
+//! classification lives in `types.rs` so mining semantics are shared.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// Normalized message record shared by all three parsers.
+#[derive(Debug, Clone)]
+pub struct RawMessage {
+    pub participant: String,
+    pub timestamp: String,
+    pub text: String,
+    pub source: String,
+}
+
+fn extract_text_parts(value: &Value) -> String {
+    // Claude: content is either a string, or an array of blocks with "text".
+    // ChatGPT: content is an object { content_type, parts: [String] }.
+    match value {
+        Value::String(s) => s.clone(),
+        Value::Array(blocks) => {
+            let mut out = Vec::new();
+            for block in blocks {
+                if let Some(text) = block.get("text").and_then(|t| t.as_str()) {
+                    out.push(text.to_string());
+                }
+            }
+            out.join("\n")
+        }
+        Value::Object(map) => {
+            if let Some(parts) = map.get("parts").and_then(|p| p.as_array()) {
+                let mut out = Vec::new();
+                for part in parts {
+                    if let Some(s) = part.as_str() {
+                        out.push(s.to_string());
+                    }
+                }
+                return out.join("\n");
+            }
+            map.get("text")
+                .and_then(|t| t.as_str())
+                .unwrap_or("")
+                .to_string()
+        }
+        _ => String::new(),
+    }
+}
+
+// ---------------------------------------------------------------- Claude
+
+#[derive(Deserialize)]
+struct ClaudeExport {
+    conversations: Vec<ClaudeConversation>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeConversation {
+    messages: Vec<ClaudeMessage>,
+}
+
+#[derive(Deserialize)]
+struct ClaudeMessage {
+    role: Option<String>,
+    text: Option<String>,
+    content: Option<Value>,
+}
+
+/// Claude export: `{ "conversations": [ { "messages": [ { role, content } ] } ] }`.
+pub fn parse_claude_export(content: &str) -> Result<Vec<RawMessage>, String> {
+    let export: ClaudeExport =
+        serde_json::from_str(content).map_err(|e| format!("not a Claude export: {e}"))?;
+    let mut out = Vec::new();
+    for conv in export.conversations {
+        for msg in conv.messages {
+            let text = match (&msg.text, &msg.content) {
+                (Some(t), _) => t.clone(),
+                (None, Some(c)) => extract_text_parts(c),
+                (None, None) => String::new(),
+            };
+            out.push(RawMessage {
+                participant: msg.role.unwrap_or_else(|| "user".to_string()),
+                timestamp: String::new(),
+                text,
+                source: "claude".to_string(),
+            });
+        }
+    }
+    Ok(out)
+}
+
+// ---------------------------------------------------------------- ChatGPT
+
+#[derive(Deserialize)]
+struct ChatGptExport {
+    mapping: std::collections::BTreeMap<String, ChatGptNode>,
+}
+
+#[derive(Deserialize)]
+struct ChatGptNode {
+    #[serde(default)]
+    message: Option<ChatGptMessage>,
+    #[serde(default)]
+    mapping: Option<std::collections::BTreeMap<String, ChatGptNode>>,
+}
+
+#[derive(Deserialize)]
+struct ChatGptMessage {
+    author: Option<ChatGptAuthor>,
+    #[serde(default)]
+    content: Option<Value>,
+}
+
+#[derive(Deserialize)]
+struct ChatGptAuthor {
+    #[serde(default)]
+    role: Option<String>,
+}
+
+/// ChatGPT export: `{ "mapping": { "<id>": { "message": { author.role,
+/// content.parts[] } } } }`. Nested `mapping` subtrees (conversation nodes
+/// that wrap child nodes) are walked recursively.
+pub fn parse_chatgpt_export(content: &str) -> Result<Vec<RawMessage>, String> {
+    let export: ChatGptExport =
+        serde_json::from_str(content).map_err(|e| format!("not a ChatGPT export: {e}"))?;
+    let mut out = Vec::new();
+    collect_chatgpt_nodes(&export.mapping, &mut out);
+    Ok(out)
+}
+
+fn collect_chatgpt_nodes(
+    nodes: &std::collections::BTreeMap<String, ChatGptNode>,
+    out: &mut Vec<RawMessage>,
+) {
+    for node in nodes.values() {
+        if let Some(msg) = &node.message {
+            if let Some(content) = msg.content.as_ref() {
+                let text = extract_text_parts(content);
+                if !text.trim().is_empty() {
+                    out.push(RawMessage {
+                        participant: msg
+                            .author
+                            .as_ref()
+                            .and_then(|a| a.role.clone())
+                            .unwrap_or_else(|| "user".to_string()),
+                        timestamp: String::new(),
+                        text,
+                        source: "chatgpt".to_string(),
+                    });
+                }
+            }
+        }
+        if let Some(nested) = &node.mapping {
+            collect_chatgpt_nodes(nested, out);
+        }
+    }
+}
+
+// ---------------------------------------------------------------- Slack
+
+#[derive(Deserialize)]
+struct SlackExport {
+    #[serde(default)]
+    #[allow(dead_code)] // shape marker: distinguishes Slack channel exports
+    channel: Option<Value>,
+    messages: Vec<SlackMessage>,
+}
+
+#[derive(Deserialize)]
+struct SlackMessage {
+    #[serde(default)]
+    r#type: Option<String>,
+    #[serde(default)]
+    user: Option<String>,
+    #[serde(default)]
+    text: Option<String>,
+}
+
+/// Slack channel export: `{ "channel": {...}, "messages": [ { user, ts,
+/// text } ] }`. Works for both full channel files and files.json-style
+/// single-message objects that wrap a `message` field.
+pub fn parse_slack_export(content: &str) -> Result<Vec<RawMessage>, String> {
+    let export: SlackExport =
+        serde_json::from_str(content).map_err(|e| format!("not a Slack export: {e}"))?;
+    let mut out = Vec::new();
+    for msg in export.messages {
+        if msg.r#type.as_deref() == Some("message") || msg.text.is_some() {
+            out.push(RawMessage {
+                participant: msg.user.unwrap_or_else(|| "unknown".to_string()),
+                timestamp: String::new(),
+                text: msg.text.unwrap_or_default(),
+                source: "slack".to_string(),
+            });
+        }
+    }
+    Ok(out)
+}

--- a/src/conversation_indexer/types.rs
+++ b/src/conversation_indexer/types.rs
@@ -1,0 +1,325 @@
+//! Mined item model + classification (FR-MP-12).
+
+use crate::db::models::{CodeElement, Relationship};
+use std::path::Path;
+
+/// Mined conversation item kind (element type in the graph).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MinedItemKind {
+    Decision,
+    Preference,
+    Milestone,
+    Problem,
+    General,
+}
+
+impl MinedItemKind {
+    /// Deterministic keyword classifier over a raw message. Prefix labels
+    /// ("decision:", "preference:", ...) win; otherwise problem phrases
+    /// first (most specific), then decision / milestone / preference
+    /// keyword heuristics. Falls back to `General`.
+    pub fn classify(text: &str) -> Self {
+        let t = text.trim();
+        let lower = t.to_ascii_lowercase();
+
+        // Explicit labels
+        for (label, kind) in [
+            ("decision:", Self::Decision),
+            ("preference:", Self::Preference),
+            ("milestone:", Self::Milestone),
+            ("problem:", Self::Problem),
+        ] {
+            if lower.starts_with(label) {
+                return kind;
+            }
+        }
+
+        // Problem signals (verb-first, passive failure phrasing)
+        if [
+            "fails",
+            "failure",
+            "broken",
+            "bug",
+            "timeout",
+            "crashes",
+            "error",
+            "timing out",
+            "stuck",
+            "keeps",
+        ]
+        .iter()
+        .any(|k| lower.contains(k))
+        {
+            return Self::Problem;
+        }
+
+        // Decision signals
+        if [
+            "we decided",
+            "decision",
+            "we will",
+            "we should",
+            "we are going to",
+            "let's use",
+        ]
+        .iter()
+        .any(|k| lower.contains(k))
+        {
+            return Self::Decision;
+        }
+
+        // Milestone signals
+        if [
+            "milestone",
+            "goal",
+            "deadline",
+            "by end of",
+            "target date",
+            "ship by",
+            "by q",
+        ]
+        .iter()
+        .any(|k| lower.contains(k))
+        {
+            return Self::Milestone;
+        }
+
+        // Preference signals
+        if [
+            "prefer",
+            "preference",
+            "preferred",
+            "rather use",
+            "would like",
+        ]
+        .iter()
+        .any(|k| lower.contains(k))
+        {
+            return Self::Preference;
+        }
+
+        Self::General
+    }
+
+    pub fn as_str(&self) -> &'static str {
+        match self {
+            Self::Decision => "decision",
+            Self::Preference => "preference",
+            Self::Milestone => "milestone",
+            Self::Problem => "problem",
+            Self::General => "general",
+        }
+    }
+}
+
+/// A mined conversation item. Raw verbatim is stored — no summarization.
+#[derive(Debug, Clone)]
+pub struct MinedItem {
+    pub kind: MinedItemKind,
+    pub verbatim: String,
+    pub source: String,
+    pub participants: Vec<String>,
+    pub timestamp: String,
+    pub topic: String,
+    pub code_targets: Vec<String>,
+}
+
+/// Deterministic topic extractor: first identifier-ish token set (e.g.
+/// "RS256", "JWT", "gRPC", "PostgreSQL"). Used for the node `name`.
+fn extract_topic(text: &str) -> String {
+    let stopwords = [
+        "decision",
+        "preference",
+        "milestone",
+        "problem",
+        "adopt",
+        "use",
+        "switch",
+        "migrate",
+        "prefer",
+        "go",
+        "pick",
+        "choose",
+        "we",
+        "the",
+        "our",
+        "new",
+        "for",
+        "with",
+        "and",
+    ];
+    for token in text.split(|c: char| !c.is_alphanumeric() && c != '_') {
+        let t = token.trim();
+        let lower = t.to_ascii_lowercase();
+        if t.len() >= 3 && !stopwords.contains(&lower.as_str()) {
+            return t.to_string();
+        }
+    }
+    text.chars().take(40).collect()
+}
+
+/// Deterministic code-target extraction: backtick-quoted paths, inline
+/// `file::symbol` patterns, and bare `src/...` paths inside the text.
+fn extract_code_targets(text: &str) -> Vec<String> {
+    use regex::Regex;
+
+    let mut targets = Vec::new();
+
+    let backtick = Regex::new(r"`([^`]+)`").unwrap();
+    for cap in backtick.captures_iter(text) {
+        if let Some(m) = cap.get(1) {
+            targets.push(m.as_str().to_string());
+        }
+    }
+
+    let file_symbol =
+        Regex::new(r"\b([A-Za-z0-9_\-./]+\.(?:rs|go|ts|js|py|java|kt))::([A-Za-z0-9_]+)\b")
+            .unwrap();
+    for cap in file_symbol.captures_iter(text) {
+        let full = format!("{}::{}", &cap[1], &cap[2]);
+        if !targets.contains(&full) {
+            targets.push(full);
+        }
+    }
+
+    let src_path = Regex::new(r"\bsrc/[A-Za-z0-9_\-./]+\.(?:rs|go|ts|js|py|java|kt)\b").unwrap();
+    for m in src_path.find_iter(text) {
+        let s = m.as_str().to_string();
+        if !targets.contains(&s) {
+            targets.push(s);
+        }
+    }
+
+    targets
+}
+
+impl MinedItem {
+    /// Build a mined item from one raw message; `None` when the message is
+    /// not classifiable.
+    pub fn from_message(message: crate::conversation_indexer::parsers::RawMessage) -> Option<Self> {
+        let text = message.text.trim().to_string();
+        if text.is_empty() {
+            return None;
+        }
+        let kind = MinedItemKind::classify(&text);
+        if kind == MinedItemKind::General {
+            return None;
+        }
+        let topic = extract_topic(&text);
+        let code_targets = extract_code_targets(&text);
+        Some(Self {
+            kind,
+            verbatim: text,
+            source: message.source,
+            participants: vec![message.participant],
+            timestamp: message.timestamp,
+            topic,
+            code_targets,
+        })
+    }
+
+    /// Qualified name of this item's graph node.
+    pub fn qualified_name(&self, project: &Path) -> String {
+        let project_name = project
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("project");
+        let slug: String = self
+            .topic
+            .chars()
+            .map(|c| {
+                if c.is_alphanumeric() {
+                    c.to_ascii_lowercase()
+                } else {
+                    '_'
+                }
+            })
+            .collect();
+        format!(
+            "conversations/{project_name}/{}/{}",
+            self.kind.as_str(),
+            slug
+        )
+    }
+
+    /// Element + relationships for the graph. Decision nodes link to code
+    /// targets via `decided_about`; other kinds point back at the decision
+    /// context only when a decision exists (handled by the caller).
+    pub fn to_graph_elements(&self, project: &Path) -> (CodeElement, Vec<Relationship>) {
+        let qn = self.qualified_name(project);
+        let element = CodeElement {
+            qualified_name: qn.clone(),
+            element_type: self.kind.as_str().to_string(),
+            name: self.topic.clone(),
+            file_path: format!("conversations/{}/{}", self.source, self.kind.as_str()),
+            line_start: 1,
+            line_end: 1,
+            language: "conversation".to_string(),
+            parent_qualified: None,
+            metadata: serde_json::json!({
+                "kind": self.kind.as_str(),
+                "verbatim": self.verbatim,
+                "source": self.source,
+                "participants": self.participants,
+                "timestamp": self.timestamp,
+                "topic": self.topic,
+            }),
+            ..Default::default()
+        };
+
+        let mut relationships = Vec::new();
+        if self.kind == MinedItemKind::Decision {
+            for target in &self.code_targets {
+                relationships.push(Relationship {
+                    id: None,
+                    source_qualified: qn.clone(),
+                    target_qualified: target.clone(),
+                    rel_type: "decided_about".to_string(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({
+                        "verbatim": self.verbatim,
+                        "confidence_label": "EXTRACTED",
+                    }),
+                    ..Default::default()
+                });
+            }
+        }
+
+        (element, relationships)
+    }
+}
+
+/// Aggregated result of a mining run.
+#[derive(Debug, Clone)]
+pub struct MiningResult {
+    pub items: Vec<MinedItem>,
+    pub sources: usize,
+    pub elements_indexed: usize,
+    pub relationships_created: usize,
+}
+
+impl MiningResult {
+    pub fn summary(&self) -> String {
+        let mut kinds: Vec<String> = self
+            .items
+            .iter()
+            .map(|i| i.kind.as_str().to_string())
+            .collect();
+        kinds.sort();
+        kinds.dedup();
+        let item_word = if self.items.len() == 1 {
+            "item"
+        } else {
+            "items"
+        };
+        format!(
+            "Mined {} {} from {} source(s) [{}]: {} elements, {} relationships",
+            self.items.len(),
+            item_word,
+            self.sources,
+            kinds.join(", "),
+            self.elements_indexed,
+            self.relationships_created
+        )
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,7 @@ pub mod budget;
 pub mod cli;
 pub mod compress;
 pub mod config;
+pub mod conversation_indexer;
 pub mod db;
 pub mod doc;
 pub mod doc_indexer;

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@ mod budget;
 mod cli;
 mod compress;
 mod config;
+mod conversation_indexer;
 mod db;
 mod doc;
 mod doc_indexer;
@@ -372,6 +373,40 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 out.as_deref(),
                 &db_path,
             )?;
+        }
+        cli::CLICommand::MineConversations {
+            format,
+            project,
+            input,
+        } => {
+            let project_path = std::path::PathBuf::from(&project);
+            let input_path = std::path::PathBuf::from(&input);
+            let fmt = conversation_indexer::ConversationFormat::from_str(&format);
+            if fmt == conversation_indexer::ConversationFormat::Unknown {
+                eprintln!(
+                    "Unknown format '{}'; use --format claude|chatgpt|slack",
+                    format
+                );
+                std::process::exit(2);
+            }
+            match conversation_indexer::mine_into_project(&project_path, &input_path, fmt) {
+                Ok(result) => {
+                    println!("{}", result.summary());
+                    for item in &result.items {
+                        println!(
+                            "  [{}] {}: {}",
+                            item.kind.as_str(),
+                            item.qualified_name(&project_path),
+                            item.verbatim.chars().take(120).collect::<String>()
+                        );
+                    }
+                    println!("Done.");
+                }
+                Err(e) => {
+                    eprintln!("mine-conversations failed: {}", e);
+                    std::process::exit(1);
+                }
+            }
         }
         cli::CLICommand::CheckConsistency { severity, limit } => {
             let project_path = find_project_root()?;

--- a/tests/conversation_mining_tests.rs
+++ b/tests/conversation_mining_tests.rs
@@ -1,0 +1,366 @@
+//! PR-40 conversation mining (US-MP-03 / FR-MP-09..13).
+//!
+//! TDD seams:
+//! 1. Parser per format (claude / chatgpt / slack fixture JSON)
+//! 2. Type classification (decision / preference / milestone / problem)
+//! 3. `decided_about` edge creation
+//! 4. CLI end-to-end with TempDir project
+
+use leankg::conversation_indexer::{
+    self, ConversationFormat, MinedItem, MinedItemKind, MiningResult,
+};
+use leankg::db::schema::init_db;
+use leankg::graph::GraphEngine;
+use std::path::PathBuf;
+use tempfile::TempDir;
+
+const FIXTURES: &str = "tests/fixtures/conversations";
+
+fn fixture(name: &str) -> PathBuf {
+    PathBuf::from(FIXTURES).join(name)
+}
+
+fn with_test_graph<F>(callback: F)
+where
+    F: FnOnce(&GraphEngine, &TempDir),
+{
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("test.db");
+    let db = init_db(db_path.as_path()).unwrap();
+    let graph = GraphEngine::new(db.clone());
+    callback(&graph, &tmp);
+}
+
+// ---------------------------------------------------------------- seam 1: parsers
+
+#[test]
+fn parses_claude_export_json() {
+    let items =
+        conversation_indexer::mine_file(&fixture("claude_export.json"), ConversationFormat::Claude)
+            .expect("claude fixture should parse");
+
+    assert_eq!(items.len(), 3, "decision + preference + decision expected");
+    let kinds: Vec<&str> = items.iter().map(|i| i.kind.as_str()).collect();
+    assert!(kinds.contains(&"decision"), "got: {kinds:?}");
+    assert!(kinds.contains(&"preference"), "got: {kinds:?}");
+    assert!(items[0].verbatim.contains("JWT"), "raw verbatim expected");
+    assert_eq!(items[0].source, "claude", "source format expected");
+}
+
+#[test]
+fn parses_chatgpt_export_json() {
+    let items = conversation_indexer::mine_file(
+        &fixture("chatgpt_export.json"),
+        ConversationFormat::ChatGpt,
+    )
+    .expect("chatgpt fixture should parse");
+
+    assert_eq!(items.len(), 2, "milestone + decision expected");
+    let kinds: Vec<&str> = items.iter().map(|i| i.kind.as_str()).collect();
+    assert!(kinds.contains(&"milestone"), "got: {kinds:?}");
+    assert!(kinds.contains(&"decision"), "got: {kinds:?}");
+    assert!(items[0].verbatim.contains("PostgreSQL"));
+    assert_eq!(items[0].source, "chatgpt");
+}
+
+#[test]
+fn parses_slack_export_json() {
+    let items =
+        conversation_indexer::mine_file(&fixture("slack_export.json"), ConversationFormat::Slack)
+            .expect("slack fixture should parse");
+
+    assert_eq!(items.len(), 3, "decision + problem + preference expected");
+    let kinds: Vec<&str> = items.iter().map(|i| i.kind.as_str()).collect();
+    assert!(kinds.contains(&"decision"), "got: {kinds:?}");
+    assert!(kinds.contains(&"problem"), "got: {kinds:?}");
+    assert!(kinds.contains(&"preference"), "got: {kinds:?}");
+    assert!(items.iter().any(|i| i.verbatim.contains("gRPC")));
+    assert_eq!(items[0].source, "slack");
+}
+
+#[test]
+fn parses_directory_of_exports() {
+    let dir = fixture(".");
+    let result = conversation_indexer::mine_directory(&dir, ConversationFormat::Claude)
+        .expect("directory should be readable");
+    // Only *.json matching the format's shape is mined; claude fixture only.
+    assert!(result.items.len() >= 2, "got {}", result.items.len());
+    assert_eq!(result.sources, 1, "one claude fixture file");
+}
+
+#[test]
+fn rejects_unknown_format() {
+    let err = conversation_indexer::mine_file(
+        &fixture("claude_export.json"),
+        ConversationFormat::Unknown,
+    );
+    assert!(err.is_err(), "unknown format must error");
+}
+
+// ---------------------------------------------------------------- seam 2: classification
+
+#[test]
+fn classifies_decision() {
+    assert_eq!(
+        MinedItemKind::classify("Decision: switch to Redis for caching"),
+        MinedItemKind::Decision
+    );
+    assert_eq!(
+        MinedItemKind::classify("We decided to use RS256 for signing."),
+        MinedItemKind::Decision
+    );
+    assert_eq!(
+        MinedItemKind::classify("we will use gRPC for inter-service communication."),
+        MinedItemKind::Decision
+    );
+}
+
+#[test]
+fn classifies_preference() {
+    assert_eq!(
+        MinedItemKind::classify("Preference: prefer async/await style in handlers"),
+        MinedItemKind::Preference
+    );
+    assert_eq!(
+        MinedItemKind::classify("I prefer protobuf over JSON for internal APIs."),
+        MinedItemKind::Preference
+    );
+}
+
+#[test]
+fn classifies_milestone() {
+    assert_eq!(
+        MinedItemKind::classify("Milestone: migration completed by end of Q3"),
+        MinedItemKind::Milestone
+    );
+    assert_eq!(
+        MinedItemKind::classify("Goal: get 100% test coverage by release"),
+        MinedItemKind::Milestone
+    );
+}
+
+#[test]
+fn classifies_problem() {
+    assert_eq!(
+        MinedItemKind::classify("Problem: the batch job keeps timing out at 5 minutes"),
+        MinedItemKind::Problem
+    );
+    assert_eq!(
+        MinedItemKind::classify("The batch job keeps timing out at 5 minutes"),
+        MinedItemKind::Problem
+    );
+}
+
+#[test]
+fn falls_back_to_general_for_unmatched_text() {
+    assert_eq!(
+        MinedItemKind::classify("Let's check the weather tomorrow"),
+        MinedItemKind::General
+    );
+}
+
+// ---------------------------------------------------------------- seam 3: graph persistence + edges
+
+#[test]
+fn indexes_mined_nodes_and_decided_about_edges() {
+    with_test_graph(|graph, tmp| {
+        let project = tmp.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+
+        let items = vec![
+            MinedItem {
+                kind: MinedItemKind::Decision,
+                verbatim: "Decision: adopt RS256 JWT for gateway auth".to_string(),
+                source: "claude".to_string(),
+                participants: vec!["alice".to_string()],
+                timestamp: "2026-07-15T10:00:00Z".to_string(),
+                topic: "auth".to_string(),
+                code_targets: vec!["src/gateway.rs::handle_auth".to_string()],
+            },
+            MinedItem {
+                kind: MinedItemKind::Preference,
+                verbatim: "Preference: async/await in handlers".to_string(),
+                source: "claude".to_string(),
+                participants: vec![],
+                timestamp: "".to_string(),
+                topic: "style".to_string(),
+                code_targets: vec![],
+            },
+        ];
+
+        let result = conversation_indexer::index_items(graph, &project, items).unwrap();
+        assert_eq!(result.elements_indexed, 2);
+        assert_eq!(result.relationships_created, 1, "one decided_about edge");
+
+        // Elements persisted with the mined types
+        let elements = graph.all_elements().unwrap();
+        let decision = elements
+            .iter()
+            .find(|e| e.element_type == "decision")
+            .expect("decision element type must exist");
+        assert_eq!(decision.name, "auth");
+        assert!(
+            decision
+                .qualified_name
+                .starts_with("conversations/proj/decision/"),
+            "qualified_name {} should carry the mined-type prefix",
+            decision.qualified_name
+        );
+        assert!(
+            decision
+                .metadata
+                .get("verbatim")
+                .and_then(|v| v.as_str())
+                .is_some(),
+            "raw verbatim stored in metadata"
+        );
+
+        // decided_about edge: decision node -> code element
+        let rels = graph.all_relationships().unwrap();
+        let edge = rels
+            .iter()
+            .find(|r| r.rel_type == "decided_about")
+            .expect("decided_about edge must exist");
+        assert_eq!(edge.target_qualified, "src/gateway.rs::handle_auth");
+        assert_eq!(edge.source_qualified, decision.qualified_name);
+    });
+}
+
+#[test]
+fn reindex_is_idempotent() {
+    with_test_graph(|graph, tmp| {
+        let project = tmp.path().join("proj");
+        std::fs::create_dir_all(&project).unwrap();
+
+        let items = vec![MinedItem {
+            kind: MinedItemKind::Decision,
+            verbatim: "Decision: use Redis".to_string(),
+            source: "slack".to_string(),
+            participants: vec![],
+            timestamp: "".to_string(),
+            topic: "cache".to_string(),
+            code_targets: vec!["src/cache.rs::init".to_string()],
+        }];
+
+        conversation_indexer::index_items(graph, &project, items.clone()).unwrap();
+        conversation_indexer::index_items(graph, &project, items).unwrap();
+
+        let elements = graph.all_elements().unwrap();
+        let decisions: Vec<_> = elements
+            .iter()
+            .filter(|e| e.element_type == "decision")
+            .collect();
+        assert_eq!(decisions.len(), 1, "second run must not duplicate nodes");
+    });
+}
+
+// ---------------------------------------------------------------- seam 4: CLI end-to-end
+
+#[test]
+fn cli_subcommand_parses_flags() {
+    use clap::Parser;
+    use leankg::cli::CLICommand;
+
+    #[derive(Parser)]
+    struct TestArgs {
+        #[command(subcommand)]
+        command: CLICommand,
+    }
+
+    let args = TestArgs::try_parse_from([
+        "leankg",
+        "mine-conversations",
+        "--format",
+        "claude",
+        "--project",
+        "/tmp/proj",
+        "--input",
+        "/tmp/chats",
+    ])
+    .unwrap();
+    match args.command {
+        CLICommand::MineConversations {
+            format,
+            project,
+            input,
+        } => {
+            assert_eq!(format, "claude");
+            assert_eq!(project, "/tmp/proj");
+            assert_eq!(input, "/tmp/chats");
+        }
+        _ => panic!("expected MineConversations command"),
+    }
+
+    // Invalid format is rejected by clap value_parser
+    assert!(TestArgs::try_parse_from([
+        "leankg",
+        "mine-conversations",
+        "--format",
+        "bogus",
+        "--project",
+        "p",
+        "--input",
+        "i",
+    ])
+    .is_err());
+}
+
+#[test]
+fn cli_mine_conversations_e2e_with_tempdir() {
+    with_test_graph(|graph, tmp| {
+        // Simulate a project dir with .leankg already initialized
+        let project = tmp.path().join("proj");
+        std::fs::create_dir_all(project.join(".leankg")).unwrap();
+        let db_path = project.join(".leankg");
+        let db = init_db(db_path.as_path()).unwrap();
+        let g2 = GraphEngine::new(db.clone());
+        let _ = graph; // keep with_test_graph signature stable
+
+        // Seed one code element the decision can point at
+        let elem = leankg::db::models::CodeElement {
+            qualified_name: "src/gateway.rs::handle_auth".to_string(),
+            element_type: "function".to_string(),
+            name: "handle_auth".to_string(),
+            file_path: "src/gateway.rs".to_string(),
+            line_start: 1,
+            line_end: 5,
+            language: "rust".to_string(),
+            parent_qualified: None,
+            cluster_id: None,
+            cluster_label: None,
+            metadata: serde_json::json!({}),
+            ..Default::default()
+        };
+        g2.insert_element(&elem).unwrap();
+
+        let result = conversation_indexer::mine_into_project(
+            &project,
+            &fixture("claude_export.json"),
+            ConversationFormat::Claude,
+        )
+        .expect("CLI-level mine must succeed");
+        assert!(result.items.len() >= 2);
+        assert!(result.elements_indexed >= 2);
+    });
+}
+
+#[test]
+fn mining_result_summary_roundtrip() {
+    let result = MiningResult {
+        items: vec![MinedItem {
+            kind: MinedItemKind::Problem,
+            verbatim: "Problem: OOM in batch".to_string(),
+            source: "slack".to_string(),
+            participants: vec![],
+            timestamp: "".to_string(),
+            topic: "batch".to_string(),
+            code_targets: vec![],
+        }],
+        sources: 1,
+        elements_indexed: 1,
+        relationships_created: 0,
+    };
+    let s = result.summary();
+    assert!(s.contains("Mined 1 item"));
+    assert!(s.contains("problem"));
+}

--- a/tests/fixtures/conversations/chatgpt_export.json
+++ b/tests/fixtures/conversations/chatgpt_export.json
@@ -1,0 +1,38 @@
+{
+  "title": "ChatGPT Export",
+  "mapping": {
+    "conv1": {
+      "id": "conv1",
+      "title": "Migrate to PostgreSQL",
+      "create_time": 1752570000.0,
+      "mapping": {
+        "m1": {
+          "id": "m1",
+          "message": {
+            "id": "m1",
+            "author": { "role": "user" },
+            "create_time": 1752570000.0,
+            "content": {
+              "content_type": "text",
+              "parts": ["We should migrate the storage layer to PostgreSQL."]
+            }
+          }
+        },
+        "m2": {
+          "id": "m2",
+          "message": {
+            "id": "m2",
+            "author": { "role": "assistant" },
+            "create_time": 1752570100.0,
+            "content": {
+              "content_type": "text",
+              "parts": [
+                "Milestone: migration completed by end of Q3. Decision: use managed RDS with read replicas."
+              ]
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/tests/fixtures/conversations/claude_export.json
+++ b/tests/fixtures/conversations/claude_export.json
@@ -1,0 +1,37 @@
+{
+  "type": "claude",
+  "conversations": [
+    {
+      "id": "conv-1",
+      "title": "Auth service redesign",
+      "created_at": "2026-07-15T10:00:00Z",
+      "messages": [
+        {
+          "id": "msg-1",
+          "role": "user",
+          "content": [
+            {
+              "type": "text",
+              "text": "We need to decide on the auth approach for the new API gateway."
+            }
+          ]
+        },
+        {
+          "id": "msg-2",
+          "role": "assistant",
+          "text": "I recommend JWT with refresh tokens. We should go with RS256 for signing."
+        },
+        {
+          "id": "msg-3",
+          "role": "user",
+          "content": "OK, decision: we adopt RS256 JWT for the gateway auth service."
+        },
+        {
+          "id": "msg-4",
+          "role": "assistant",
+          "text": "Good. Also noting a preference: prefer async/await style in the new handlers."
+        }
+      ]
+    }
+  ]
+}

--- a/tests/fixtures/conversations/slack_export.json
+++ b/tests/fixtures/conversations/slack_export.json
@@ -1,0 +1,26 @@
+{
+  "channel": {
+    "name": "platform-eng",
+    "id": "C123"
+  },
+  "messages": [
+    {
+      "type": "message",
+      "user": "U1",
+      "ts": "1752570000.000000",
+      "text": "Decision: we will use gRPC for inter-service communication."
+    },
+    {
+      "type": "message",
+      "user": "U2",
+      "ts": "1752570100.000000",
+      "text": "Problem: the batch job keeps timing out at 5 minutes."
+    },
+    {
+      "type": "message",
+      "user": "U1",
+      "ts": "1752570200.000000",
+      "text": "Preference: prefer protobuf over JSON for internal APIs."
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- IDs: US-MP-03, FR-MP-09, FR-MP-10, FR-MP-11, FR-MP-12, FR-MP-13
- Seams: format parsers (claude/chatgpt/slack export JSON) → shared classifier → graph persistence (`insert_elements` / `insert_relationships`) → `mine-conversations` CLI subcommand

New module `src/conversation_indexer/`:
- `parsers.rs` — per-format export JSON parsers, normalized to `RawMessage` (FR-MP-09..11)
- `types.rs` — `MinedItemKind` classifier (decision/preference/milestone/problem), `MinedItem` → element + `decided_about` edge (FR-MP-12)
- `mod.rs` — `mine_file` / `mine_directory` / `mine_into_project` / `index_items`

CLI (FR-MP-13):
```bash
leankg mine-conversations --format claude|chatgpt|slack --project <path> --input <file-or-dir>
```
Raw verbatim stored in `metadata.verbatim` — no summarization. Decision nodes link to code targets via `decided_about`. Re-runs idempotent (qualified-name keyed).

## Test plan
- [x] Red→green TDD slices (14 tests, one failing test per seam: parser per format, classification, edge creation, CLI e2e with TempDir project)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --lib` (744 passed)
- [x] Integration / TempDir tests (15 passed: `cargo test --test conversation_mining_tests`)
- [x] Live smoke + `docs/reports/conversation-mining-2026-08-01.md` — all 3 formats mined, `decided_about` edge verified `decision -> src/gateway.rs::handle_auth`
- [x] Tracker rows listed for DONE after merge: US-MP-03, FR-MP-09..13
- [x] No resurrection of hard-deleted MCP tools (none touched; forbidden paths untouched)
- [x] No AI attribution