### PR TITLE
feat(ge): ADR extraction + install matrix + service_calls breadth (Wave 2e)

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ curl -fsSL https://raw.githubusercontent.com/FreePeak/LeanKG/main/scripts/instal
 | `cursor`                          | Binary + MCP + skill + AGENTS.md + session hook                           |
 | `claude`                          | Binary + MCP + plugin + skill + CLAUDE.md + hooks                         |
 | `opencode`                        | Binary + MCP + plugin + skill + AGENTS.md                                 |
+| `codex`                           | Binary + MCP (`~/.codex/config.toml`) + skill + AGENTS.md                 |
 | `gemini` / `kilo` / `antigravity` | Binary + MCP + skill + agent docs                                         |
 | `docker`                          | Hub image (`freepeak/leankg:latest`, `:0.19.21`) + MCP HTTP (**no Rust**) |
 
@@ -334,8 +335,9 @@ Repo ──► Indexer ──► Knowledge Graph ──► MCP Tools ──► A
 | Cursor                     | Yes        | Per-project install; always-on graph-first rule + session hook; skill `using-leankg` |
 | Claude Code                | Yes        | Plugin + full lifecycle hooks (PreToolUse nudge)                                     |
 | OpenCode                   | Yes        | Plugin + skill                                                                       |
+| Codex CLI                  | Yes        | `~/.codex/config.toml` `[mcp_servers.leankg]` + skill + AGENTS.md                    |
 | Gemini CLI                 | Yes        | MCP + skill / agent docs                                                             |
-| Codex / Antigravity / Kilo | Yes        | MCP + skill / agent docs                                                             |
+| Antigravity / Kilo         | Yes        | MCP + skill / agent docs                                                             |
 | Docker MCP HTTP            | Yes        | Shared RocksDB; multi-repo mounts                                                    |
 
 ```bash
@@ -457,6 +459,8 @@ Full CLI: [docs/cli-reference.md](docs/cli-reference.md)
 | [docs/cli-reference.md](docs/cli-reference.md)               | All CLI commands                                                                           |
 | [docs/mcp-tools.md](docs/mcp-tools.md)                       | MCP tool reference                                                                         |
 | [docs/agentic-instructions.md](docs/agentic-instructions.md) | AI tool setup & auto-trigger                                                               |
+| [docs/install-matrix.md](docs/install-matrix.md)             | Assistant install matrix (Cursor / Claude Code / Codex / …)                                |
+| [docs/reflect-skill.md](docs/reflect-skill.md)               | Reflect / query-outcome loop guidance                                                      |
 | [docs/architecture.md](docs/architecture.md)                 | System design & data model                                                                 |
 | [docs/web-ui.md](docs/web-ui.md)                             | Web UI                                                                                     |
 | [docs/benchmark.md](docs/benchmark.md)                       | Benchmark methodology                                                                      |

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -43,6 +43,12 @@ cargo run -- impact <file> --depth 3   # Calculate impact radius
 cargo run -- status            # Show index status
 ```
 
+### Reflect (US-GF-16)
+After a graph query resolves a task, call `report_query_outcome` once
+(`useful` / `dead_end` / `corrected`, with a `note` on what worked for
+dead-ends/corrections). Lessons land in `.leankg/reflections/LESSONS.md` and
+feed next-session recall. See [`docs/reflect-skill.md`](reflect-skill.md).
+
 ---
 
 ## Code Structure Overview

--- a/docs/install-matrix.md
+++ b/docs/install-matrix.md
@@ -1,0 +1,42 @@
+# Assistant Install Matrix (US-GF-15 / FR-GF-23)
+
+One-command install for every supported AI coding tool. All targets install the
+binary + MCP wiring + skills/agent docs via `scripts/install.sh`.
+
+## Quick install
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/FreePeak/LeanKG/main/scripts/install.sh | bash -s -- <target>
+```
+
+| Target      | Config written                                        | Skill / docs              | Hooks / rules            |
+| ----------- | ----------------------------------------------------- | ------------------------- | ------------------------ |
+| `cursor`    | `.cursor/mcp.json` (per-project) + `~/.cursor/mcp.json` | `~/.cursor/skills/using-leankg` + `~/.cursor/AGENTS.md` | graph-first rule + session hook |
+| `claude`    | `~/.config/claude/settings.json` (`mcpServers.leankg`) | `~/.config/claude/CLAUDE.md` | PreToolUse nudge hooks   |
+| `opencode`  | `.opencode.json` (per-project)                        | `~/.config/opencode/skills/using-leankg` + `AGENTS.md` | —                        |
+| `codex`     | `~/.codex/config.toml` (`[mcp_servers.leankg]`)      | `~/.codex/skills/using-leankg` + `~/.codex/AGENTS.md` | —                        |
+| `gemini`    | `~/.gemini/settings.json` or `gemini mcp add`         | `~/.gemini/skills/using-leankg` + `GEMINI.md` | —                        |
+| `kilo`      | `~/.config/kilo/kilo.json`                            | `~/.config/kilo/skills/using-leankg` + `AGENTS.md` | —                        |
+| `antigravity` | `~/.gemini/antigravity/`                            | `~/.gemini/antigravity/skills` | —                        |
+| `docker`    | — (no binary)                                         | —                          | MCP HTTP `:9699`         |
+
+## Manual equivalents
+
+| Tool | File | Snippet |
+| ---- | ---- | ------- |
+| Codex CLI | `~/.codex/config.toml` | `[mcp_servers.leankg]\ncommand = "leankg"\nargs = ["mcp-stdio", "--watch"]` |
+| Cursor | `~/.cursor/mcp.json` | `{"mcpServers": {"leankg": {"command": "leankg", "args": ["mcp-stdio", "--watch"]}}}` |
+| Claude Code | `~/.config/claude/settings.json` | same shape under `mcpServers` |
+| OpenCode | `~/.config/opencode/opencode.json` | `{"mcp": {"leankg_dev": {"type": "local", "command": ["leankg", "mcp-stdio", "--watch"]}}}` |
+| Gemini | `gemini mcp add leankg leankg mcp-stdio --watch --scope user` | — |
+
+After install, index a project and verify:
+
+```bash
+leankg init && leankg index ./src
+curl -sf http://localhost:9699/health   # Docker MCP only
+```
+
+> **Docker MCP project paths:** when talking to the containerized MCP on
+> `:9699`, pass the **container mount** as `project=` (e.g. `/workspace`), never
+> a Mac host path. See [AGENTS.md](AGENTS.md).

--- a/docs/mcp-setup.md
+++ b/docs/mcp-setup.md
@@ -62,6 +62,16 @@ Add to `~/.config/claude/settings.json`:
 }
 ```
 
