### PR TITLE
feat(graph): god-node importance scoring + architecture hotspots (FR-GF-10/12)

### DIFF
--- a/docs/reports/fr-gf-10-12-god-node-scoring-2026-08-02.md
+++ b/docs/reports/fr-gf-10-12-god-node-scoring-2026-08-02.md
@@ -1,0 +1,55 @@
+# FR-GF-10/12 live evidence — 2026-08-02
+
+## Environment
+- leankg version / commit: v0.19.30 + PR-12 branch `prd/god-node-scoring` (worktree build)
+- MCP: local stdio-embedded MCP HTTP on `:9711` (release binary from worktree)
+- project=: `/tmp/gf10-live-smoke` (TempDir fixture, indexed fresh)
+
+## Steps
+1. Create fixture `src/hub.rs` with `hub()` calling 3 leaves + `main()`
+2. `leankg index ./src` (release binary) — index-time scoring hook runs via `refresh_index_inventory`
+3. `leankg gods --limit 5` — CLI reads persisted `node_scores`
+4. `mcp-http` on `:9711`, `get_architecture(max_items=5)` — god nodes in hotspots
+5. `get_god_nodes(limit=3)` — MCP tool reads persisted scores
+
+## Results
+
+### Index
+```
+Indexed 1 files (5 elements)
+```
+(warn: `all_elements()` deprecated log — expected, existing behavior)
+
+### CLI `leankg gods --limit 5`
+```
+Top 5 god nodes:
+  1. ./src/hub.rs::hub [function] degree=13 (hub)
+  2. ./src/hub.rs::main [function] degree=11 (main)
+  3. ./src/hub.rs [File] degree=6 (hub.rs)
+  4. proc_1_main [process] degree=4 (Main → Leaf_a)
+  5. proc_0_main [process] degree=4 (Main → Unknown)
+```
+Pass: hub is top god node (degree 13 = in+out over 32 relationships including process/contains edges).
+
+### MCP `get_architecture(max_items=5)` — FR-GF-12
+```
+god_nodes:
+  element[5]{degree,element_type,name,pagerank_score,qualified_name,rank_score}:
+    13,function,hub,0.06058688734671503,"./src/hub.rs::hub",0.7181760662040144
+    11,function,main,0.05882222072496605,"./src/hub.rs::main",0.6099543585251821
+    6,File,hub.rs,0.06681074620901373,./src/hub.rs,0.3431201469396272
+    ...
+  hotspots:
+    file_path[1]: ./src/hub.rs,5
+  truncated_sections: original_count 10 -> returned 5 (god_nodes)
+```
+Pass: `god_nodes` section present with `degree`, `rank_score`, `pagerank_score` per entry; max_items truncation works.
+
+### MCP `get_god_nodes(limit=3)`
+```
+nodes: hub(13, rank 0.718), main(11, rank 0.610), hub.rs(6, rank 0.343)
+```
+Pass: persisted scores (not live recompute) — values identical to architecture god_nodes.
+
+## Tracker
+- Mark `FR-GF-10`, `FR-GF-12` DONE after merge.

