### PR TITLE
feat(ge): graph-aware planner goal→MCP DAG (US-GE-02)

### DIFF
--- a/docs/graph-planner-schema.md
+++ b/docs/graph-planner-schema.md
@@ -1,0 +1,91 @@
+# Graph-aware planner (US-GE-02 / FR-GE-02) — DAG JSON schema
+
+**PR-30** — branch `prd/ge-planner`. Pure, deterministic, rule-based planner: goal string → DAG of MCP tool steps with a join over the shared graph. No LLM calls. The harness (Cursor/Claude) executes the emitted DAG; LeanKG stays the memory layer.
+
+**Entry point:** `plan_dag(goal: &str, available: &[ToolDefinition], project: Option<&str>) -> Option<PlanDag>` in `src/graph/planner.rs`. `available` = `ToolRegistry::list_tools()` (or a filtered subset); only tools present in the supplied catalog are emitted.
+
+## Contract
+
+```json
+{
+  "goal": "find god nodes",
+  "project": "/workspace",
+  "nodes": [
+    {
+      "id": 0,
+      "tool": "get_overview_context",
+      "input": "project overview",
+      "stage": 1,
+      "join": false
+    },
+    {
+      "id": 1,
+      "tool": "get_god_nodes",
+      "input": "find god nodes",
+      "stage": 2,
+      "join": false
+    },
+    {
+      "id": 2,
+      "tool": "query_graph",
+      "input": "find god nodes",
+      "stage": 3,
+      "join": true
+    }
+  ],
+  "edges": [
+    {"from": 0, "to": 1, "flow": "get_overview_context output feeds get_god_nodes input"},
+    {"from": 1, "to": 2, "flow": "get_god_nodes output feeds query_graph input"},
+    {"from": 0, "to": 2, "flow": "get_overview_context output joins shared graph context"}
+  ],
+  "join": "query_graph joins god-node candidates against shared graph relationships",
+  "best_effort": false
+}
+```
+
+## Fields
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `goal` | string | The trimmed input goal. |
+| `project` | string \| null | Shared `project=` context applied to every step (mandatory container path when talking to Docker MCP). |
+| `nodes[].id` | int | Unique, sequential (0-based). |
+| `nodes[].tool` | string | MCP tool name from the supplied catalog. |
+| `nodes[].input` | string | Concrete argument: the goal itself, or a tool-typical default (`project overview` for the prefix step). |
+| `nodes[].stage` | int | Execution stage; nodes sharing a stage may run in parallel. Strictly non-decreasing. |
+| `nodes[].join` | bool | Exactly one node is the graph join point (`query_graph`, else the last step). |
+| `edges[].from`/`to` | int | Data flow: `from` output feeds `to` input. Both always reference existing node ids; no duplicate (from,to) pairs. |
+| `edges[].flow` | string | Human-readable label of the carried data. |
+| `join` | string | Description of the join over shared elements/relationships. |
+| `best_effort` | bool | `true` when the goal matched no known intent (fallback = overview + graph join). |
+
+## Semantics
+
+- **Deterministic:** same goal + same catalog → identical DAG (JSON-stable, covered by test `plan_is_deterministic`).
+- **Empty/blank goal** → empty DAG (`nodes: []`, `edges: []`, no `join`).
+- **Unknown goal** → best-effort plan: `get_overview_context` → `query_graph` join, `best_effort: true`.
+- **Catalog filtering:** a tool missing from `available` is never emitted (e.g. `kg_semantic_context` absent without `embeddings` feature); the join falls back to the last emitted node.
+- **Fan-out:** `semantic_search` + `concept_search` share one stage (parallel), joined by `query_graph` on the next stage.
+- **Prefix:** `get_overview_context` is always stage 1 when available; a plan never contains duplicate tool steps.
+
+## Rules (keyword → tool plan)
+
+| Intent keys (lowercased substring match) | Tool steps | Join |
+|------------------------------------------|-----------|------|
+| god / hub / central / most-connected / connected | `get_god_nodes` → `query_graph` | god-node candidates vs shared graph relationships |
+| dead / unused / orphan | `find_dead_code` → `get_callers` → `query_graph` | dead-code candidates + caller neighborhoods |
+| impact / breaking / what breaks / change / refactor / break | `get_context` → `get_impact_radius` → `get_dependents` → `get_dependencies` → `query_graph` | dependents/dependencies into change-impact subgraph |
+| test / coverage / tested | `query_file` → `get_tested_by` → `query_graph` | tested_by edges + element neighborhood |
+| trace / requirement / traceability / fr- / us- / doc | `search_by_requirement` → `get_traceability` → `get_files_for_doc` → `find_related_docs` → `query_graph` | traceability chains + doc refs over shared elements |
+| call / caller / callee / depend / who calls / what calls | `get_callers` → `get_call_graph` → `query_graph` | caller/callee hops into call subgraph |
+| where is / where are / find / implemented / which / what is / how does | `semantic_search` ∥ `concept_search` → `query_file` → `query_graph` | search hits around discovered seeds |
+| cluster / module / architecture / overview / component | `get_architecture` → `get_clusters` → `get_cluster_context` → `query_graph` | cluster neighborhoods over shared graph |
+| large / complex / long function / big function | `find_large_functions` → `get_context` → `query_graph` | large-function candidates + graph context |
+
+## Verification
+
+- Unit: `tests/planner_tests.rs` (9 tests: god-node DAG + join, join description, best-effort, empty DAG, JSON schema validity, catalog filtering, determinism, parallel fan-out, edge labels).
+- Unit (module): `src/graph/planner.rs` `#[cfg(test)]` (empty goal, catalog filtering).
+- Gates: `cargo fmt --all -- --check`, `cargo clippy --all -- -D warnings`, `cargo test --lib` (775 passed), `cargo test planner` (9 passed).
+
+Harness remains Cursor/Claude — this module ships the planner + schema only; no MCP tool is added in PR-30.

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -9,6 +9,7 @@ pub mod layout;
 pub mod layout3d;
 pub mod nl_query;
 pub mod persistent_cache;