+### Codex CLI
+
+Add to `~/.codex/config.toml`:
+
+```toml
+[mcp_servers.leankg]
+command = "leankg"
+args = ["mcp-stdio", "--watch"]
+```
+
 ### Gemini CLI
 
 Add to `~/.config/gemini-cli/mcp.json`:

--- a/docs/reflect-skill.md
+++ b/docs/reflect-skill.md
@@ -1,0 +1,57 @@
+# Reflect / Query-Outcome Loop (US-GF-16)
+
+Default skill guidance for agents: **record what worked, load it next session.**
+
+## Loop
+
+```
+answer (useful / dead_end / corrected)
+  → report_query_outcome(question, nodes, outcome, note)   # append LESSONS.md
+  → next session: session recall / overview enrichment loads LESSONS
+```
+
+## When to report
+
+Call `report_query_outcome` after any LeanKG graph query that resolves a task:
+
+| Outcome | Use when |
+| ------- | -------- |
+| `useful` | Query result directly answered the question |
+| `dead_end` | Query returned nothing useful; note what to try instead |
+| `corrected` | You fixed a wrong answer; note the correct resolution |
+
+Guidance:
+
+- Report **once per task**, not per tool call.
+- `note` is optional but high-value: capture the resolution so the next agent
+  skips the dead end.
+- Useful results bias future ranking toward the same nodes.
+
+## Where lessons land
+
+- `.leankg/reflections/LESSONS.md` — append-only journal written by
+  `report_query_outcome` (US-GF-09 / FR-GF-19).
+- `.leankg/sessions/recall_index.jsonl` — recall index fed by LESSONS,
+  diary, and knowledge writes (US-SM-01..04).
+- Session start: `get_overview_context` with `recall=true` injects ranked
+  lessons (US-SM-02, default OFF); `session_recall` recovers a single ref.
+
+## Default skill guidance
+
+Add this block to the agent's `using-leankg` skill / AGENTS.md:
+
+```markdown
+### Reflect
+
+After a graph query resolves a task, call
+`report_query_outcome(question, nodes, outcome: useful|dead_end|corrected, note)`
+once. If `dead_end` or `corrected`, include what actually worked in `note`.
+Do not report per-tool-call; one report per task.
+```
+
+## Verify
+
+```bash
+ls .leankg/reflections/LESSONS.md          # exists after first report
+tail -5 .leankg/reflections/LESSONS.md     # latest entry
+```

--- a/instructions/using-leankg/SKILL.md
+++ b/instructions/using-leankg/SKILL.md
@@ -104,6 +104,15 @@ After `mcp_index_docs`, path aliases resolve on read; markdown refs resolve to i
 
 Miss payloads include `tried[]` — do not assume empty graph when aliases fail.
 
+### Reflect (US-GF-16)
+
+After a graph query resolves a task, call
+`report_query_outcome(question, nodes, outcome: useful|dead_end|corrected, note)`
+**once per task** (not per tool call). If `dead_end` or `corrected`, include
+what actually worked in `note`. Lessons append to
+`.leankg/reflections/LESSONS.md` and feed next-session recall. See
+[`docs/reflect-skill.md`](../../docs/reflect-skill.md).
+
 ### Hard-removed tools (do not call)
 
 `mcp_hello`, `mcp_impact`, `get_doc_for_file`, `find_clones`, `wake_up`, `search_by_environment`, `load_layer`, `get_doc_structure`

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -22,6 +22,7 @@ Commands:
   opencode      Install and configure LeanKG for OpenCode AI
   cursor        Install and configure LeanKG for Cursor AI
   claude        Install and configure LeanKG for Claude Code/Desktop
+  codex         Install and configure LeanKG for Codex CLI
   gemini        Install and configure LeanKG for Gemini CLI
   kilo          Install and configure LeanKG for Kilo Code
   antigravity   Install and configure LeanKG for Anti Gravity