--- a/src/graph/god_nodes.rs
+++ b/src/graph/god_nodes.rs
@@ -1,0 +1,384 @@
+//! God-node / importance scoring (FR-GF-10) + persisted `node_scores`.
+//!
+//! FR-GF-10: index-time node importance = degree (in + out relationship
+//! count) plus an optional cheap PageRank-like iterative rank. Scores are
+//! persisted in a `node_scores` relation at index time so `get_architecture`
+//! hotspots (FR-GF-12) and `get_god_nodes` can read them without recomputing
+//! over every relationship on each call.
+
+use crate::db::models::{CodeElement, Relationship};
+use crate::db::schema::{run_script, CozoDb};
+use crate::graph::GraphEngine;
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+
+/// One persisted importance score row.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct NodeScore {
+    pub qualified_name: String,
+    /// Total relationship count (in + out).
+    pub degree: u64,
+    /// Cheap iterative rank (normalized 0.0..=1.0, degree fallback when
+    /// no relationships exist). Optional — always computed because it is
+    /// nearly free on top of the degree pass.
+    pub rank_score: f64,
+    /// PageRank-like score (normalized 0.0..=1.0) when the caller opts in.
+    pub pagerank_score: Option<f64>,
+}
+
+/// Builds a degree + iterative-rank score table for every element in the
+/// graph. Pure function over the two model lists — the unit-test seam for
+/// FR-GF-10.
+///
+/// Scoring (importance = degree first, PageRank refines ties):
+/// - `degree` = in + out relationship count (the classic god-node metric).
+/// - `pagerank_score` = cheap power-iteration rank, normalized to the
+///   maximum after the last iteration. Nodes with no outgoing edges are
+///   handled via the standard dangling-mass redistribution term.
+/// - `rank_score` = blended importance: `0.7 * (degree / max_degree) +
+///   0.3 * pagerank_normalized`. Pure PageRank favors in-target nodes over
+///   outward hubs; blending keeps hubs (the intended god nodes) on top while
+///   still differentiating equal-degree nodes.
+///
+/// Ordering is rank desc, then degree desc, then name asc (deterministic).
+pub fn score_graph(
+    elements: &[CodeElement],
+    relationships: &[Relationship],
+    iterations: usize,
+    damping: f64,
+) -> Vec<NodeScore> {
+    let iterations = iterations.max(1);
+    let damping = damping.clamp(0.0, 1.0);
+
+    // Adjacency: for each target, the sources that point at it.
+    let mut in_neighbors: HashMap<String, Vec<String>> = HashMap::new();
+    let mut out_degree: HashMap<String, usize> = HashMap::new();
+    for rel in relationships {
+        in_neighbors
+            .entry(rel.target_qualified.clone())
+            .or_default()
+            .push(rel.source_qualified.clone());
+        *out_degree.entry(rel.source_qualified.clone()).or_default() += 1;
+    }
+
+    let mut degree: HashMap<String, u64> = HashMap::new();
+    for rel in relationships {
+        *degree.entry(rel.source_qualified.clone()).or_default() += 1;
+        *degree.entry(rel.target_qualified.clone()).or_default() += 1;
+    }
+    // Nodes with no relationships still get a row (degree 0).
+    for e in elements {
+        degree.entry(e.qualified_name.clone()).or_insert(0);
+        in_neighbors.entry(e.qualified_name.clone()).or_default();
+        out_degree.entry(e.qualified_name.clone()).or_insert(0);
+    }
+
+    let n = degree.len();
+    let mut rank: HashMap<String, f64> = degree
+        .keys()
+        .map(|k| (k.clone(), 1.0 / n.max(1) as f64))
+        .collect();
+
+    for _ in 0..iterations {
+        let mut next: HashMap<String, f64> = HashMap::with_capacity(n);
+        // Dangling mass: nodes with zero out-degree leak their rank back.
+        let dangling_sum: f64 = rank
+            .iter()
+            .filter(|(k, _)| out_degree.get(*k).copied().unwrap_or(0) == 0)
+            .map(|(_, v)| v)
+            .sum();
+        let base = damping / n.max(1) as f64;
+        for node in rank.keys() {
+            let incoming: f64 = in_neighbors
+                .get(node)
+                .map(|srcs| {
+                    srcs.iter()
+                        .map(|s| {
+                            let od = out_degree.get(s).copied().unwrap_or(1).max(1);
+                            rank.get(s).copied().unwrap_or(0.0) / od as f64
+                        })
+                        .sum()
+                })
+                .unwrap_or(0.0);
+            next.insert(
+                node.clone(),
+                base + (1.0 - damping) * (incoming + dangling_sum / n.max(1) as f64),
+            );
+        }
+        rank = next;
+    }
+
+    let max_rank = rank.values().cloned().fold(0.0_f64, f64::max);
+    let pagerank_max = max_rank.max(1.0);
+
+    let max_degree = degree.values().cloned().max().unwrap_or(0).max(1);
+    let has_edges = !relationships.is_empty();
+
+    let mut scores: Vec<NodeScore> = degree
+        .into_iter()
+        .map(|(qn, deg)| {
+            let deg_norm = deg as f64 / max_degree as f64;
+            if has_edges {
+                let pr_norm = rank.get(&qn).copied().unwrap_or(0.0) / pagerank_max;
+                NodeScore {
+                    qualified_name: qn,
+                    degree: deg,
+                    rank_score: 0.7 * deg_norm + 0.3 * pr_norm,
+                    pagerank_score: Some(pr_norm),
+                }
+            } else {
+                NodeScore {
+                    qualified_name: qn,
+                    degree: deg,
+                    rank_score: deg_norm,
+                    pagerank_score: None,
+                }
+            }
+        })
+        .collect();
+    // Degree tiebreak keeps god-node ordering deterministic and matches the
+    // existing `get_god_nodes` (degree descending).
+    scores.sort_by(|a, b| {
+        b.rank_score
+            .partial_cmp(&a.rank_score)
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(b.degree.cmp(&a.degree))
+            .then(a.qualified_name.cmp(&b.qualified_name))
+    });
+    scores
+}
+
+const CREATE_NODE_SCORES: &str = r#":create node_scores {
+    qualified_name: String =>
+    degree: Int,
+    rank_score: Float,
+    pagerank_score: Float?
+}"#;
+
+pub fn ensure_node_scores_table(db: &CozoDb) -> Result<(), Box<dyn std::error::Error>> {
+    let existing: std::collections::HashSet<String> =
+        run_script(db, "::relations", Default::default())?
+            .rows
+            .iter()
+            .filter_map(|r| r.first().and_then(|v| v.get_str()).map(String::from))
+            .collect();
+    if !existing.contains("node_scores") {
+        run_script(db, CREATE_NODE_SCORES, Default::default())?;
+    }
+    Ok(())
+}
+
+/// Persist a fresh score table. Full replace (`:replace` requires an exact
+/// full-relation rewrite; we instead delete all rows then put — the table is
+/// small relative to the graph and this keeps the relation non-canonical).
+pub fn persist_scores(db: &CozoDb, scores: &[NodeScore]) -> Result<(), Box<dyn std::error::Error>> {
+    ensure_node_scores_table(db)?;
+    run_script(
+        db,
+        r#"?[qualified_name] := *node_scores[qualified_name, _, _, _] :rm node_scores { qualified_name }"#,
+        Default::default(),
+    )?;
+    for chunk in scores.chunks(500) {
+        let batch: Vec<serde_json::Value> = chunk
+            .iter()
+            .map(|s| {
+                serde_json::json!([
+                    s.qualified_name,
+                    s.degree as i64,
+                    s.rank_score,
+                    s.pagerank_score,
+                ])
+            })
+            .collect();
+        let query = r#"?[qualified_name, degree, rank_score, pagerank_score] <- $batch :put node_scores { qualified_name, degree, rank_score, pagerank_score }"#;
+        let mut params = std::collections::BTreeMap::new();
+        params.insert("batch".to_string(), serde_json::Value::Array(batch));
+        run_script(db, query, params)?;
+    }
+    Ok(())
+}
+
+/// Load persisted scores, highest rank first.
+pub fn load_scores(db: &CozoDb) -> Result<Vec<NodeScore>, Box<dyn std::error::Error>> {
+    ensure_node_scores_table(db)?;
+    let result = run_script(
+        db,
+        r#"?[qualified_name, degree, rank_score, pagerank_score] := *node_scores[qualified_name, degree, rank_score, pagerank_score] :order -rank_score"#,
+        Default::default(),
+    )?;
+    Ok(result
+        .rows
+        .iter()
+        .map(|row| NodeScore {
+            qualified_name: row[0].get_str().unwrap_or("").to_string(),
+            degree: row[1].get_int().unwrap_or(0) as u64,
+            rank_score: row[2].get_float().unwrap_or(0.0),
+            pagerank_score: row[3].get_float(),
+        })
+        .collect())
+}
+
+/// Index-time entry point: recompute + persist scores for the whole graph.
+/// Called from `refresh_index_inventory` so both bulk and incremental index
+/// runs refresh scores once per batch (FR-GF-10). Never fails the index:
+/// callers log and continue.
+pub fn refresh_node_scores(graph: &GraphEngine) -> Result<usize, Box<dyn std::error::Error>> {
+    let elements = graph.all_elements()?;
+    let relationships = graph.all_relationships()?;
+    let scores = score_graph(&elements, &relationships, 25, 0.85);
+    let n = scores.len();
+    persist_scores(graph.db(), &scores)?;
+    Ok(n)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::schema::init_db;
+    use tempfile::TempDir;
+
+    fn element(qn: &str) -> CodeElement {
+        CodeElement {
+            qualified_name: qn.to_string(),
+            element_type: "function".to_string(),
+            name: qn.rsplit("::").next().unwrap_or(qn).to_string(),
+            file_path: qn.split("::").next().unwrap_or("").to_string(),
+            line_start: 1,
+            line_end: 10,
+            language: "rust".to_string(),
+            ..Default::default()
+        }
+    }
+
+    fn rel(src: &str, dst: &str) -> Relationship {
+        Relationship {
+            source_qualified: src.to_string(),
+            target_qualified: dst.to_string(),
+            rel_type: "calls".to_string(),
+            confidence: 0.9,
+            metadata: serde_json::json!({}),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn score_graph_degree_counts_in_and_out() {
+        // a -> b, a -> c, c -> b : degree a=2 (out), b=2 (in), c=2 (in+out)
+        let elements = vec![element("x::a"), element("x::b"), element("x::c")];
+        let rels = vec![
+            rel("x::a", "x::b"),
+            rel("x::a", "x::c"),
+            rel("x::c", "x::b"),
+        ];
+        let scores = score_graph(&elements, &rels, 5, 0.85);
+        let by_qn: HashMap<&str, &NodeScore> = scores
+            .iter()
+            .map(|s| (s.qualified_name.as_str(), s))
+            .collect();
+        assert_eq!(by_qn["x::a"].degree, 2);
+        assert_eq!(by_qn["x::b"].degree, 2);
+        assert_eq!(by_qn["x::c"].degree, 2);
+        assert_eq!(scores.len(), 3);
+    }
+
+    #[test]
+    fn score_graph_ranked_highest_first() {
+        // Hub node a connects to many leaves; a must outrank a leaf.
+        let mut elements = vec![element("x::a"), element("x::leaf1"), element("x::leaf2")];
+        elements.push(element("x::leaf3"));
+        let rels = vec![
+            rel("x::a", "x::leaf1"),
+            rel("x::a", "x::leaf2"),
+            rel("x::a", "x::leaf3"),
+        ];
+        let scores = score_graph(&elements, &rels, 25, 0.85);
+        assert_eq!(scores[0].qualified_name, "x::a");
+        assert_eq!(scores[0].degree, 3);
+        assert_eq!(scores[1].degree, 1);
+        assert!(scores[0].rank_score > scores[1].rank_score);
+        // Optional PageRank-like score is present and normalized.
+        assert!(scores[0].pagerank_score.unwrap() <= 1.0);
+        assert!(scores[0].pagerank_score.unwrap() > 0.0);
+    }
+
+    #[test]
+    fn score_graph_dangling_node_handled() {
+        // b has no out-edges (dangling); must not produce NaN/inf and the
+        // sink must not overflow: both nodes keep finite, in-range scores.
+        let elements = vec![element("x::a"), element("x::b")];
+        let rels = vec![rel("x::a", "x::b")];
+        let scores = score_graph(&elements, &rels, 25, 0.85);
+        assert_eq!(scores.len(), 2);
+        assert!(scores.iter().all(|s| s.rank_score.is_finite()));
+        assert!(scores.iter().all(|s| s
+            .pagerank_score
+            .is_some_and(|p| p.is_finite() && (0.0..=1.0).contains(&p))));
+        // Equal degree (1/1) → the sink b ranks marginally higher via
+        // PageRank; the key guarantee is a stable total order, no ties.
+        assert_eq!(scores[0].qualified_name, "x::b");
+        assert_eq!(scores[1].qualified_name, "x::a");
+        assert!(scores[0].pagerank_score.unwrap() > scores[1].pagerank_score.unwrap());
+    }
+
+    #[test]
+    fn score_graph_empty_graph_returns_zero_scores() {
+        let scores = score_graph(&[], &[], 5, 0.85);
+        assert!(scores.is_empty());
+    }
+
+    #[test]
+    fn persist_and_load_scores_roundtrip() {
+        let tmp = TempDir::new().unwrap();
+        let db = init_db(tmp.path()).unwrap();
+        let scores = vec![
+            NodeScore {
+                qualified_name: "x::hub".to_string(),
+                degree: 4,
+                rank_score: 1.0,
+                pagerank_score: Some(0.9),
+            },
+            NodeScore {
+                qualified_name: "x::leaf".to_string(),
+                degree: 1,
+                rank_score: 0.1,
+                pagerank_score: Some(0.05),
+            },
+        ];
+        persist_scores(&db, &scores).unwrap();
+        let loaded = load_scores(&db).unwrap();
+        assert_eq!(loaded.len(), 2);
+        assert_eq!(loaded[0].qualified_name, "x::hub");
+        assert_eq!(loaded[0].degree, 4);
+        assert_eq!(loaded[0].pagerank_score, Some(0.9));
+        assert_eq!(loaded[1].qualified_name, "x::leaf");
+    }
+
+    #[test]
+    fn persist_scores_replaces_previous_run() {
+        let tmp = TempDir::new().unwrap();
+        let db = init_db(tmp.path()).unwrap();
+        persist_scores(
+            &db,
+            &[NodeScore {
+                qualified_name: "x::old".to_string(),
+                degree: 2,
+                rank_score: 0.5,
+                pagerank_score: None,
+            }],
+        )
+        .unwrap();
+        persist_scores(
+            &db,
+            &[NodeScore {
+                qualified_name: "x::new".to_string(),
+                degree: 3,
+                rank_score: 1.0,
+                pagerank_score: Some(1.0),
+            }],
+        )
+        .unwrap();
+        let loaded = load_scores(&db).unwrap();
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].qualified_name, "x::new");
+    }
+}

