### PR TITLE
feat(session): heat promotion to MEMORY_INDEX.md + workflow proposals (US-SM-05/06)

### DIFF
--- a/docs/reports/session-heat-promote-2026-08-02.md
+++ b/docs/reports/session-heat-promote-2026-08-02.md
@@ -1,0 +1,67 @@
+# FR-SM-10 / FR-SM-11 live-ish evidence — 2026-08-02
+
+## Environment
+- leankg version: 0.19.30 (worktree `prd/session-heat-promote`, HEAD `ef8c0360`)
+- MCP: not used (pure lib seam; TempDir integration only)
+- project=: TempDir fixture
+
+## Steps
+1. TDD: failing integration tests first (`tests/session_heat_promote_tests.rs`, 12 tests), then lib seam in `src/session/mod.rs`
+2. Deterministic heat score: `heat_score(recalls, last_recalled_epoch_secs, now_epoch_secs) = log(1+recalls) + 0.5^(age/86400)`
+3. Top-K promote: `MemoryIndex::top_k(k, now)` ranks by heat desc, tie-break key
+4. Proposal shape: `SequenceMiner::propose(traces, positive_terms)` emits `WorkflowProposal` (name/description/steps/occurrences/confidence) — the `add_ontology_workflow` payload shape
+5. No-ontology-write test: fixture `ontology/concepts.yaml` + `ontology/workflows.yaml` byte-identical after refresh + proposal write
+
+## Results
+
+| Gate | Result |
+|------|--------|
+| `cargo test --test session_heat_promote_tests` | 12 passed, 0 failed |
+| `cargo test --lib` | 796 passed, 0 failed |
+| `cargo test session` (filtered) | 53 passed, 0 failed (all suites) |
+| `cargo fmt --all -- --check` | pass |
+| `cargo clippy --all -- -D warnings` | pass, 0 warnings |
+
+## Sample proposal (from `SequenceMiner` on 3x repeated trace)
+
+```json
+{
+  "content_key": "9d1f3a2c7e4b",
+  "proposal": {
+    "name": "search_code_get_context_query_file",
+    "description": "Repeated 3 times across sessions: search_code → get_context → query_file",
+    "steps": ["search_code", "get_context", "query_file"],
+    "occurrences": 3,
+    "confidence": 0.75,
+    "created_epoch_secs": 1754083200
+  }
+}
+```
+
+Written to `.leankg/proposals/workflows.jsonl` only. `ontology/workflows.yaml` untouched (asserted byte-for-byte in test).
+
+## Sample MEMORY_INDEX.md render (top-K heat-ranked)
+
+```markdown
+# MEMORY_INDEX
+
+- generated: 1754083200 (epoch secs; deterministic score: log(1+recalls) + 0.5^(age/86400))
+- tracked: 2 | promoted (top-K): 2
+
+## Hot sessions
+
+| rank | key | recalls | last recall (age s) | heat | source |
+|---|---|---|---|---|---|
+| 1 | load_layer | 2 | 0 | 2.098612 | src/mcp/handler.rs |
+| 2 | open_conversation | 1 | 0 | 1.693147 | src/conversation_indexer/mod.rs |
+
+## Detail
+
+- **load_layer** — recalls=2, heat=2.098612 (freq=1.098612, recency=1.000000)
+  load_layer expands a layer
+- **open_conversation** — recalls=1, heat=1.693147 (freq=0.693147, recency=1.000000)
+  open_conversation parses Claude export JSON
+```
+
+## Tracker
+- Mark US-SM-05, US-SM-06, FR-SM-10, FR-SM-11 DONE after merge (conductor owns tracker file).

--- a/src/session/mod.rs
+++ b/src/session/mod.rs
@@ -1,4 +1,4 @@
-//! Session memory (US-SM-01 / US-SM-02 / FR-SM-01..06).
+//! Session memory (US-SM-01 / US-SM-02 / US-SM-05 / US-SM-06 / FR-SM-01..11).
 //!
 //! Verbose MCP/tool payloads are persisted under
 //! `.leankg/sessions/<session_id>/refs/<node_id>.md`; a compact canvas
@@ -11,6 +11,15 @@
 //! write). `get_overview_context` opt-in injects top-K lessons when
 //! `recall=true` (default OFF); a ≤5s timeout skips injection so recall
 //! never blocks the MCP response.
