### PR TITLE
docs(reports): REL-041 Track E 3D live evidence

### DIFF
--- a/docs/reports/rel-041-track-e-3d-2026-08-02.md
+++ b/docs/reports/rel-041-track-e-3d-2026-08-02.md
@@ -1,0 +1,168 @@
+# REL-041 — Track E 3D graph UI live evidence report
+
+**Date:** 2026-08-02
+**Tracker:** `REL-041` (release-level evidence for Track E 3D `graph-ui/`; keep 2D `ui/`)
+**PRD:** §8.3 roll-up — 3D graph UI Track E (`graph-ui/`; keep 2D `ui/`); FR-E01..E05 / FR-E10..E14 / FR-E20..E28 / US-CBM-E1
+**Campaign:** [`docs/planning/2026-08-01-all-open-prd-campaign.md`](../planning/2026-08-01-all-open-prd-campaign.md) — PR-54 `track-e-rel-041-evidence`
+
+## Summary
+
+Track E shipped across three merged PRs on `origin/main` — PR-50 (layout3d API,
+`#171`), PR-51 (graph-ui scaffold, `#181`), PR-52 (scene LOD, `#180`) — plus the
+in-flight PR-53 (panels). This report verifies every shipped piece exists on
+`origin/main`, the Rust + npm gates pass, and the 2D explorers `ui/` / `ui-v2/`
+remain untouched. The `graph-ui/` 3D explorer is a **separate** package from the
+2D explorers (own Vite config, own build, own dev server port 5174).
+
+## Environment
+
+| Item | Value |
+|------|-------|
+| Worktree | `.worktrees/prd/track-e-rel-041-evidence` |
+| Base commit (origin/main) | `169fa91f` — Merge PR-52 scene LOD (`#180`) |
+| Track E commits on base | `26a2afdd` scaffold (PR-51), `96dd6051` + `2edb110e` scene LOD (PR-52); PR-50 layout3d via `94dd500a`/tracker DONE (#171) |
+| graph-ui version | `0.1.0` (`leankg-graph-ui`, private) |
+| Rust version | cargo nightly/release toolchain per repo (release builds only) |
+
+## 1. Shipped pieces on origin/main — verified
+
+### Rust layout3d (PR-50, FR-E10..E14)
+
+| Piece | Location | Verified |
+|-------|----------|----------|
+| 3D layout module | `src/graph/layout3d.rs` (13 KB, `pub fn layout3d(node_ids, edges, iterations, seed) -> Layout3DResult`) | exists |
+| Module export | `src/graph/mod.rs:11` `pub mod layout3d;`, `:36` `pub use layout3d::*;` | exists |
+| REST route | `src/web/mod.rs:407` `.route("/api/graph/layout3d", get(handlers::api_graph_layout3d))` | exists |
+| Handler | `src/web/handlers.rs:3345` `api_graph_layout3d` — reads all elements + `calls/imports/contains/references` edges from DB, computes seeded 3D positions | exists |
+| Deterministic | same graph + same `iterations` + same `seed` → byte-identical positions (doc comment `handlers.rs:3343`) | 10 unit tests |
+
+Unit tests (`src/graph/layout3d.rs`): deterministic reproducibility, different
+seed ⇒ different positions, all nodes placed + finite bounds, positions within
+unit cube, connected nodes closer, z-axis spread, empty input, unknown-edge
+ignore, iteration clamp. Integration (`tests/layout3d_tests.rs`): real temp-file
+CozoDB round trip — deterministic + bounded, survives empty graph.
+
+### graph-ui/ 3D explorer (PR-51 + PR-52, FR-E01..E05 / FR-E20..E28)
+
+```
+graph-ui/package.json              # leankg-graph-ui 0.1.0, Vite + React 19 + three 0.175 + R3F + drei
+graph-ui/vite.config.ts            # dev port 5174, /api proxy → http://127.0.0.1:8080
+graph-ui/src/GraphExplorer.tsx     # main explorer shell
+graph-ui/src/scene/GraphScene.tsx  # R3F 3D scene (FR-E01/E02)
+graph-ui/src/lod/{lod,useLod}.ts   # adaptive LOD (FR-E20..E28)
+graph-ui/src/components/{LodNodeScene,DetailPanel,ClusterLegend}.tsx
+graph-ui/src/lib/{api,types,color,selection}.ts
+graph-ui/src/services/graphData.ts # layout3d fetch (on-demand, FR-E05)
+graph-ui/test/unit/                # vitest: api (4), color (3), graph-explorer (6)
+```
+
+API wiring: `graph-ui/src/lib/api.ts:20` fetches
+`/api/graph/layout3d?iterations=${iterations}&seed=${seed}`; dev proxy forwards
+`/api` to the LeanKG server on `:8080`.
+
+## 2. Live checks
+
+### Rust gates (worktree `prd/track-e-rel-041-evidence`)
+
+```
+cargo fmt --all -- --check         PASS
+cargo clippy --all -- -D warnings  PASS (0 warnings)
+cargo test --lib                   PASS — 801 passed, 0 failed
+cargo build --release              PASS (6m55s, v0.19.30)
+```
+
+### graph-ui gates
+
+```
+cd graph-ui && npm ci              PASS
+npm test                           PASS — 3 files, 13 tests (api 4, color 3, graph-explorer 6)
+npm run build                      PASS — tsc -b && vite build, dist/ built in ~1.5s
+```
+
+Build output: `dist/assets/index-*.js` 1053.6 kB (gzip 289.3 kB) — Vite chunk
+>500 kB warning only, no error.
+
+### Live-served REST
+
+`GET /api/graph/layout3d` — see [Live-served](#live-served) below.
+
+## 3. Keep-2D confirmation — ui/ and ui-v2/ untouched
+
+| Explorer | Present | Touched by Track E? | Latest commit |
+|----------|---------|---------------------|---------------|
+| `ui/` (2D Phase-1) | yes | no — last change pre-Track E (`7c5806f2`, readme) | `7c5806f2` |
+| `ui-v2/` (2D company explorer) | yes | no — last change `185dc4bd` (US-UI2-08/09) | `185dc4bd` |
+| `graph-ui/` (3D, Track E) | yes | Track E only (`26a2afdd`, `96dd6051`, `2edb110e`) | `2edb110e` |
+
+No Track E commit touches `ui/` or `ui-v2/` paths — verified via per-directory
+`git log`. `leankg serve` still serves `ui-v2/dist` preferentially and `ui/dist`
+as legacy (PRD requirement "do not block company ui-v2 on Track E" holds).
+
+## Live-served
+
+RUNNING — `leankg serve --port 18123 --project /tmp/rel041-proj` (release
+binary, v0.19.30) against a freshly indexed `src/` tree (188 files, 8747
+elements, 52575 relationships). `GET /api/graph/layout3d?iterations=30&seed=42`
+returned **HTTP 200 in 4.7s**:
+
+```json
+{
+  "success": true,
+  "data": {
+    "nodes": [
+      {"node_id": "/", "x": 0.0, "y": 1.0, "z": 0.6851153551888334},
+      {"node_id": "/Users", "x": 0.531343502103429, "y": 1.0, "z": 0.504387819611324},
+      {"node_id": "/Users/linh.doan", "x": 1.0, "y": 1.0, "z": 0.8535013373509193},
+      …
+    ],
+    "bounds": {
+      "min_x": 0.0, "max_x": 1.0,
+      "min_y": 0.0, "max_y": 1.0,
+      "min_z": 0.0001037212204974626, "max_z": 0.9999361514426429
+    }
+  },
+  "error": null
+}
+```
+
+Actual: 8938 nodes (every indexed element), all positions within unit cube,
+finite bounds — matches the deterministic layout contract. Mega-graph note:
+`layout3d` is O(n²) repulsion per iteration (same as the 2D layout) — a full
+89k-element repo took >100s at `iterations=30`; the graph-ui scene LOD /
+progressive-load (FR-E20..E28) caps the rendered node set client-side, so the
+server-side layout cost only binds on the full-element call. No code change
+needed — documented behavior, matches 2D `layout`.
+
+## Commands for a human to re-run
+
+```bash
+# 1. Index a project (small tree — layout3d is O(n²), keep < ~10k elements)
+mkdir -p /tmp/proj && cd /tmp/proj
+/path/to/leankg init --path /tmp/proj/.leankg
+/path/to/leankg index /path/to/src
+
+# 2. Rust server
+/path/to/leankg serve --port 8080 --project /tmp/proj
+
+# 3. Verify REST shape
+curl 'http://127.0.0.1:8080/api/graph/layout3d?iterations=30&seed=42'
+
+# 4. 3D explorer dev server (proxies /api → :8080)
+cd graph-ui && npm ci && npm run dev    # http://localhost:5174
+
+# 5. Verify proxied chain
+curl 'http://localhost:5174/api/graph/layout3d?iterations=30&seed=42'
+```
+
+## Gates
+
+- [x] `cargo fmt --all -- --check`
+- [x] `cargo clippy --all -- -D warnings`
+- [x] `cargo test --lib`
+- [x] `cd graph-ui && npm test`
+- [x] `cd graph-ui && npm run build`
+
+## Not in scope
+
+- PR-53 (panels FR-E30..E43) — in flight, separate PR
+- Tracker rows (`docs/prd-task-tracker.md` / `.json`) — conductor-owned; do not edit


### PR DESCRIPTION
## REL-041 — Track E 3D graph UI live evidence (PR-54)

Verifies Track E shipped pieces on origin/main (PR-50 layout3d #171, PR-51 scaffold #181, PR-52 scene LOD #180) and records live evidence.

### Report: docs/reports/rel-041-track-e-3d-2026-08-02.md

**Shipped pieces verified:**
- src/graph/layout3d.rs — pub fn layout3d (deterministic, seeded, unit-cube)
- GET /api/graph/layout3d — src/web/mod.rs:407 + src/web/handlers.rs:3345
- graph-ui/ — package.json (leankg-graph-ui 0.1.0), GraphExplorer.tsx, scene/GraphScene.tsx, lod/{lod,useLod}.ts, lib/api.ts (layout3d fetch), 13 vitest tests
- ui/ and ui-v2/ present, untouched by Track E (git log per-dir: last changes pre-Track E)

**Gates — ALL PASS:**
- cargo fmt --all -- --check
- cargo clippy --all -- -D warnings (0 warnings)
- cargo test --lib (801 passed, 0 failed)
- cargo build --release (6m55s, v0.19.30)
- graph-ui npm test (13 tests) + npm run build

**Live-served:** leankg serve (release) + curl of /api/graph/layout3d?iterations=30&seed=42 → HTTP 200 in 4.7s, 8938 nodes, all positions in unit cube, finite bounds. Mega-graph note: layout3d is O(n²) like 2D layout; scene LOD caps rendered set client-side.

NOTE: tracker ID REL-041 → DONE after merge (conductor-owned).