--- a/src/graph/inventory.rs
+++ b/src/graph/inventory.rs
@@ -127,6 +127,12 @@ pub fn refresh_index_inventory(
         notes: notes.to_string(),
     };
     upsert_inventory(db, &inv)?;
+    // FR-GF-10: index completion refreshes persisted god-node importance
+    // scores so `get_architecture` hotspots (FR-GF-12) and `get_god_nodes`
+    // read index-time scores instead of recomputing per call.
+    if let Err(e) = crate::graph::god_nodes::refresh_node_scores(graph) {
+        tracing::warn!("node_scores refresh at index completion failed: {}", e);
+    }
     Ok(inv)
 }
 
@@ -255,5 +261,62 @@ mod tests {
         let loaded = load_latest_inventory(graph.db()).unwrap().unwrap();
         assert_eq!(loaded.total_elements, 0);
         assert_eq!(loaded.notes, "test");
+    }
+
+    // FR-GF-10: index completion refreshes persisted god-node scores.
+    #[test]
+    fn refresh_index_inventory_refreshes_node_scores() {
+        let dir = TempDir::new().unwrap();
+        let db = init_db(dir.path()).unwrap();
+        let graph = GraphEngine::new(db);
+        use crate::db::models::CodeElement;
+        graph
+            .insert_element(&CodeElement {
+                qualified_name: "src/hub.rs::hub".to_string(),
+                element_type: "function".to_string(),
+                name: "hub".to_string(),
+                file_path: "src/hub.rs".to_string(),
+                line_start: 1,
+                line_end: 5,
+                language: "rust".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        graph
+            .insert_element(&CodeElement {
+                qualified_name: "src/leaf.rs::leaf".to_string(),
+                element_type: "function".to_string(),
+                name: "leaf".to_string(),
+                file_path: "src/leaf.rs".to_string(),
+                line_start: 1,
+                line_end: 5,
+                language: "rust".to_string(),
+                ..Default::default()
+            })
+            .unwrap();
+        graph
+            .insert_relationship(&crate::db::models::Relationship {
+                source_qualified: "src/hub.rs::hub".to_string(),
+                target_qualified: "src/leaf.rs::leaf".to_string(),
+                rel_type: "calls".to_string(),
+                confidence: 0.9,
+                metadata: serde_json::json!({}),
+                ..Default::default()
+            })
+            .unwrap();
+
+        refresh_index_inventory(&graph, "test").unwrap();
+
+        let scores = crate::graph::god_nodes::load_scores(graph.db()).unwrap();
+        assert!(
+            !scores.is_empty(),
+            "node_scores should be refreshed at index completion"
+        );
+        let hub = scores
+            .iter()
+            .find(|s| s.qualified_name == "src/hub.rs::hub")
+            .expect("hub should be scored");
+        assert_eq!(hub.degree, 1);
+        assert!(scores[0].rank_score > 0.0);
     }
 }

--- a/src/graph/mod.rs
+++ b/src/graph/mod.rs
@@ -5,6 +5,7 @@ pub mod context;
 pub mod entity_resolve;
 pub mod export;
 pub mod export_select;
+pub mod god_nodes;
 pub mod inventory;
 pub mod l1_cache;
 pub mod layout;
@@ -23,6 +24,8 @@ pub use clustering::*;
 pub use context::{ContextElement, ContextPriority, ContextProvider, ContextResult};
 #[allow(unused_imports)]
 pub use entity_resolve::{resolve, resolve_exact, Match, MAX_MATCHES};
+#[allow(unused_imports)]
+pub use god_nodes::{load_scores, persist_scores, refresh_node_scores, score_graph, NodeScore};
 #[allow(unused_imports)]
 pub use inventory::{
     ensure_index_inventory_table, inventory_to_json, load_latest_inventory,

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -4089,6 +4089,32 @@ impl GraphEngine {
             Self::truncate_section("clusters", clusters, max_items, &mut truncated_sections);
         let hotspots =
             Self::truncate_section("hotspots", hotspots, max_items, &mut truncated_sections);
+
+        // FR-GF-12: include god nodes (index-time importance scores) in the
+        // hotspots section. Never fails the whole response: a scoring read
+        // problem degrades to an empty list.
+        let god_node_values: Vec<serde_json::Value> = self
+            .get_god_nodes(10, None)
+            .unwrap_or_default()
+            .into_iter()
+            .map(|g| {
+                serde_json::json!({
+                    "qualified_name": g.qualified_name,
+                    "name": g.name,
+                    "element_type": g.element_type,
+                    "degree": g.degree,
+                    "rank_score": g.rank_score,
+                    "pagerank_score": g.pagerank_score,
+                })
+            })
+            .collect();
+        let god_nodes = Self::truncate_section(
+            "god_nodes",
+            god_node_values,
+            max_items,
+            &mut truncated_sections,
+        );
+
         let relationship_counts = Self::truncate_section(
             "relationship_summary",
             relationship_counts,
@@ -4102,6 +4128,7 @@ impl GraphEngine {
             "routes": routes,
             "clusters": clusters,
             "hotspots": hotspots,
+            "god_nodes": god_nodes,
             "relationship_summary": relationship_counts,
             "knowledge_count": self.count_knowledge().unwrap_or(0),
             "total_elements": self.count_elements().unwrap_or(0),
@@ -4439,12 +4466,18 @@ pub struct NodeExplanation {
 }
 
 /// US-GF-05: Top-degree node entry for god-node ranking.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+/// FR-GF-10: `rank_score` / `pagerank_score` carry the index-time
+/// importance scores persisted by `src/graph/god_nodes.rs`.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GodNode {
     pub qualified_name: String,
     pub name: String,
     pub element_type: String,
     pub degree: usize,
+    #[serde(default)]
+    pub rank_score: f64,
+    #[serde(default)]
+    pub pagerank_score: Option<f64>,
 }
 
 /// US-GF-06: Per-label count + percentage for confidence distribution.
@@ -5189,17 +5222,41 @@ impl GraphEngine {
         exclude_hubs_percentile: Option<u8>,
     ) -> Result<Vec<GodNode>, Box<dyn std::error::Error>> {
         let limit = limit.clamp(1, 200);
-        let all_rels = self.all_relationships()?;
         let elements = self.all_elements()?;
 
-        let mut degree: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
-        for r in &all_rels {
-            *degree.entry(r.source_qualified.clone()).or_default() += 1;
-            *degree.entry(r.target_qualified.clone()).or_default() += 1;
-        }
+        // FR-GF-10: prefer index-time persisted scores (degree + rank) when
+        // present; fall back to a live degree pass for DBs indexed before
+        // this feature.
+        let persisted = crate::graph::god_nodes::load_scores(self.db())?;
+        let use_persisted = !persisted.is_empty();
 
-        let mut nodes: Vec<(String, usize)> = degree.into_iter().collect();
-        nodes.sort_by_key(|n| std::cmp::Reverse(n.1));
+        let mut nodes: Vec<(String, u64, f64, Option<f64>)> = if use_persisted {
+            persisted
+                .into_iter()
+                .map(|s| (s.qualified_name, s.degree, s.rank_score, s.pagerank_score))
+                .collect()
+        } else {
+            let all_rels = self.all_relationships()?;
+            let mut degree: std::collections::HashMap<String, u64> =
+                std::collections::HashMap::new();
+            for r in &all_rels {
+                *degree.entry(r.source_qualified.clone()).or_default() += 1;
+                *degree.entry(r.target_qualified.clone()).or_default() += 1;
+            }
+            let max_degree = degree.values().cloned().max().unwrap_or(0).max(1);
+            degree
+                .into_iter()
+                .map(|(qn, deg)| (qn, deg, deg as f64 / max_degree as f64, None))
+                .collect()
+        };
+
+        // Rank first, then degree, then name for deterministic ordering.
+        nodes.sort_by(|a, b| {
+            b.2.partial_cmp(&a.2)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then(b.1.cmp(&a.1))
+                .then(a.0.cmp(&b.0))
+        });
 
         if let Some(pctl) = exclude_hubs_percentile {
             if !nodes.is_empty() {
@@ -5210,7 +5267,7 @@ impl GraphEngine {
         }
 
         let qn_set: std::collections::HashSet<String> =
-            nodes.iter().map(|(qn, _)| qn.clone()).collect();
+            nodes.iter().map(|(qn, _, _, _)| qn.clone()).collect();
         let by_qn: std::collections::HashMap<String, CodeElement> = elements
             .into_iter()
             .filter(|e| qn_set.contains(&e.qualified_name))
@@ -5220,7 +5277,7 @@ impl GraphEngine {
         Ok(nodes
             .into_iter()
             .take(limit)
-            .map(|(qn, deg)| {
+            .map(|(qn, deg, rank_score, pagerank_score)| {
                 let element_type = by_qn
                     .get(&qn)
                     .map(|e| e.element_type.clone())
@@ -5233,7 +5290,9 @@ impl GraphEngine {
                     qualified_name: qn,
                     name,
                     element_type,
-                    degree: deg,
+                    degree: deg as usize,
+                    rank_score,
+                    pagerank_score,
                 }
             })
             .collect())
@@ -6400,6 +6459,73 @@ mod tests {
         assert_eq!(obj["total_elements"].as_u64().unwrap(), 2);
     }
 
+    // FR-GF-12: get_architecture hotspots section must include god nodes
+    // computed at index time (persisted `node_scores` relation).
+
+    #[test]
+    fn test_architecture_hotspots_include_god_nodes_from_persisted_scores() {
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "hub", "function", "src/hub.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "leaf_a", "function", "src/leaf.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "leaf_b", "function", "src/leaf.rs", "rust", 6, 10);
+        insert_test_rel(
+            &engine,
+            "src/hub.rs::hub",
+            "src/leaf.rs::leaf_a",
+            "calls",
+            0.9,
+        );
+        insert_test_rel(
+            &engine,
+            "src/hub.rs::hub",
+            "src/leaf.rs::leaf_b",
+            "calls",
+            0.9,
+        );
+        // Index-time scoring pass (the FR-GF-10 hook).
+        crate::graph::god_nodes::refresh_node_scores(&engine).unwrap();
+
+        let arch = engine.get_architecture(None).unwrap();
+        let obj = arch.as_object().unwrap();
+        let god_nodes = obj["god_nodes"].as_array().unwrap();
+        assert!(
+            !god_nodes.is_empty(),
+            "god_nodes section should be populated"
+        );
+        let top = god_nodes[0].as_object().unwrap();
+        assert_eq!(top["qualified_name"].as_str().unwrap(), "src/hub.rs::hub");
+        assert_eq!(top["degree"].as_u64().unwrap(), 2);
+    }
+
+    #[test]
+    fn test_architecture_hotspots_falls_back_to_live_compute_without_scores() {
+        // No persisted node_scores yet (e.g. DB written before FR-GF-10):
+        // get_architecture must still emit god nodes via a live degree pass.
+        let (engine, _tmp) = make_test_engine();
+        insert_test_element_full(&engine, "hub", "function", "src/hub.rs", "rust", 1, 5);
+        insert_test_element_full(&engine, "leaf", "function", "src/leaf.rs", "rust", 1, 5);
+        insert_test_rel(
+            &engine,
+            "src/hub.rs::hub",
+            "src/leaf.rs::leaf",
+            "calls",
+            0.9,
+        );
+
+        let arch = engine.get_architecture(None).unwrap();
+        let obj = arch.as_object().unwrap();
+        let god_nodes = obj["god_nodes"].as_array().unwrap();
+        assert!(
+            !god_nodes.is_empty(),
+            "god_nodes should fall back to live degree"
+        );
+        assert_eq!(
+            god_nodes[0]["qualified_name"].as_str().unwrap(),
+            "src/hub.rs::hub"
+        );
+        assert_eq!(god_nodes[0]["degree"].as_u64().unwrap(), 1);
+    }
+
     #[test]
     fn test_architecture_finds_entry_points() {
         let (engine, _tmp) = make_test_engine();
@@ -7013,12 +7139,14 @@ mod tests {
             name: "a".into(),
             element_type: "file".into(),
             degree: 5,
+            ..Default::default()
         };
         let b = GodNode {
             qualified_name: "b".into(),
             name: "b".into(),
             element_type: "file".into(),
             degree: 10,
+            ..Default::default()
         };
         let mut v = [a.clone(), b.clone()];
         v.sort_by_key(|x| std::cmp::Reverse(x.degree));
@@ -7041,6 +7169,7 @@ mod tests {
                 name: "a".into(),
                 element_type: "file".into(),
                 degree: 4,
+                ..Default::default()
             }],
             confidence_distribution: vec![
                 LabelCount {

--- a/tests/phase1_integration_test.rs
+++ b/tests/phase1_integration_test.rs
@@ -260,6 +260,51 @@ fn test_get_architecture_on_leankg_patterns() {
     assert!(obj["total_files"].as_u64().unwrap() > 0);
 }
 
+// FR-GF-12: god nodes appear in get_architecture hotspots after an index
+// completion pass refreshes persisted node scores (FR-GF-10).
+#[test]
+fn test_architecture_god_nodes_after_index_time_scoring() {
+    let (engine, _tmp) = make_engine();
+    populate_with_leankg_patterns(&engine);
+
+    // Simulate the index-completion hook (runs inside
+    // refresh_index_inventory after both bulk and incremental indexing).
+    leankg::graph::god_nodes::refresh_node_scores(&engine).unwrap();
+
+    let arch = engine
+        .get_architecture(None)
+        .expect("get_architecture should succeed");
+    let obj = arch.as_object().unwrap();
+
+    let god_nodes = obj["god_nodes"].as_array().unwrap();
+    assert!(
+        !god_nodes.is_empty(),
+        "god_nodes section should list scored elements"
+    );
+
+    // Most-connected element in the fixture: execute_tool (3 calls out),
+    // ahead of main (2 calls out) and get_architecture (1 call in + 1
+    // tested_by in = 2).
+    let top = god_nodes[0].as_object().unwrap();
+    assert_eq!(
+        top["qualified_name"].as_str().unwrap(),
+        "src/mcp/handler.rs::execute_tool"
+    );
+    assert_eq!(top["degree"].as_u64().unwrap(), 3);
+    assert!(
+        top["rank_score"].as_f64().unwrap() > 0.0,
+        "rank_score should be populated"
+    );
+
+    // Persisted scores are the source: reloading must agree.
+    let persisted = leankg::graph::god_nodes::load_scores(engine.db()).unwrap();
+    assert_eq!(
+        persisted[0].qualified_name,
+        "src/mcp/handler.rs::execute_tool"
+    );
+    assert_eq!(persisted[0].degree, 3);
+}
+
 #[test]
 fn test_get_graph_schema_on_leankg_patterns() {
     let (engine, _tmp) = make_engine();


### PR DESCRIPTION
## Summary
- IDs: FR-GF-10, FR-GF-12
- Seams: `score_graph` pure function (`src/graph/god_nodes.rs`), `node_scores` relation persistence, `refresh_node_scores` index-time hook (inside `refresh_index_inventory`), `get_architecture` god_nodes section, `get_god_nodes` persisted-score read

FR-GF-10: index-time god-node / importance scoring. Degree (in+out relationship count) + optional cheap PageRank-like iterative rank (25 iters, damping 0.85, dangling-mass redistribution). `rank_score` = blended importance (0.7 degree-norm + 0.3 pagerank-norm); `pagerank_score` reported separately. Persisted in new `node_scores` relation, refreshed at index completion via `refresh_index_inventory` (both bulk + incremental index paths).

FR-GF-12: `get_architecture` hotspots section now includes `god_nodes` (top 10 by rank, degree, name; honors max_items truncation). `get_god_nodes` reads persisted scores with live-degree fallback for pre-feature DBs.

## Test plan
- [x] Red→green TDD slices (unit: scoring correctness on synthetic graphs, persistence roundtrip/replace; integration: TempDir fixture index → architecture god_nodes)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --lib` (753 passed, 3 ignored)
- [x] `cargo test god_node` (8 passed)
- [x] Integration: `cargo test --test phase1_integration_test` (13 passed), `mcp_tools_redundancy_tests` (44 passed), `phase1_benchmark_test` (32 passed)
- [x] Live smoke + `docs/reports/fr-gf-10-12-god-node-scoring-2026-08-02.md` (release binary: `leankg gods`, MCP `get_architecture`/`get_god_nodes` on fresh fixture)
- [x] Tracker rows FR-GF-10, FR-GF-12 → DONE after merge
- [x] No resurrection of hard-deleted MCP tools
- [x] No AI attribution

## Notes
- Pre-existing failures on origin/main (not from this PR): `tests/integration.rs:132` `test_init_db_repairs_legacy_code_elements_after_recorded_migration` (eval::replace_rel_with_indices) and `tests/test_all_tools_return_data.rs:133` `test_all_mcp_tools_return_data` (empty-tool count 1). Verified identical on clean origin/main worktree.