+pub mod planner;
 pub mod query;
 pub mod traversal;
 
@@ -33,6 +34,8 @@ pub use layout3d::*;
 pub use nl_query::{QueryGraphEdge, QueryGraphNode, QueryGraphResult};
 #[allow(unused_imports)]
 pub use persistent_cache::*;
+#[allow(unused_imports)]
+pub use planner::*;
 #[allow(unused_imports)]
 pub use query::*;
 #[allow(unused_imports)]

--- a/src/graph/planner.rs
+++ b/src/graph/planner.rs
@@ -1,0 +1,309 @@
+// US-GE-02 / FR-GE-02: graph-aware planner.
+// Goal string -> DAG of MCP tool steps with a join over the shared graph.
+// Pure, deterministic, rule-based (keyword match over the MCP tool catalog).
+// No LLM calls. The harness (Cursor/Claude) executes the emitted DAG.
+
+use crate::mcp::tools::ToolDefinition;
+use serde::Serialize;
+
+/// One MCP tool step in the plan.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlanNode {
+    pub id: u32,
+    pub tool: String,
+    /// A concrete argument to pass (extracted from the goal or tool-typical).
+    pub input: String,
+    /// Execution stage; nodes sharing a stage may run in parallel.
+    pub stage: u32,
+    /// True when this node is the graph join point (shared element/relationship queries).
+    pub join: bool,
+}
+
+/// Data-flow edge: `from` output feeds `to` input.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlanEdge {
+    pub from: u32,
+    pub to: u32,
+    pub flow: String,
+}
+
+/// The plan DAG. Serialized as the FR-GE-02 JSON contract.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PlanDag {
+    pub goal: String,
+    pub project: Option<String>,
+    pub nodes: Vec<PlanNode>,
+    pub edges: Vec<PlanEdge>,
+    /// Text description of the join point over the shared graph.
+    pub join: Option<String>,
+    /// True when the goal matched no known intent (best-effort overview plan).
+    pub best_effort: bool,
+}
+
+impl PlanDag {
+    /// Serialize the DAG to the JSON contract emitted to the harness.
+    pub fn to_json(&self) -> String {
+        serde_json::to_string_pretty(self).unwrap_or_default()
+    }
+}
+
+/// A rule: keyword tokens matching a goal -> ordered tool plan with a join.
+struct Rule<'a> {
+    keys: &'a [&'a str],
+    tools: &'a [&'a str],
+    join_desc: &'a str,
+}
+
+const RULES: &[Rule] = &[
+    Rule {
+        keys: &[
+            "god",
+            "hub",
+            "central",
+            "most-connected",
+            "most connected",
+            "connected",
+        ],
+        tools: &["get_god_nodes", "query_graph"],
+        join_desc: "query_graph joins god-node candidates against shared graph relationships",
+    },
+    Rule {
+        keys: &["dead", "unused", "orphan"],
+        tools: &["find_dead_code", "get_callers", "query_graph"],
+        join_desc:
+            "query_graph joins dead-code candidates with caller neighborhoods from the shared graph",
+    },
+    Rule {
+        keys: &[
+            "impact",
+            "breaking",
+            "what breaks",
+            "change",
+            "refactor",
+            "break",
+        ],
+        tools: &[
+            "get_context",
+            "get_impact_radius",
+            "get_dependents",
+            "get_dependencies",
+            "query_graph",
+        ],
+        join_desc: "query_graph joins dependents/dependencies into a shared change-impact subgraph",
+    },
+    Rule {
+        keys: &["test", "coverage", "tested"],
+        tools: &["query_file", "get_tested_by", "query_graph"],
+        join_desc: "query_graph joins tested_by edges with the element's shared graph neighborhood",
+    },
+    Rule {
+        keys: &["trace", "requirement", "traceability", "fr-", "us-", "doc"],
+        tools: &[
+            "search_by_requirement",
+            "get_traceability",
+            "get_files_for_doc",
+            "find_related_docs",
+            "query_graph",
+        ],
+        join_desc: "query_graph joins traceability chains and doc refs over shared elements",
+    },
+    Rule {
+        keys: &[
+            "call",
+            "caller",
+            "callee",
+            "depend",
+            "who calls",
+            "what calls",
+        ],
+        tools: &["get_callers", "get_call_graph", "query_graph"],
+        join_desc: "query_graph joins caller/callee hops into a shared call subgraph",
+    },
+    Rule {
+        keys: &[
+            "where is",
+            "where are",
+            "find",
+            "implemented",
+            "which",
+            "what is",
+            "how does",
+        ],
+        tools: &[
+            "semantic_search",
+            "concept_search",
+            "query_file",
+            "query_graph",
+        ],
+        join_desc:
+            "query_graph joins search hits into a shared subgraph around the discovered seeds",
+    },
+    Rule {
+        keys: &["cluster", "module", "architecture", "overview", "component"],
+        tools: &[
+            "get_architecture",
+            "get_clusters",
+            "get_cluster_context",
+            "query_graph",
+        ],
+        join_desc: "query_graph joins cluster neighborhoods over the shared graph",
+    },
+    Rule {
+        keys: &["large", "complex", "long function", "big function"],
+        tools: &["find_large_functions", "get_context", "query_graph"],
+        join_desc: "query_graph joins large-function candidates with their shared graph context",
+    },
+];
+
+/// Tools that always appear at the head of a plan (before intent-specific nodes).
+const PREFIX_TOOLS: &[&str] = &["get_overview_context"];
+
+/// Search tools that fan out in parallel (same stage).
+const PARALLEL_GROUP: &[&str] = &["semantic_search", "concept_search"];
+
+fn has(goal: &str, keys: &[&str]) -> bool {
+    let g = goal.to_lowercase();
+    keys.iter().any(|k| g.contains(k))
+}
+
+/// Turn a natural-language goal into a DAG of MCP tool steps.
+/// Deterministic: same goal + same catalog -> same DAG.
+/// Unknown goals still yield a best-effort plan (overview + graph join).
+/// Empty/blank goals yield an empty DAG.
+pub fn plan_dag(
+    goal: &str,
+    available: &[ToolDefinition],
+    project: Option<&str>,
+) -> Option<PlanDag> {
+    let goal = goal.trim();
+    if goal.is_empty() {
+        return Some(PlanDag {
+            goal: String::new(),
+            project: project.map(|p| p.to_string()),
+            nodes: Vec::new(),
+            edges: Vec::new(),
+            join: None,
+            best_effort: false,
+        });
+    }
+
+    let names: Vec<&str> = available.iter().map(|t| t.name.as_str()).collect();
+    let matched = RULES.iter().find(|r| has(goal, r.keys));
+    let picks: Vec<&str> = match matched {
+        Some(r) => r.tools.to_vec(),
+        None => vec!["get_overview_context", "query_graph"],
+    };
+    // Only emit tools that exist in the supplied catalog, and skip tools the
+    // prefix stage already emitted (avoid duplicate steps).
+    let picks: Vec<&str> = picks
+        .into_iter()
+        .filter(|t| names.contains(t) && !PREFIX_TOOLS.contains(t))
+        .collect();
+
+    let mut nodes: Vec<PlanNode> = Vec::new();
+    let mut edges: Vec<PlanEdge> = Vec::new();
+    let mut stage = 1u32;
+    let mut prev_stage_last: Option<u32> = None;
+
+    let mut push = |tool: &str, input: &str, join: bool, new_stage: bool| {
+        let id = nodes.len() as u32;
+        if new_stage {
+            prev_stage_last = nodes.last().map(|n| n.id);
+            stage += 1;
+        }
+        nodes.push(PlanNode {
+            id,
+            tool: tool.to_string(),
+            input: input.to_string(),
+            stage,
+            join,
+        });
+        if let Some(src) = prev_stage_last {
+            if src != id {
+                edges.push(PlanEdge {
+                    from: src,
+                    to: id,
+                    flow: format!("{} output feeds {} input", nodes[src as usize].tool, tool),
+                });
+            }
+        }
+    };
+
+    // Prefix tools — stage 1.
+    for t in PREFIX_TOOLS {
+        if names.contains(t) {
+            push(t, "project overview", false, false);
+        }
+    }
+
+    // Intent-specific tools. Parallel group members share one stage; all else sequential.
+    for (i, t) in picks.iter().enumerate() {
+        let is_join = i + 1 == picks.len();
+        let new_stage = i == 0 || !PARALLEL_GROUP.contains(t);
+        push(t, goal, is_join, new_stage);
+    }
+
+    // Ensure exactly one join node: the query_graph step, else the last step.
+    let join_idx = nodes
+        .iter()
+        .position(|n| n.tool == "query_graph")
+        .unwrap_or_else(|| nodes.len().saturating_sub(1));
+    for (i, n) in nodes.iter_mut().enumerate() {
+        n.join = i == join_idx;
+    }
+    // Data-flow edges from every other step into the join (skip pairs already
+    // connected by a sequential feed edge).
+    for n in &nodes {
+        if n.id as usize == join_idx {
+            continue;
+        }
+        let connected = edges
+            .iter()
+            .any(|e| e.from == n.id && e.to == join_idx as u32);
+        if !connected {
+            edges.push(PlanEdge {
+                from: n.id,
+                to: join_idx as u32,
+                flow: format!("{} output joins shared graph context", n.tool),
+            });
+        }
+    }
+
+    let join_desc = matched
+        .map(|r| r.join_desc)
+        .unwrap_or("query_graph joins all step outputs over the shared element/relationship graph")
+        .to_string();
+    let best_effort = matched.is_none();
+    Some(PlanDag {
+        goal: goal.to_string(),
+        project: project.map(|p| p.to_string()),
+        nodes,
+        edges,
+        join: Some(join_desc),
+        best_effort,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::mcp::tools::ToolRegistry;
+
+    fn tools() -> Vec<ToolDefinition> {
+        ToolRegistry::list_tools()
+    }
+
+    #[test]
+    fn unit_empty_goal_empty_dag() {
+        let dag = plan_dag("", &tools(), None).unwrap();
+        assert!(dag.nodes.is_empty() && dag.edges.is_empty());
+    }
+
+    #[test]
+    fn unit_join_only_uses_available_tools() {
+        let mut available = tools();
+        available.retain(|t| t.name != "query_graph");
+        let dag = plan_dag("find god nodes", &available, None).unwrap();
+        assert!(dag.nodes.iter().all(|n| n.tool != "query_graph"));
+    }
+}

--- a/tests/planner_tests.rs
+++ b/tests/planner_tests.rs
@@ -1,0 +1,152 @@
+// US-GE-02 / FR-GE-02: graph-aware planner — goal -> MCP tool DAG with graph join.
+// Pure, deterministic, no LLM. Harness (Cursor/Claude) executes the emitted DAG.
+
+use leankg::graph::planner::{plan_dag, PlanEdge, PlanNode};
+use leankg::mcp::tools::ToolRegistry;
+
+fn tools() -> Vec<leankg::mcp::tools::ToolDefinition> {
+    ToolRegistry::list_tools()
+}
+
+#[test]
+fn god_nodes_goal_emits_dag_with_join() {
+    let dag = plan_dag("find god nodes", &tools(), None).expect("plan must succeed");
+    let names: Vec<&str> = dag.nodes.iter().map(|n| n.tool.as_str()).collect();
+    assert!(
+        names.contains(&"get_god_nodes"),
+        "god-node plan must include get_god_nodes, got {names:?}"
+    );
+    assert!(
+        names.contains(&"query_graph"),
+        "god-node plan must include query_graph join, got {names:?}"
+    );
+    let join_nodes: Vec<&PlanNode> = dag.nodes.iter().filter(|n| n.join).collect();
+    assert_eq!(join_nodes.len(), 1, "exactly one graph join point");
+    assert_eq!(join_nodes[0].tool, "query_graph");
+    assert!(
+        dag.edges.iter().any(|e| e.from == 1 && e.to == 2),
+        "god_nodes output must feed the query_graph join, edges: {:?}",
+        dag.edges
+    );
+}
+
+#[test]
+fn god_nodes_goal_join_mentions_shared_graph() {
+    let dag = plan_dag("find god nodes", &tools(), None).expect("plan must succeed");
+    let join = dag.join.expect("join must be described");
+    assert!(
+        join.contains("graph") || join.contains("element") || join.contains("shared"),
+        "join description must mention the shared graph, got: {join}"
+    );
+}
+
+#[test]
+fn unknown_goal_is_best_effort_plan() {
+    let dag = plan_dag("make the website faster", &tools(), None).expect("plan must succeed");
+    assert!(dag.best_effort, "unknown goal must be marked best_effort");
+    assert!(!dag.nodes.is_empty(), "best-effort plan must not be empty");
+    assert!(
+        dag.nodes.iter().any(|n| n.tool == "get_overview_context"),
+        "best-effort plan should start with overview context"
+    );
+}
+
+#[test]
+fn empty_goal_emits_empty_dag() {
+    let dag = plan_dag("", &tools(), None).expect("empty goal must not error");
+    assert!(dag.nodes.is_empty());
+    assert!(dag.edges.is_empty());
+    let dag = plan_dag("   ", &tools(), None).expect("blank goal must not error");
+    assert!(dag.nodes.is_empty());
+}
+
+#[test]
+fn dag_json_schema_is_valid() {
+    let dag = plan_dag(
+        "what is the impact of changing auth/login.rs",
+        &tools(),
+        Some("p1"),
+    )
+    .expect("plan must succeed");
+    let json = dag.to_json();
+    let v: serde_json::Value = serde_json::from_str(&json).expect("output must be valid JSON");
+    assert_eq!(v["goal"], "what is the impact of changing auth/login.rs");
+    assert_eq!(v["project"], "p1");
+    assert!(v["nodes"].is_array() && !v["nodes"].as_array().unwrap().is_empty());
+    assert!(v["edges"].is_array());
+    let ids: Vec<i64> = v["nodes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|n| n["id"].as_i64().unwrap())
+        .collect();
+    let unique: std::collections::HashSet<_> = ids.iter().collect();
+    assert_eq!(unique.len(), ids.len(), "node ids must be unique");
+    for edge in v["edges"].as_array().unwrap() {
+        let from = edge["from"].as_i64().unwrap();
+        let to = edge["to"].as_i64().unwrap();
+        assert!(
+            ids.contains(&from),
+            "edge from {from} must reference a node"
+        );
+        assert!(ids.contains(&to), "edge to {to} must reference a node");
+    }
+}
+
+#[test]
+fn plan_only_uses_available_tools() {
+    let mut available = tools();
+    available.retain(|t| t.name != "query_graph");
+    let dag = plan_dag("find god nodes", &available, None).expect("plan must succeed");
+    assert!(
+        !dag.nodes.iter().any(|n| n.tool == "query_graph"),
+        "plan must not emit unavailable tool query_graph"
+    );
+    assert!(
+        dag.nodes.iter().any(|n| n.tool == "get_god_nodes"),
+        "get_god_nodes still available and must be used"
+    );
+}
+
+#[test]
+fn plan_is_deterministic() {
+    let a = plan_dag("what breaks if I change src/main.rs", &tools(), None).expect("plan a");
+    let b = plan_dag("what breaks if I change src/main.rs", &tools(), None).expect("plan b");
+    assert_eq!(a, b, "same goal must produce identical DAG");
+    assert_eq!(a.to_json(), b.to_json());
+}
+
+#[test]
+fn parallel_search_stage_fans_out_before_join() {
+    let dag = plan_dag("where is the refund flow implemented", &tools(), None)
+        .expect("plan must succeed");
+    let search: Vec<&PlanNode> = dag
+        .nodes
+        .iter()
+        .filter(|n| n.tool == "semantic_search" || n.tool == "concept_search")
+        .collect();
+    assert_eq!(
+        search.len(),
+        2,
+        "search fan-out must run concept_search + semantic_search"
+    );
+    assert!(
+        search[0].stage == search[1].stage,
+        "fan-out tools must share a stage for parallel execution"
+    );
+    let join: Vec<&PlanNode> = dag.nodes.iter().filter(|n| n.join).collect();
+    assert_eq!(join.len(), 1);
+    assert!(
+        join[0].stage > search[0].stage,
+        "join must run after the fan-out stage"
+    );
+}
+
+#[test]
+fn edge_carries_data_flow_label() {
+    let dag = plan_dag("find god nodes", &tools(), None).expect("plan must succeed");
+    assert!(
+        dag.edges.iter().all(|e: &PlanEdge| !e.flow.is_empty()),
+        "every edge must describe the data flow it carries"
+    );
+}


### PR DESCRIPTION
## Summary

PR-30: US-GE-02 / FR-GE-02 — optional graph-aware planner. Goal string → DAG of MCP tool/subagent steps with a join over the shared graph. Pure, deterministic, rule-based (keyword match over existing MCP tool catalog); zero LLM calls. Harness remains Cursor/Claude — this PR ships the planner + JSON schema only.

## Changes

- `src/graph/planner.rs` (new): `plan_dag(goal, available, project) -> Option<PlanDag>`; `PlanNode` (id/tool/input/stage/join), `PlanEdge` (from/to/flow), `PlanDag` (goal/project/nodes/edges/join/best_effort) + `to_json()`.
- `src/graph/mod.rs`: register `planner` module + re-exports.
- `tests/planner_tests.rs` (new): 9 tests — god-node goal → DAG with `get_god_nodes` + `query_graph` join, join description, unknown goal → best-effort, empty goal → empty DAG, JSON schema validity, catalog filtering, determinism, parallel search fan-out, edge labels.
- `docs/graph-planner-schema.md` (new): JSON contract + rule table + verification.

## Behavior

- Empty/blank goal → empty DAG.
- Unknown goal → best-effort plan (`get_overview_context` → `query_graph` join, `best_effort: true`).
- Only tools present in the supplied catalog are emitted (e.g. `kg_semantic_context` absent without `embeddings` feature).
- `semantic_search` ∥ `concept_search` share one stage (parallel), joined by `query_graph` next stage.
- Deterministic: same goal + catalog → identical JSON.

## Gates

- `cargo fmt --all -- --check` — pass
- `cargo clippy --all -- -D warnings` — pass
- `cargo test --lib` — 775 passed, 0 failed
- `cargo test planner` — 9 passed, 0 failed

Tracker: US-GE-02, FR-GE-02 → DONE after merge.