@@ -1370,10 +1371,52 @@ EOF
     echo "Configured LeanKG for Kilo at $config_file"
 }
 
+configure_codex() {
+    # Codex CLI reads ~/.codex/config.toml with an [mcp_servers.*] section.
+    local config_dir="$HOME/.codex"
+    local config_file="$config_dir/config.toml"
+    local leankg_path="${INSTALL_DIR}/${BINARY_NAME}"
+    local needs_update=false
+
+    mkdir -p "$config_dir"
+
+    if [ -f "$config_file" ]; then
+        if grep -q '\[mcp_servers.leankg\]' "$config_file" 2>/dev/null; then
+            local current_path
+            current_path=$(grep -A3 '\[mcp_servers.leankg\]' "$config_file" | grep 'command' | sed -nE 's/.*command[[:space:]]*=[[:space:]]*"?([^"]*)"?.*/\1/p' | head -1)
+            if [ -n "$current_path" ] && [ "$current_path" != "$leankg_path" ]; then
+                echo "Updating LeanKG binary path in Codex config: $current_path -> $leankg_path"
+                needs_update=true
+            else
+                echo "LeanKG already properly configured in Codex"
+                return
+            fi
+        else
+            needs_update=true
+        fi
+    else
+        needs_update=true
+    fi
+
+    local tmp_file
+    tmp_file=$(mktemp)
+    if [ -f "$config_file" ]; then
+        grep -v '\[mcp_servers.leankg\]' "$config_file" > "$tmp_file" 2>/dev/null || true
+    fi
+    cat >> "$tmp_file" <<EOF
+
+[mcp_servers.leankg]
+command = "$leankg_path"
+args = ["mcp-stdio", "--watch"]
+EOF
+    mv "$tmp_file" "$config_file"
+    echo "Configured LeanKG for Codex at $config_file"
+}
+
 configure_gemini() {
     local leankg_path="${INSTALL_DIR}/${BINARY_NAME}"
     local needs_update=false
-    
+
     if command -v gemini >/dev/null 2>&1; then
         echo "Configuring LeanKG for Gemini CLI using 'gemini mcp add'..."
         gemini mcp add leankg "$leankg_path" mcp-stdio --watch --scope user || true
@@ -1740,7 +1783,7 @@ main() {
             curl -fsSL "$GITHUB_RAW/scripts/docker-up.sh" | bash
             exit 0
             ;;
-        opencode|cursor|claude|gemini|kilo|antigravity)
+        opencode|cursor|claude|codex|gemini|kilo|antigravity)
             install_binary "$platform" "full"
             ;;
         *)
@@ -1769,6 +1812,11 @@ main() {
                 configure_claude
                 setup_claude_hooks
                 install_claude_instructions
+                ;;
+            codex)
+                configure_codex
+                install_leankg_skill "$HOME/.codex/skills" "codex"
+                install_agents_instructions "$HOME/.codex/AGENTS.md"
                 ;;
             gemini)
                 configure_gemini

--- a/src/doc_indexer/mod.rs
+++ b/src/doc_indexer/mod.rs
@@ -166,6 +166,13 @@ impl DocIndexer {
         let code_refs = self.extract_code_references(&content);
         let mut relationships = heading_rels;
 
+        // FR-GF-16: ADR/RFC citations → rationale nodes + cited_by/references edges.
+        let (rationale_elements, rationale_rels) =
+            extract_rationale_citations(&content, &qualified_name);
+        let mut sections = sections;
+        sections.extend(rationale_elements);
+        relationships.extend(rationale_rels);
+
         let mut resolved_count = 0u32;
         let mut skipped_count = 0u32;
 
@@ -619,6 +626,171 @@ impl DocTreeNode {
     }
 }
 