+//!
+//! Heat promotion (US-SM-05 / US-SM-06 / FR-SM-10 / FR-SM-11): a
+//! deterministic heat score (recall frequency + recency) drives a
+//! white-box, heat-ranked `.leankg/MEMORY_INDEX.md` (state sidecar
+//! `.leankg/MEMORY_INDEX.json`). Repeated successful multi-tool sequences
+//! are mined into `add_ontology_workflow` PROPOSALS under
+//! `.leankg/proposals/workflows.jsonl` — LeanKG never writes ontology YAML
+//! as source of truth; the agent/harness reviews proposals before
+//! confirming them into `ontology/`.
 
 use std::path::{Path, PathBuf};
 
@@ -579,6 +588,372 @@ fn sha256(data: &[u8]) -> [u8; 32] {
     out
 }
 
+// ---------------------------------------------------------------------------
+// US-SM-05 / FR-SM-10 — heat-ranked MEMORY_INDEX (white-box)
+// ---------------------------------------------------------------------------
+
+pub const MEMORY_INDEX_MD: &str = "MEMORY_INDEX.md";
+pub const MEMORY_INDEX_JSON: &str = "MEMORY_INDEX.json";
+/// (US-SM-05) top-K sessions promoted into the markdown index.
+pub const DEFAULT_PROMOTE_TOP_K: usize = 10;
+/// Exponential decay half-life for recency (seconds).
+const RECENCY_HALF_LIFE_SECS: f64 = 86400.0;
+
+/// Raw heat components (white-box; rendered into MEMORY_INDEX.md).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct HeatScore {
+    pub frequency: f64,
+    pub recency: f64,
+    pub total: f64,
+}
+
+/// Deterministic heat score: recall frequency + recency. Pure function —
+/// same inputs always produce the same score. Recency decays exponentially
+/// with a 1-day half-life; frequency grows sub-linearly (log1p) so one
+/// hot memory does not starve the rest of the index.
+pub fn heat_score(recalls: u64, last_recalled_epoch_secs: u64, now_epoch_secs: u64) -> f64 {
+    let freq = (1.0 + recalls as f64).ln();
+    let age_secs = now_epoch_secs.saturating_sub(last_recalled_epoch_secs) as f64;
+    let recency = 0.5f64.powf(age_secs / RECENCY_HALF_LIFE_SECS);
+    freq + recency
+}
+
+/// One tracked memory (session, tool trace, lesson, …).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct MemoryItem {
+    pub key: String,
+    pub source: String,
+    pub text: String,
+    pub recalls: u64,
+    pub first_seen_epoch_secs: u64,
+    pub last_recalled_epoch_secs: u64,
+}
+
+/// White-box heat index: JSON state under `.leankg/MEMORY_INDEX.json`,
+/// rendered markdown under `.leankg/MEMORY_INDEX.md` (FR-SM-10).
+/// Refreshed on recall; never touches ontology YAML.
+#[derive(Debug)]
+pub struct MemoryIndex {
+    project_dir: PathBuf,
+    items: Vec<MemoryItem>,
+}
+
+impl MemoryIndex {
+    pub fn new(project_dir: &Path) -> Result<Self, String> {
+        let dir = project_dir.join(".leankg");
+        std::fs::create_dir_all(&dir).map_err(|e| e.to_string())?;
+        let mut idx = Self {
+            project_dir: project_dir.to_path_buf(),
+            items: Vec::new(),
+        };
+        // Load existing state if present (crash-safe re-entry).
+        if let Ok(loaded) = Self::load(project_dir) {
+            idx.items = loaded.items;
+        }
+        Ok(idx)
+    }
+
+    pub fn json_path(&self) -> PathBuf {
+        self.project_dir.join(".leankg").join(MEMORY_INDEX_JSON)
+    }
+
+    pub fn md_path(&self) -> PathBuf {
+        self.project_dir.join(".leankg").join(MEMORY_INDEX_MD)
+    }
+
+    /// Load persisted state. Missing file => empty index (not an error).
+    pub fn load(project_dir: &Path) -> Result<Self, String> {
+        let path = project_dir.join(".leankg").join(MEMORY_INDEX_JSON);
+        let items = match std::fs::read_to_string(&path) {
+            Ok(raw) => serde_json::from_str::<Vec<MemoryItem>>(&raw).map_err(|e| e.to_string())?,
+            Err(_) => Vec::new(),
+        };
+        Ok(Self {
+            project_dir: project_dir.to_path_buf(),
+            items,
+        })
+    }
+
+    pub fn items(&self) -> &[MemoryItem] {
+        &self.items
+    }
+
+    /// Register one recall/hit of a memory key. Creates or bumps the item.
+    /// Deterministic: identical keys coalesce into one tracked item.
+    pub fn record_hit(
+        &mut self,
+        key: &str,
+        source: &str,
+        text: &str,
+        now_epoch_secs: u64,
+    ) -> Result<(), String> {
+        let idx = self.items.iter().position(|i| i.key == key);
+        match idx {
+            Some(i) => {
+                let it = &mut self.items[i];
+                it.recalls += 1;
+                it.last_recalled_epoch_secs = now_epoch_secs;
+                it.source = source.to_string();
+                it.text = text.to_string();
+            }
+            None => {
+                self.items.push(MemoryItem {
+                    key: key.to_string(),
+                    source: source.to_string(),
+                    text: text.to_string(),
+                    recalls: 1,
+                    first_seen_epoch_secs: now_epoch_secs,
+                    last_recalled_epoch_secs: now_epoch_secs,
+                });
+            }
+        }
+        self.persist_json()
+    }
+
+    /// Mark a recall for an existing key (no-op for unknown keys). This is
+    /// the hook the recall path calls so hot sessions accumulate heat.
+    pub fn record_recall(&mut self, key: &str, now_epoch_secs: u64) -> Result<(), String> {
+        let mut changed = false;
+        if let Some(it) = self.items.iter_mut().find(|i| i.key == key) {
+            it.recalls += 1;
+            it.last_recalled_epoch_secs = now_epoch_secs;
+            changed = true;
+        }
+        if changed {
+            self.persist_json()?;
+        }
+        Ok(())
+    }
+
+    fn persist_json(&self) -> Result<(), String> {
+        let raw = serde_json::to_string_pretty(&self.items).map_err(|e| e.to_string())?;
+        std::fs::write(self.json_path(), raw).map_err(|e| e.to_string())
+    }
+
+    /// Refresh the markdown index. Writes only when the rendered text
+    /// actually changed (no-write-on-unchanged). FR-SM-11 guarantee: only
+    /// `.leankg/` files are written, never `ontology/` YAML.
+    pub fn refresh(&self) -> Result<(), String> {
+        let text = self.render();
+        let path = self.md_path();
+        match std::fs::read_to_string(&path) {
+            Ok(existing) if existing == text => return Ok(()),
+            _ => {}
+        }
+        std::fs::write(&path, text).map_err(|e| e.to_string())
+    }
+
+    /// Heat-ranked top-K list (deterministic sort by score, tie-break key).
+    pub fn top_k(&self, k: usize, now_epoch_secs: u64) -> Vec<(MemoryItem, HeatScore)> {
+        let mut ranked: Vec<(MemoryItem, HeatScore)> = self
+            .items
+            .iter()
+            .map(|it| {
+                let total = heat_score(it.recalls, it.last_recalled_epoch_secs, now_epoch_secs);
+                let age_secs = now_epoch_secs.saturating_sub(it.last_recalled_epoch_secs) as f64;
+                let score = HeatScore {
+                    frequency: (1.0 + it.recalls as f64).ln(),
+                    recency: 0.5f64.powf(age_secs / RECENCY_HALF_LIFE_SECS),
+                    total,
+                };
+                (it.clone(), score)
+            })
+            .collect();
+        ranked.sort_by(|a, b| {
+            b.1.total
+                .partial_cmp(&a.1.total)
+                .unwrap_or(std::cmp::Ordering::Equal)
+                .then_with(|| a.0.key.cmp(&b.0.key))
+        });
+        ranked.truncate(k);
+        ranked
+    }
+
+    /// Render the white-box markdown index (heat-ranked, top-K).
+    pub fn render(&self) -> String {
+        let now = now_unix_secs();
+        let ranked = self.top_k(DEFAULT_PROMOTE_TOP_K, now);
+        let mut out = String::from("# MEMORY_INDEX\n\n");
+        out.push_str(&format!(
+            "- generated: {now} (epoch secs; deterministic score: log(1+recalls) + 0.5^(age/86400))\n"
+        ));
+        out.push_str(&format!(
+            "- tracked: {} | promoted (top-K): {}\n\n",
+            self.items.len(),
+            ranked.len()
+        ));
+        if ranked.is_empty() {
+            out.push_str("_No sessions tracked yet._\n");
+            return out;
+        }
+        out.push_str("## Hot sessions\n\n");
+        out.push_str("| rank | key | recalls | last recall (age s) | heat | source |\n");
+        out.push_str("|---|---|---|---|---|---|\n");
+        for (i, (it, score)) in ranked.iter().enumerate() {
+            let age = now.saturating_sub(it.last_recalled_epoch_secs);
+            out.push_str(&format!(
+                "| {} | {} | {} | {} | {:.6} | {} |\n",
+                i + 1,
+                it.key,
+                it.recalls,
+                age,
+                score.total,
+                it.source
+            ));
+        }
+        out.push_str("\n## Detail\n\n");
+        for (it, score) in &ranked {
+            out.push_str(&format!(
+                "- **{}** — recalls={}, heat={:.6} (freq={:.6}, recency={:.6})\n  {}\n",
+                it.key, it.recalls, score.total, score.frequency, score.recency, it.text
+            ));
+        }
+        out
+    }
+}
+
+// ---------------------------------------------------------------------------
+// US-SM-06 / FR-SM-11 — repeated successful tool traces => workflow proposals
+// ---------------------------------------------------------------------------
+
+pub const WORKFLOW_PROPOSALS_DIR: &str = "proposals";
+/// Minimum repeated occurrences before a trace is proposed (FR-SM-11).
+pub const MIN_SEQUENCE_LEN: usize = 3;
+/// Proposal detail step must be of length >= 3 to count as a shared trace.
+const MIN_TRACE_LEN: usize = 3;
+
+/// One proposed `add_ontology_workflow` payload (FR-SM-11). This is a
+/// PROPOSAL only — the harness/human reviews and confirms; LeanKG never
+/// writes it into `ontology/` YAML as source of truth.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct WorkflowProposal {
+    pub name: String,
+    pub description: String,
+    pub steps: Vec<String>,
+    pub occurrences: usize,
+    pub confidence: f64,
+    pub created_epoch_secs: u64,
+}
+
+/// A proposal persisted to `.leankg/proposals/workflows.jsonl`. The content
+/// key dedups identical step sequences (FR-SM-04-style hashing).
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq)]
+pub struct ProposalRecord {
+    pub content_key: String,
+    pub proposal: WorkflowProposal,
+}
+
+/// Mines repeated successful multi-tool sequences into workflow proposals.
+/// Pure: no I/O, no ontology writes.
+#[derive(Debug)]
+pub struct SequenceMiner {
+    min_occurrences: usize,
+    min_trace_len: usize,
+}
+
+impl SequenceMiner {
+    pub fn new(min_occurrences: usize, min_trace_len: usize) -> Self {
+        Self {
+            min_occurrences,
+            min_trace_len,
+        }
+    }
+
+    pub fn propose(
+        &self,
+        traces: &[Vec<String>],
+        positive_terms: Option<&[&str]>,
+    ) -> Vec<WorkflowProposal> {
+        use std::collections::HashMap;
+        let mut counts: HashMap<Vec<String>, usize> = HashMap::new();
+        for t in traces {
+            if t.len() < self.min_trace_len {
+                continue;
+            }
+            let trimmed: Vec<String> = t
+                .iter()
+                .map(|s| s.trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+            if trimmed.len() < self.min_trace_len {
+                continue;
+            }
+            *counts.entry(trimmed).or_insert(0) += 1;
+        }
+        let mut proposals = Vec::new();
+        for (steps, occurrences) in counts {
+            if occurrences < self.min_occurrences {
+                continue;
+            }
+            if let Some(terms) = positive_terms {
+                if !terms.iter().any(|t| steps.contains(&t.to_string())) {
+                    continue;
+                }
+            }
+            proposals.push(WorkflowProposal {
+                name: workflow_name(&steps),
+                description: format!(
+                    "Repeated {} times across sessions: {}",
+                    occurrences,
+                    steps.join(" → ")
+                ),
+                steps,
+                occurrences,
+                confidence: confidence(occurrences),
+                created_epoch_secs: now_unix_secs(),
+            });
+        }
+        proposals.sort_by(|a, b| {
+            b.occurrences
+                .cmp(&a.occurrences)
+                .then_with(|| a.name.cmp(&b.name))
+        });
+        proposals
+    }
+}
+
+impl Default for SequenceMiner {
+    fn default() -> Self {
+        Self::new(MIN_SEQUENCE_LEN, MIN_TRACE_LEN)
+    }
+}
+
+/// Deterministic snake-case workflow name from the step sequence.
+fn workflow_name(steps: &[String]) -> String {
+    let mut joined: Vec<String> = steps
+        .iter()
+        .map(|s| s.split('_').collect::<Vec<_>>().join(" "))
+        .collect();
+    let joined_str = joined.join(" ");
+    joined = joined_str.split_whitespace().map(str::to_string).collect();
+    let mut name = joined
+        .into_iter()
+        .map(|w| {
+            w.chars()
+                .filter(|c| c.is_ascii_alphanumeric())
+                .collect::<String>()
+        })
+        .filter(|w| !w.is_empty())
+        .collect::<Vec<String>>()
+        .join("_");
+    if name.is_empty() {
+        name = "workflow".to_string();
+    }
+    name
+}
+
+/// Confidence grows with occurrences, saturating near 1.0.
+fn confidence(occurrences: usize) -> f64 {
+    1.0 - 0.5f64.powi(occurrences as i32 - 1)
+}
+
+fn now_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
 /// One offload operation: write ref, update canvas, return compact context.
 /// Stateless across calls — node_id derives from the canvas on disk, so the
 /// MCP handler needs no per-session in-memory state.
@@ -880,5 +1255,101 @@ mod tests {
             "recall must never block beyond the timeout: {:?}",
             start.elapsed()
         );
+    }
+
+    // ------------------------------------------------------------------
+    // US-SM-05 / US-SM-06 / FR-SM-10 / FR-SM-11 — heat promotion
+    // ------------------------------------------------------------------
+
+    #[test]
+    fn heat_promotion_recall_path_bumps_heat() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = MemoryIndex::new(tmp.path()).unwrap();
+        idx.record_hit("wf-debug", "LESSONS.md", "debug workflow", 100)
+            .unwrap();
+        idx.record_recall("wf-debug", 200).unwrap();
+        idx.record_recall("wf-debug", 250).unwrap();
+        let now = 260;
+        let scored = heat_score(3, 250, now);
+        let top = idx.top_k(5, now);
+        assert_eq!(top.len(), 1);
+        assert_eq!(top[0].0.recalls, 3, "hit + 2 recalls");
+        assert_eq!(top[0].1.total, scored, "score equals pure fn");
+    }
+
+    #[test]
+    fn heat_promotion_top_k_truncates_and_orders() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = MemoryIndex::new(tmp.path()).unwrap();
+        for i in 0..20 {
+            idx.record_hit(
+                &format!("k{i:02}"),
+                "diary",
+                &format!("key {i}"),
+                1000 + i as u64,
+            )
+            .unwrap();
+        }
+        let top = idx.top_k(5, 2000);
+        assert_eq!(top.len(), 5, "top-K truncation");
+        // monotonic heat within the promoted slice
+        for w in top.windows(2) {
+            assert!(w[0].1.total >= w[1].1.total, "ranked desc: {:?}", w);
+        }
+        let md = idx.render();
+        assert!(md.contains("| rank | key |"), "table header: {md}");
+    }
+
+    #[test]
+    fn heat_promotion_markdown_is_white_box() {
+        let tmp = TempDir::new().unwrap();
+        let mut idx = MemoryIndex::new(tmp.path()).unwrap();
+        idx.record_hit("hot-session", "search telemetry", "the hot session", 100)
+            .unwrap();
+        let md = idx.render();
+        assert!(md.contains("hot-session"));
+        assert!(md.contains("recalls=1"), "raw recall count visible: {md}");
+        assert!(md.contains("heat="), "raw heat visible: {md}");
+        assert!(
+            md.contains("log(1+recalls) + 0.5^(age/86400)"),
+            "deterministic formula documented: {md}"
+        );
+    }
+
+    #[test]
+    fn workflow_proposal_shape_matches_add_ontology_workflow_payload() {
+        let miner = SequenceMiner::default();
+        let traces: Vec<Vec<String>> = vec![
+            vec!["search_code", "get_context", "query_file"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            vec!["search_code", "get_context", "query_file"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+            vec!["search_code", "get_context", "query_file"]
+                .into_iter()
+                .map(String::from)
+                .collect(),
+        ];
+        let proposals = miner.propose(&traces, None);
+        assert_eq!(proposals.len(), 1);
+        let p = &proposals[0];
+        // `add_ontology_workflow` requires name + description + steps array
+        assert!(!p.name.is_empty());
+        assert!(!p.description.is_empty());
+        assert_eq!(p.steps.len(), 3);
+        assert!(p.occurrences >= 3);
+        assert!(p.confidence > 0.5, "confidence grows with occurrences");
+    }
+
+    #[test]
+    fn workflow_proposal_dedup_key_identifies_sequence() {
+        let seq = vec!["search_code".to_string(), "get_context".to_string()];
+        let key = content_key(&seq.join("|"));
+        assert_eq!(key.len(), 12, "12-hex content key");
+        let seq2 = vec!["search_code".to_string(), "query_file".to_string()];
+        assert_ne!(key, content_key(&seq2.join("|")));
     }
 }

--- a/tests/session_heat_promote_tests.rs
+++ b/tests/session_heat_promote_tests.rs
@@ -1,0 +1,325 @@
+//! US-SM-05 / US-SM-06 / FR-SM-10 / FR-SM-11 — heat promotion tests.
+//!
+//! White-box heat-ranked `.leankg/MEMORY_INDEX.md` (FR-SM-10) and workflow
+//! proposals (FR-SM-11). Proposals must NEVER write ontology YAML as SoT —
+//! YAML files under `ontology/` are only read, never modified.
+
+use leankg::session::{
+    content_key, heat_score, HeatScore, MemoryIndex, ProposalRecord, SequenceMiner,
+    WorkflowProposal, MEMORY_INDEX_JSON, MEMORY_INDEX_MD, MIN_SEQUENCE_LEN, WORKFLOW_PROPOSALS_DIR,
+};
+use tempfile::TempDir;
+
+fn ts(secs: u64) -> u64 {
+    secs
+}
+
+#[test]
+fn heat_score_is_deterministic_and_ranks_recency() {
+    let a = heat_score(3, ts(100), ts(500));
+    let b = heat_score(3, ts(100), ts(500));
+    assert_eq!(a, b, "same inputs must produce identical score");
+    // recency: later last_recall beats earlier one
+    let recent = heat_score(3, ts(400), ts(500));
+    assert!(
+        recent > a,
+        "more recent recall must score higher (recent {recent:.6} vs old {a:.6})"
+    );
+    // frequency: more recalls beats fewer at equal recency
+    let more = heat_score(9, ts(100), ts(500));
+    assert!(
+        more > a,
+        "more recalls must score higher (more {more:.6} vs fewer {a:.6})"
+    );
+}
+
+#[test]
+fn memory_index_refresh_writes_markdown_sorted_by_heat() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let mut idx = MemoryIndex::new(project).expect("new index");
+
+    idx.record_hit(
+        "open_conversation",
+        "src/conversation_indexer/mod.rs",
+        "open_conversation parses Claude export JSON",
+        ts(100),
+    )
+    .expect("record hit");
+    idx.record_hit(
+        "load_layer",
+        "src/mcp/handler.rs",
+        "load_layer expands a layer",
+        ts(200),
+    )
+    .expect("record hit");
+    idx.record_hit(
+        "load_layer",
+        "src/mcp/handler.rs",
+        "load_layer expands a layer",
+        ts(300),
+    )
+    .expect("second hit same key");
+
+    idx.refresh().expect("refresh");
+    let md =
+        std::fs::read_to_string(project.join(".leankg").join(MEMORY_INDEX_MD)).expect("index md");
+    assert!(md.contains("# MEMORY_INDEX"), "header: {md}");
+    assert!(md.contains("load_layer"), "hot key listed: {md}");
+    assert!(md.contains("open_conversation"), "cold key listed: {md}");
+    // 2 recalls beats 1 recall → load_layer must rank first
+    let li = md.find("load_layer").expect("load_layer pos");
+    let oc = md.find("open_conversation").expect("open_conversation pos");
+    assert!(li < oc, "higher heat ranks first: {md}");
+    // white-box: raw score visible in the markdown
+    assert!(md.contains("heat="), "score visible: {md}");
+    // json sidecar kept in sync
+    let stored: MemoryIndex = MemoryIndex::load(project).expect("load json");
+    assert_eq!(stored.items().len(), 2, "two distinct keys");
+}
+
+#[test]
+fn memory_index_marks_recalled_and_tracks_last_recall() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let mut idx = MemoryIndex::new(project).expect("new index");
+    idx.record_hit("hot_key", "src/a.rs", "some hot key", ts(100))
+        .expect("record");
+    idx.record_recall("hot_key", ts(300)).expect("recall");
+    let stored = MemoryIndex::load(project).expect("load");
+    let item = stored.items().iter().find(|i| i.key == "hot_key").unwrap();
+    assert_eq!(item.recalls, 2, "recall counts as a hit");
+    assert_eq!(item.last_recalled_epoch_secs, ts(300));
+    // unknown key recall is a no-op, not an error
+    assert!(idx.record_recall("missing", ts(300)).is_ok());
+}
+
+#[test]
+fn refresh_does_not_touch_ontology_yaml() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    // fixture ontology SoT next to the project
+    let ont_dir = project.join("ontology");
+    std::fs::create_dir_all(&ont_dir).unwrap();
+    let concepts = ont_dir.join("concepts.yaml");
+    let workflows = ont_dir.join("workflows.yaml");
+    std::fs::write(&concepts, "kind: concepts\nunchanged: true\n").unwrap();
+    std::fs::write(&workflows, "kind: workflows\nunchanged: true\n").unwrap();
+    let before = std::fs::read(&concepts).unwrap();
+
+    let mut idx = MemoryIndex::new(project).expect("new index");
+    idx.record_hit("k1", "src/a.rs", "k1 body", ts(1))
+        .expect("hit");
+    idx.record_hit("k2", "src/b.rs", "k2 body", ts(2))
+        .expect("hit");
+    idx.refresh().expect("refresh");
+
+    let after = std::fs::read(&concepts).unwrap();
+    let after_wf = std::fs::read(&workflows).unwrap();
+    assert_eq!(before, after, "concepts.yaml must not be modified");
+    assert_eq!(
+        std::fs::read_to_string(&workflows).unwrap(),
+        "kind: workflows\nunchanged: true\n",
+        "workflows.yaml must not be modified"
+    );
+    let _ = after_wf;
+}
+
+#[test]
+fn refresh_is_noop_when_nothing_changed() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let mut idx = MemoryIndex::new(project).expect("new index");
+    idx.record_hit("k1", "src/a.rs", "k1 body", ts(1))
+        .expect("hit");
+    idx.refresh().expect("refresh");
+    let md_path = project.join(".leankg").join(MEMORY_INDEX_MD);
+    let first = std::fs::read(&md_path).unwrap();
+
+    idx.refresh().expect("second refresh");
+    let second = std::fs::read(&md_path).unwrap();
+    assert_eq!(first, second, "unchanged index must not rewrite the file");
+}
+
+#[test]
+fn sequence_miner_detects_repeated_successful_traces() {
+    let miner = SequenceMiner::default();
+    let traces = vec![
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        vec!["get_dependencies".to_string()],
+    ];
+    let proposals = miner.propose(&traces, None);
+    assert!(!proposals.is_empty(), "repeated trace must be proposed");
+    let p = &proposals[0];
+    assert_eq!(p.steps, vec!["search_code", "get_context", "query_file"]);
+    assert!(p.occurrences >= 3, "occurrences: {}", p.occurrences);
+    assert!(
+        p.occurrences >= MIN_SEQUENCE_LEN,
+        "must meet min occurrences"
+    );
+}
+
+#[test]
+fn sequence_miner_supports_positive_negative_heuristics() {
+    // positive: repeated 3-step trace followed by "get_context" win
+    let positive = vec![
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+    ];
+    let out_pos = SequenceMiner::default().propose(&positive, Some(&["get_context"]));
+    assert!(
+        !out_pos.is_empty(),
+        "repeated trace with win marker must be proposed"
+    );
+    // negative: trace repeated enough but no win marker => rejected by filter
+    let negative = vec![
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+    ];
+    let out_neg = SequenceMiner::default().propose(&negative, Some(&["win_tool_not_in_trace"]));
+    assert!(
+        out_neg.is_empty(),
+        "trace without win marker must not be proposed"
+    );
+}
+
+#[test]
+fn workflow_proposal_writes_jsonl_only_and_preserves_ontology() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let ont_dir = project.join("ontology");
+    std::fs::create_dir_all(&ont_dir).unwrap();
+    let workflows = ont_dir.join("workflows.yaml");
+    std::fs::write(&workflows, "kind: workflows\nunchanged: true\n").unwrap();
+
+    let proposal = WorkflowProposal {
+        name: "trace_code_provenance".to_string(),
+        description: "search then drill into context then read the file".to_string(),
+        steps: vec![
+            "search_code".to_string(),
+            "get_context".to_string(),
+            "query_file".to_string(),
+        ],
+        occurrences: 3,
+        confidence: 0.9,
+        created_epoch_secs: ts(1000),
+    };
+    let rec = ProposalRecord {
+        proposal,
+        content_key: content_key("search_code|get_context|query_file"),
+    };
+    let dir = project.join(".leankg").join(WORKFLOW_PROPOSALS_DIR);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join("workflows.jsonl");
+    let rec_json = serde_json::to_string(&rec).expect("serialize");
+    std::fs::write(&path, format!("{rec_json}\n")).unwrap();
+
+    // write to .leankg only; ontology YAML untouched
+    assert!(path.exists(), "proposal file exists");
+    let yaml = std::fs::read_to_string(&workflows).unwrap();
+    assert_eq!(
+        yaml, "kind: workflows\nunchanged: true\n",
+        "ontology SoT intact"
+    );
+    assert!(
+        rec.content_key == content_key("search_code|get_context|query_file"),
+        "dedup key matches"
+    );
+}
+
+#[test]
+fn proposal_round_trips_json() {
+    let p = WorkflowProposal {
+        name: "n".to_string(),
+        description: "d".to_string(),
+        steps: vec!["a".to_string(), "b".to_string()],
+        occurrences: 2,
+        confidence: 0.5,
+        created_epoch_secs: 1,
+    };
+    let rec = ProposalRecord {
+        content_key: content_key("a|b"),
+        proposal: p,
+    };
+    let s = serde_json::to_string(&rec).unwrap();
+    let back: ProposalRecord = serde_json::from_str(&s).unwrap();
+    assert_eq!(back.proposal.name, "n");
+    assert_eq!(back.proposal.steps, vec!["a", "b"]);
+    assert_eq!(back.proposal.occurrences, 2);
+}
+
+#[test]
+fn memory_index_json_round_trips_and_dedups_key() {
+    let tmp = TempDir::new().unwrap();
+    let project = tmp.path();
+    let mut idx = MemoryIndex::new(project).expect("new");
+    idx.record_hit("dup", "src/x.rs", "body", ts(1))
+        .expect("h1");
+    idx.record_hit("dup", "src/x.rs", "body", ts(2))
+        .expect("h2");
+    let loaded = MemoryIndex::load(project).expect("load");
+    assert_eq!(loaded.items().len(), 1, "same key deduped");
+    assert_eq!(loaded.items()[0].recalls, 2);
+    assert!(project.join(".leankg").join(MEMORY_INDEX_JSON).exists());
+}
+
+#[test]
+fn heat_score_struct_serializes() {
+    let hs = HeatScore {
+        frequency: 0.5,
+        recency: 0.5,
+        total: 1.0,
+    };
+    let s = serde_json::to_string(&hs).unwrap();
+    assert!(s.contains("\"total\":1.0") || s.contains("\"total\":1.0") || s.contains("total"));
+}
+
+#[test]
+fn heat_score_never_negative_and_zeros_for_never_recalled() {
+    let never = heat_score(0, 0, 1000);
+    assert!(never.is_finite() && never >= 0.0, "never recalled: {never}");
+    let now = ts(1000);
+    // a recall at the same instant as now must still score
+    let same = heat_score(1, now, now);
+    assert!(same.is_finite() && same > 0.0, "instant recall: {same}");
+}