+/// FR-GF-16: extract ADR/RFC citation markers from markdown content.
+///
+/// Recognized citation shapes (outside fenced code blocks):
+/// - ADR headings / inline refs: `## ADR-004`, `ADR-004:`, `[ADR-004](…adr-0004.md)`,
+///   `AD-0001`, `doc/adr/0001-…`
+/// - RFC citations: `RFC 8252`, `RFC8252`, `RFC 8252:`
+///
+/// Each citation becomes a `rationale` CodeElement (element_type
+/// `rationale_adr` / `rationale_rfc`) carrying the citation id + title in
+/// metadata, plus:
+/// - a `contains`-style `cited_by` edge from the citing document to the
+///   rationale node (source = document, target = rationale),
+/// - a `references` edge from the rationale node to the citation's own doc
+///   file when the ADR text contains a resolvable `docs/adr/…` link target.
+///
+/// Returns (rationale_elements, relationships).
+pub fn extract_rationale_citations(
+    content: &str,
+    doc_qualified: &str,
+) -> (Vec<CodeElement>, Vec<Relationship>) {
+    use regex::Regex;
+    let mut elements: Vec<CodeElement> = Vec::new();
+    let mut relationships: Vec<Relationship> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    let adr_re = Regex::new(r"(?i)\b(?:ADR|AD)[-_: ]?(\d{3,4})\b").unwrap();
+    let rfc_re = Regex::new(r"(?i)\bRFC[-: ]?(\d{2,5})\b").unwrap();
+    // docs/adr/0001-title.md or docs/decisions/0001-title.md
+    let adr_link_re =
+        Regex::new(r"(?i)(?:docs/)?(?:adr|decisions?)/?(\d{3,4})[-_][\w-]+\.md").unwrap();
+
+    let mut in_code_block = false;
+    for (line_idx, line) in content.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.starts_with("```") {
+            in_code_block = !in_code_block;
+            continue;
+        }
+        if in_code_block || trimmed.is_empty() {
+            continue;
+        }
+
+        // ADR citation
+        if let Some(cap) = adr_re.captures(trimmed) {
+            let id = cap
+                .get(1)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            let marker = if trimmed.to_uppercase().contains("ADR") {
+                "ADR"
+            } else {
+                "AD"
+            };
+            let key = format!("{}:{}", marker, id);
+            if seen.insert(key.clone()) {
+                // Title: try "ADR-004: Title" or "ADR-004 Title"
+                let title = trimmed
+                    .split_once(':')
+                    .map(|(_, t)| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+                    .unwrap_or_else(|| {
+                        trimmed
+                            .split_whitespace()
+                            .skip(1)
+                            .collect::<Vec<_>>()
+                            .join(" ")
+                    });
+                let qn = format!("{}::{}@{}", doc_qualified, key, line_idx);
+                elements.push(CodeElement {
+                    qualified_name: qn.clone(),
+                    element_type: "rationale_adr".to_string(),
+                    name: format!("{} {}", key, title.chars().take(60).collect::<String>()),
+                    file_path: doc_qualified.to_string(),
+                    line_start: (line_idx + 1) as u32,
+                    line_end: (line_idx + 1) as u32,
+                    language: "markdown".to_string(),
+                    parent_qualified: Some(doc_qualified.to_string()),
+                    metadata: serde_json::json!({
+                        "marker": marker,
+                        "kind": "rationale_adr",
+                        "citation_id": format!("{}-{}", marker, id),
+                        "summary": title.chars().take(200).collect::<String>(),
+                    }),
+                    ..Default::default()
+                });
+                relationships.push(Relationship {
+                    id: None,
+                    source_qualified: doc_qualified.to_string(),
+                    target_qualified: qn.clone(),
+                    rel_type: "cited_by".to_string(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({"marker": marker, "citation_id": format!("{}-{}", marker, id)}),
+                    ..Default::default()
+                });
+            }
+        }
+
+        // RFC citation
+        if let Some(cap) = rfc_re.captures(trimmed) {
+            let id = cap
+                .get(1)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            let key = format!("RFC:{}", id);
+            if seen.insert(key.clone()) {
+                let title = trimmed
+                    .split_once(':')
+                    .map(|(_, t)| t.trim().to_string())
+                    .filter(|t| !t.is_empty())
+                    .unwrap_or_default();
+                let qn = format!("{}::{}@{}", doc_qualified, key, line_idx);
+                elements.push(CodeElement {
+                    qualified_name: qn.clone(),
+                    element_type: "rationale_rfc".to_string(),
+                    name: format!("RFC {}", id),
+                    file_path: doc_qualified.to_string(),
+                    line_start: (line_idx + 1) as u32,
+                    line_end: (line_idx + 1) as u32,
+                    language: "markdown".to_string(),
+                    parent_qualified: Some(doc_qualified.to_string()),
+                    metadata: serde_json::json!({
+                        "marker": "RFC",
+                        "kind": "rationale_rfc",
+                        "citation_id": format!("RFC-{}", id),
+                        "summary": title.chars().take(200).collect::<String>(),
+                    }),
+                    ..Default::default()
+                });
+                relationships.push(Relationship {
+                    id: None,
+                    source_qualified: doc_qualified.to_string(),
+                    target_qualified: qn.clone(),
+                    rel_type: "cited_by".to_string(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({"marker": "RFC", "citation_id": format!("RFC-{}", id)}),
+                    ..Default::default()
+                });
+            }
+        }
+
+        // ADR link in the text → references edge to that ADR doc file
+        if let Some(cap) = adr_link_re.captures(trimmed) {
+            let id = cap
+                .get(1)
+                .map(|m| m.as_str().to_string())
+                .unwrap_or_default();
+            let target = format!("docs/adr/{}-{}.md", id, "adr");
+            if !seen.contains(&format!("link:{}", id)) {
+                seen.insert(format!("link:{}", id));
+                relationships.push(Relationship {
+                    id: None,
+                    source_qualified: doc_qualified.to_string(),
+                    target_qualified: target,
+                    rel_type: "references".to_string(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({"confidence_label": "EXTRACTED", "citation": format!("ADR-{}", id)}),
+                    ..Default::default()
+                });
+            }
+        }
+    }
+
+    (elements, relationships)
+}
+
 pub fn index_docs_directory(
     docs_path: &Path,
     graph: &GraphEngine,
@@ -663,4 +835,54 @@ pub fn index_docs_directory(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_extract_adr_citation_heading() {
+        let content = "## ADR-004: Use CozoDB for storage\n\nWe choose CozoDB because...\n";
+        let (elems, rels) = extract_rationale_citations(content, "docs/architecture.md");
+        assert_eq!(elems.len(), 1);
+        assert_eq!(elems[0].element_type, "rationale_adr");
+        assert_eq!(elems[0].metadata.get("citation_id").unwrap(), "ADR-004");
+        assert!(elems[0]
+            .metadata
+            .get("summary")
+            .unwrap()
+            .as_str()
+            .unwrap()
+            .contains("Use CozoDB"));
+        assert!(rels.iter().any(|r| r.rel_type == "cited_by"));
+    }
+
+    #[test]
+    fn test_extract_rfc_citation_inline() {
+        let content = "Auth uses RFC 8252 (OAuth 2.0 for Native Apps).\n";
+        let (elems, rels) = extract_rationale_citations(content, "docs/auth.md");
+        assert_eq!(elems.len(), 1);
+        assert_eq!(elems[0].element_type, "rationale_rfc");
+        assert_eq!(elems[0].metadata.get("citation_id").unwrap(), "RFC-8252");
+        assert!(rels.iter().any(|r| r.rel_type == "cited_by"));
+    }
+
+    #[test]
+    fn test_extract_skips_code_blocks() {
+        let content = "## Context\n\n```markdown\nADR-007: old\n```\n\nADR-009: real\n";
+        let (elems, _) = extract_rationale_citations(content, "docs/design.md");
+        let ids: Vec<_> = elems
+            .iter()
+            .filter_map(|e| e.metadata.get("citation_id").and_then(|v| v.as_str()))
+            .collect();
+        assert_eq!(ids, vec!["ADR-009"]);
+    }
+
+    #[test]
+    fn test_extract_adr_link_references() {
+        let content = "See [ADR-003](docs/adr/0003-use-redis.md) for the decision.\n";
+        let (_, rels) = extract_rationale_citations(content, "docs/design.md");
+        assert!(rels.iter().any(|r| r.rel_type == "references"));
+    }
 }

--- a/src/indexer/microservice.rs
+++ b/src/indexer/microservice.rs
@@ -17,9 +17,13 @@ impl MicroserviceExtractor {
             // Matches: dns:///service-name.default.svc.cluster.local.:10000
             grpc_pattern: Regex::new(r"dns:///([a-z0-9-]+)\.default\.svc\.cluster\.local\.:\d+")
                 .unwrap(),
-            // Matches: http://service-name.default.svc.cluster.local./
-            _http_pattern: Regex::new(r"https?://([a-z0-9-]+)\.default\.svc\.cluster\.local\.")
-                .unwrap(),
+            // Matches http(s)://service-name[:port][/path] — k8s DNS
+            // (…default.svc.cluster.local), docker-compose service names,
+            // or plain host:port.
+            _http_pattern: Regex::new(
+                r"https?://([a-z0-9_-]+)(?:\.default\.svc\.cluster\.local\.?)?(?::\d+)?(?:/|$)",
+            )
+            .unwrap(),
             client_dirs: vec!["internal/external".to_string()],
         }
     }
@@ -34,7 +38,10 @@ impl MicroserviceExtractor {
                 Regex::new(r"dns:///[a-z0-9-]+\.default\.svc\.cluster\.local\.\:\d+").unwrap()
             }),
             _http_pattern: Regex::new(&http_pattern).unwrap_or_else(|_| {
-                Regex::new(r"https?://[a-z0-9-]+\.default\.svc\.cluster\.local\.").unwrap()
+                Regex::new(
+                    r"https?://([a-z0-9_-]+)(?:\.default\.svc\.cluster\.local\.?)?(?::\d+)?(?:/|$)",
+                )
+                .unwrap()
             }),
             client_dirs,
         }
@@ -107,7 +114,13 @@ impl MicroserviceExtractor {
         relationships
     }
 
-    /// Extract gRPC calls from file content
+    /// Extract gRPC/HTTP/Docker service calls from file content.
+    ///
+    /// FR-B13: beyond `grpc.NewClient("dns:///…")`, also detects
+    /// `http.NewRequest` / `client.Get("http://service:port/…")` /
+    /// `fmt.Sprintf("http://service:8080/…")` style calls so
+    /// `service_calls` edges are produced for docker-compose and plain
+    /// http(s) service addresses, not just k8s DNS.
     fn extract_grpc_calls(
         &self,
         content: &str,
@@ -118,17 +131,86 @@ impl MicroserviceExtractor {
 
         // Pattern: grpc.NewClient("dns:///service-name.default.svc.cluster.local.:10000", ...)
         let grpc_client_re = Regex::new(r#"(?m)grpc\.NewClient\s*\(\s*"([^"]+)"[,\s]"#).unwrap();
+        // Pattern: http(s) client calls with an inline URL string argument.
+        // Covers `http.Get("url")`, `client.Get("url")`, and
+        // `http.NewRequest("GET", "url", body)` (URL as 2nd arg).
+        let http_call_re = Regex::new(
+            r#"(?m)(?:http\.(?:Get|Post|Do)|client\.(?:Get|Post|Do|Request))\s*\(\s*"([^"]+)""#,
+        )
+        .unwrap();
+        let http_new_request_re =
+            Regex::new(r#"(?m)http\.NewRequest\s*\(\s*"[^"]+"\s*,\s*"([^"]+)""#).unwrap();
+        // Pattern: bare docker-compose service refs `service-name:port`
+        // inside quotes (no dots — those are URLs or DNS names, handled
+        // above). Requires an explicit :port so plain quoted words are
+        // not treated as services.
+        let docker_addr_re = Regex::new(r#"["']([a-z][a-z0-9_-]+):(\d+)["']"#).unwrap();
+
+        let add =
+            |address: &str, protocol: &str, cap_start: usize, rels: &mut Vec<Relationship>| {
+                if let Some(service_name) = self.extract_service_name(address, protocol) {
+                    let line_number = content[..cap_start].lines().count() as u32;
+                    rels.push(self.create_relationship(
+                        service_name,
+                        protocol.to_string(),
+                        address.to_string(),
+                        "unknown".to_string(),
+                        file_path.to_string(),
+                        line_number,
+                        project_service,
+                    ));
+                }
+            };
 
         for cap in grpc_client_re.captures_iter(content) {
             let address = &cap[1];
-            if let Some(service_name) = self.extract_service_name(address, "grpc") {
+            add(
+                address,
+                "grpc",
+                cap.get(0).map(|m| m.end()).unwrap_or(0),
+                &mut relationships,
+            );
+        }
+
+        for cap in http_call_re
+            .captures_iter(content)
+            .chain(http_new_request_re.captures_iter(content))
+        {
+            let address = &cap[1];
+            if address.starts_with("http://") || address.starts_with("https://") {
+                let protocol = if address.starts_with("https://") {
+                    "https"
+                } else {
+                    "http"
+                };
+                add(
+                    address,
+                    protocol,
+                    cap.get(0).map(|m| m.end()).unwrap_or(0),
+                    &mut relationships,
+                );
+            }
+        }
+
+        // Bare docker-compose service refs `service-name:port` inside quotes
+        // (no dots — URLs/DNS handled above).
+        for cap in docker_addr_re.captures_iter(content) {
+            let name = &cap[1];
+            let port = &cap[2];
+            if name.contains('.') {
+                continue;
+            }
+            let address = format!("{}:{}", name, port);
+            if let Some(service_name) = self.extract_service_name(&address, "docker") {
+                if service_name == *project_service.as_deref().unwrap_or("") {
+                    continue;
+                }
                 let line_number = content[..cap.get(0).map(|m| m.end()).unwrap_or(0)]
                     .lines()
                     .count() as u32;
-
                 relationships.push(self.create_relationship(
                     service_name,
-                    "grpc".to_string(),
+                    "docker".to_string(),
                     address.to_string(),
                     "unknown".to_string(),
                     file_path.to_string(),
@@ -141,17 +223,46 @@ impl MicroserviceExtractor {
         relationships
     }
 
-    /// Extract service name from DNS address
+    /// Extract service name from a service address.
+    ///
+    /// FR-B13: beyond the k8s DNS regex, also handle:
+    /// - `http(s)://service-name[.domain][:port][/path]` (incl. docker-compose
+    ///   service names like `http://api-gateway:8080/`),
+    /// - bare docker-compose service names (`api-gateway:8080`, `db:5432`).
     fn extract_service_name(&self, address: &str, protocol: &str) -> Option<String> {
-        if protocol == "grpc" {
-            // dns:///service-name.default.svc.cluster.local.:10000
-            if let Some(caps) = self.grpc_pattern.captures(address) {
-                return Some(
-                    caps.get(1)
-                        .map(|m| m.as_str().to_string())
-                        .unwrap_or_default(),
-                );
+        match protocol {
+            "grpc" => {
+                // dns:///service-name.default.svc.cluster.local.:10000
+                if let Some(caps) = self.grpc_pattern.captures(address) {
+                    return Some(
+                        caps.get(1)
+                            .map(|m| m.as_str().to_string())
+                            .unwrap_or_default(),
+                    );
+                }
             }
+            "http" | "https" => {
+                // http://service-name[.namespace][:port][/path]
+                if let Some(caps) = self._http_pattern.captures(address) {
+                    return Some(
+                        caps.get(1)
+                            .map(|m| m.as_str().to_string())
+                            .unwrap_or_default(),
+                    );
+                }
+            }
+            "docker" => {
+                // docker-compose service names: `service-name:8080` or plain `service-name`
+                let docker_re = Regex::new(r"^([a-z][a-z0-9_-]*)(?::\d+)?(?:/.*)?$").unwrap();
+                if let Some(caps) = docker_re.captures(address) {
+                    return Some(
+                        caps.get(1)
+                            .map(|m| m.as_str().to_string())
+                            .unwrap_or_default(),
+                    );
+                }
+            }
+            _ => {}
         }
         None
     }
@@ -229,23 +340,16 @@ impl MicroserviceExtractor {
         if let Some(obj) = yaml.as_mapping() {
             for (key, val) in obj {
                 let key_str = key.as_str().unwrap_or("");
-                if key_str.ends_with("_address")
-                    && val
-                        .as_str()
-                        .map(|s| s.starts_with("dns:///"))
-                        .unwrap_or(false)
-                {
-                    let address = val.as_str().unwrap_or("");
-                    if let Some(service_name) = self.extract_service_name(address, "grpc") {
-                        relationships.push(self.create_relationship(
-                            service_name,
-                            "grpc".to_string(),
-                            address.to_string(),
-                            key_str.to_string(),
-                            file_path.to_string(),
-                            0,
+                if key_str.ends_with("_address") {
+                    if let Some(address) = val.as_str() {
+                        if let Some(rel) = self.yaml_address_relationship(
+                            address,
+                            key_str,
+                            file_path,
                             project_service,
-                        ));
+                        ) {
+                            relationships.push(rel);
+                        }
                     }
                 }
                 // Recurse into nested mappings
@@ -260,6 +364,61 @@ impl MicroserviceExtractor {
         relationships
     }
 
+    /// Build a service_calls relationship from a YAML `*_address` string,
+    /// handling dns:///, http(s)://, and bare docker `name:port` forms.
+    fn yaml_address_relationship(
+        &self,
+        address: &str,
+        key_str: &str,
+        file_path: &str,
+        project_service: &Option<String>,
+    ) -> Option<Relationship> {
+        if address.starts_with("dns:///") {
+            if let Some(service_name) = self.extract_service_name(address, "grpc") {
+                return Some(self.create_relationship(
+                    service_name,
+                    "grpc".to_string(),
+                    address.to_string(),
+                    key_str.to_string(),
+                    file_path.to_string(),
+                    0,
+                    project_service,
+                ));
+            }
+        } else if address.starts_with("http://") || address.starts_with("https://") {
+            let protocol = if address.starts_with("https://") {
+                "https"
+            } else {
+                "http"
+            };
+            if let Some(service_name) = self.extract_service_name(address, protocol) {
+                return Some(self.create_relationship(
+                    service_name,
+                    protocol.to_string(),
+                    address.to_string(),
+                    key_str.to_string(),
+                    file_path.to_string(),
+                    0,
+                    project_service,
+                ));
+            }
+        } else if !address.contains('.') && !address.contains('/') {
+            // docker-compose style: `service-name:8080` (bare name w/o dots).
+            if let Some(service_name) = self.extract_service_name(address, "docker") {
+                return Some(self.create_relationship(
+                    service_name,
+                    "docker".to_string(),
+                    address.to_string(),
+                    key_str.to_string(),
+                    file_path.to_string(),
+                    0,
+                    project_service,
+                ));
+            }
+        }
+        None
+    }
+
     fn extract_from_yaml_internal(
         &self,
         yaml: &serde_yaml::Mapping,
@@ -270,23 +429,13 @@ impl MicroserviceExtractor {
 
         for (key, val) in yaml {
             let key_str = key.as_str().unwrap_or("");
-            if key_str.ends_with("_address")
-                && val
-                    .as_str()
-                    .map(|s| s.starts_with("dns:///"))
-                    .unwrap_or(false)
-            {
-                let address = val.as_str().unwrap_or("");
-                if let Some(service_name) = self.extract_service_name(address, "grpc") {
-                    relationships.push(self.create_relationship(
-                        service_name,
-                        "grpc".to_string(),
-                        address.to_string(),
-                        key_str.to_string(),
-                        file_path.to_string(),
-                        0,
-                        project_service,
-                    ));
+            if key_str.ends_with("_address") {
+                if let Some(address) = val.as_str() {
+                    if let Some(rel) =
+                        self.yaml_address_relationship(address, key_str, file_path, project_service)
+                    {
+                        relationships.push(rel);
+                    }
                 }
             }
             if let Some(nested) = val.as_mapping() {
@@ -405,5 +554,84 @@ grpc.NewClient("dns:///service-a.default.svc.cluster.local.:10000",
         let path = "/workspace/my-service/internal/external/client.go";
         let service = extractor.infer_source_service(path);
         assert_eq!(service, "my-service");
+    }
+
+    // FR-B13: service_calls beyond k8s DNS regex.
+
+    #[test]
+    fn test_http_address_matches_docker_service_name() {
+        let extractor = MicroserviceExtractor::new();
+        // docker-compose service address without .svc.cluster.local suffix
+        let address = "http://api-gateway:8080/v1/users";
+        let service = extractor.extract_service_name(address, "http");
+        assert_eq!(service, Some("api-gateway".to_string()));
+    }
+
+    #[test]
+    fn test_http_address_matches_k8s_dns() {
+        let extractor = MicroserviceExtractor::new();
+        let address = "http://user-service.default.svc.cluster.local/health";
+        let service = extractor.extract_service_name(address, "http");
+        assert_eq!(service, Some("user-service".to_string()));
+    }
+
+    #[test]
+    fn test_https_address_matches() {
+        let extractor = MicroserviceExtractor::new();
+        let address = "https://billing-api:8443";
+        let service = extractor.extract_service_name(address, "https");
+        assert_eq!(service, Some("billing-api".to_string()));
+    }
+
+    #[test]
+    fn test_docker_service_name_with_port() {
+        let extractor = MicroserviceExtractor::new();
+        let service = extractor.extract_service_name("redis-cache:6379", "docker");
+        assert_eq!(service, Some("redis-cache".to_string()));
+    }
+
+    #[test]
+    fn test_grpc_client_http_address_emits_service_call() {
+        let extractor = MicroserviceExtractor::new();
+        let content = r#"
+http.NewRequest("GET", "http://order-service:8080/orders", nil)
+client.Get("https://payment-api:8443/pay")
+"#;
+        let rels = extractor.extract_grpc_calls(content, "client.go", &None);
+        let protocols: Vec<&str> = rels
+            .iter()
+            .map(|r| r.metadata["protocol"].as_str().unwrap())
+            .collect();
+        assert!(protocols.contains(&"http"));
+        assert!(protocols.contains(&"https"));
+        let targets: Vec<&str> = rels.iter().map(|r| r.target_qualified.as_str()).collect();
+        assert!(targets.contains(&"order-service"));
+        assert!(targets.contains(&"payment-api"));
+    }
+
+    #[test]
+    fn test_docker_bare_addr_in_yaml() {
+        let extractor = MicroserviceExtractor::new();
+        let yaml: serde_yaml::Value = serde_yaml::from_str(
+            r#"
+redis_address: "redis-cache:6379"
+grpc_address: "dns:///cart-service.default.svc.cluster.local.:9000"
+http_address: "http://web-front:3000"
+"#,
+        )
+        .unwrap();
+        let rels = extractor.extract_from_yaml(&yaml, "config.yaml", &None);
+        assert_eq!(rels.len(), 3);
+        let protocols: Vec<&str> = rels
+            .iter()
+            .map(|r| r.metadata["protocol"].as_str().unwrap())
+            .collect();
+        assert!(protocols.contains(&"docker"));
+        assert!(protocols.contains(&"grpc"));
+        assert!(protocols.contains(&"http"));
+        let targets: Vec<&str> = rels.iter().map(|r| r.target_qualified.as_str()).collect();
+        assert!(targets.contains(&"redis-cache"));
+        assert!(targets.contains(&"cart-service"));
+        assert!(targets.contains(&"web-front"));
     }
 }


### PR DESCRIPTION
## Summary
Wave 2e sweep: GF install/ADR batch + Service/IaC batch. Docs/polish PR — code mostly pre-existing, shipped only real work.

## Per-ID status

| ID | Status | What shipped |
|----|--------|--------------|
| FR-GF-16 | **DONE** | ADR/RFC citation extraction in `src/doc_indexer/mod.rs` → `rationale_adr`/`rationale_rfc` nodes with `cited_by` edges + `references` to ADR docs. Wired into `parse_doc_file`. 4 unit tests. |
| FR-GF-23 | **DONE** | `codex` target in `scripts/install.sh` — writes `~/.codex/config.toml` `[mcp_servers.leankg]`, idempotent, preserves existing sections. README + docs/install-matrix.md + docs/mcp-setup.md updated. |
| US-GF-15 | **DONE** | `docs/install-matrix.md` — table of Cursor/Claude Code/OpenCode/Codex/Gemini/Kilo/Antigravity/Docker one-command install targets + manual equivalents. |
| US-GF-16 | **DONE** | `docs/reflect-skill.md` + reflect block in `instructions/using-leankg/SKILL.md` + docs/AGENTS.md — default skill guidance calling `report_query_outcome` once per task, LESSONS.md lands at `.leankg/reflections/`. |
| FR-B13 | **DONE** | `service_calls` beyond k8s DNS: http(s) client calls (`http.Get`/`client.Get`/`http.NewRequest`) + docker-compose `name:port` bare refs + YAML `*_address` http(s)/docker forms. 6 unit tests. |
| FR-B16 | **DEFERRED** | Runtime trace ingestion: nothing exists; heavy (OTLP/zipkin collector + span model). Would need new ingestion module. Deferred with rationale — do not build in docs/polish batch. |
| FR-B40..B44 | **PARTIAL → DONE (subset)** | IaC Resource/Module (`src/indexer/terraform.rs` resource/data/variable/output/module/provider, wired in both index + watcher paths) and snapshot (`export_graph_snapshot` MCP + `export_snapshot` budgeted streaming) already shipped. ADR extraction covered by FR-GF-16. **DATA_FLOWS deferred** — only static wiki diagram (`src/doc/wiki.rs`), no real IaC data-flow extraction. |
| FR-B51 | **DEFERRED** | openCypher→Cozo: only Neo4j Cypher *export* (`src/graph/export.rs::generate_cypher`); no input translation exists. Full openCypher→Datalog subset is heavy; deferred. |

## Seams
- `src/doc_indexer/mod.rs::extract_rationale_citations` (new, pure fn)
- `src/indexer/microservice.rs::extract_grpc_calls` / `extract_service_name` / `yaml_address_relationship`
- `scripts/install.sh::configure_codex`
- Docs: install-matrix.md, reflect-skill.md, SKILL.md, AGENTS.md, mcp-setup.md, README.md

## Test plan
- [x] Red→green TDD (10 new unit tests: 4 doc_indexer + 6 microservice)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --lib` — 826 passed, 0 failed
- [x] `bash -n scripts/install.sh` + sandboxed configure_codex idempotency check
- [x] No resurrection of hard-deleted MCP tools
- [x] No AI attribution

## Tracker
Rows listed for DONE after merge: FR-GF-16, FR-GF-23, US-GF-15, US-GF-16, FR-B13. FR-B40..B44 subset (DATA_FLOWS stays NOT_DONE with note). FR-B16, FR-B51 stay NOT_DONE (deferred).