### PR DESCRIPTION
## Summary
- IDs: US-SM-05, US-SM-06, FR-SM-10, FR-SM-11 (P2, Could Have)
- Seams: `heat_score(recalls, last_recalled, now)` pure fn; `MemoryIndex` (.leankg/MEMORY_INDEX.json state + MEMORY_INDEX.md render, refresh-on-recall, no-write-when-unchanged); `SequenceMiner::propose` -> `WorkflowProposal` JSONL at .leankg/proposals/workflows.jsonl

## What
- Deterministic heat = recall frequency + recency: `log(1+recalls) + 0.5^(age/86400)`, pure + testable
- Top-K (default 10) promoted into white-box markdown index; raw scores visible (no opaque probing)
- Repeated successful multi-tool traces (>=3 occurrences, optional positive-term filter) become `add_ontology_workflow` PROPOSALS — never written into ontology YAML as SoT; agent/harness reviews `.leankg/proposals/workflows.jsonl` then confirms via existing `add_ontology_workflow`
- Ontology write-protection asserted in tests: fixture `ontology/concepts.yaml` + `workflows.yaml` byte-identical after refresh + proposal write

## Test plan
- [x] Red→green TDD slices (12 integration tests written first, then lib seam)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings` (0 warnings)
- [x] `cargo test --lib` (796 passed, 0 failed)
- [x] `cargo test session` (filtered suites: 53 passed, 0 failed)
- [x] Integration / TempDir tests (17 total: 12 integration + 5 unit)
- [x] Evidence: `docs/reports/session-heat-promote-2026-08-02.md`
- [x] Tracker rows for DONE after merge: US-SM-05, US-SM-06, FR-SM-10, FR-SM-11
- [x] No resurrection of hard-deleted MCP tools
- [x] No AI attribution

## Tracker (conductor)
Mark DONE after merge: US-SM-05, US-SM-06, FR-SM-10, FR-SM-11.