### PR TITLE
feat(p3): windows smoke + MCP resources overview + lang breadth (PR-63/64/65)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -142,6 +142,16 @@ jobs:
       - name: Build
         run: cargo build --release --target ${{ matrix.target }}
 
+      # US-CBM-C5: Windows smoke — the release job builds the binary but
+      # never runs it. `tests/windows_smoke.rs` (`#[cfg(windows)]`) runs the
+      # real CLI end-to-end (init → index → query → version) on the host
+      # where it was compiled, so path/quoting/CRLF regressions surface at
+      # release time instead of in the field.
+      - name: Windows smoke (init → index → query)
+        if: matrix.runs-on == 'windows-latest'
+        shell: bash
+        run: cargo test --release --test windows_smoke
+
       - name: Package
         run: |
           mkdir -p release

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -555,8 +555,8 @@ Second identical run (unchanged code) **must** skip fresh rows and must **not** 
   - US-LANG-02 Swift — **PARTIAL**: regex extractor wired for bulk + incremental index (`src/indexer/swift.rs`); heritage/call-graph/tree-sitter still pending
   - US-LANG-03 XML — **DONE and indexed** (`.xml` + Android path) (`92db9aa`)
   - US-LANG-04 Objective-C — **PARTIAL**: regex extractor wired for bulk + incremental (`.m`/`.mm`/`.h`); protocol conformance / full selectors pending
-  - US-GF-10 Vue/Svelte — **DONE (index walk)**: regex extractors in `src/indexer/sfc.rs` (`e617a49`); `.vue` / `.svelte` wired into `find_files_sync` + bulk + incremental (REL-032, 2026-08-02)
-  - US-GF-12 SQL DDL — **DONE (index walk)**: parser in `src/indexer/sql.rs` (`de314eb`); `.sql` wired into `find_files_sync` + bulk + incremental (REL-032, 2026-08-02); live `--postgres <dsn>` introspection still open
+  - US-GF-10 Vue/Svelte — **DONE (index walk)**: regex extractors in `src/indexer/sfc.rs` (`e617a49`); `.vue` / `.svelte` wired into `find_files_sync` + bulk + incremental (REL-032, 2026-08-02). Verified 2026-08-02 (`extracts_vue_sfc_with_script_setup_and_template` / `extracts_svelte_component`); remaining long-tail grammars (shell, Scala, Lua, Zig, Astro) stay P3 leftovers, non-blocking
+  - US-GF-12 SQL DDL — **DONE (index walk) / PARTIAL (live DSN)**: parser in `src/indexer/sql.rs` (`de314eb`); `.sql` wired into `find_files_sync` + bulk + incremental (REL-032, 2026-08-02). 2026-08-02: inline `REFERENCES` FK extraction for PG/MySQL column style + PG-dialect dump test (`extracts_postgres_dialect_dump`) covering SERIAL/BIGSERIAL, quoted identifiers, `nextval()` defaults. Live `--postgres <dsn>` introspection remains the open half of US-GF-12
 - Agent-graph UX series — DONE:
   - US-GF-07 rationale extraction (`# WHY:` / `# NOTE:` / `# HACK:` / `# FIXME:` / `# XXX:` markers) → `rationale` elements with `explains` edges (`b0c9477`)
   - US-GF-08 PR impact dashboard — `get_pr_impact` MCP + `leankg prs` CLI (`30e41f0`)
@@ -572,9 +572,10 @@ Second identical run (unchanged code) **must** skip fresh rows and must **not** 
   - US-CBM-B7 clone / near-duplicate detection — historically shipped as `find_clones` MCP + `leankg clones` CLI (`55e6e72`); **hard-removed 2026-07-20** (prefer semantic HNSW discovery)
   - US-CBM-B8 cross-repo similar edges — `find_cross_repo_similar` (`ab16c9b`)
   - US-CBM-C2 hot-path cache for high-frequency MCP tools (`836f0a3`)
+  - US-CBM-C5 Windows build + smoke — release CI ships a `windows-latest` job (`.github/workflows/release.yml`, `x86_64-pc-windows-msvc`); 2026-08-02 added `tests/windows_smoke.rs` (`#[cfg(windows)]`) exercising real-binary `init → index → query → version` on Windows. CI test job itself remains ubuntu-only; Windows is exercised at release time by the smoke suite
 - GitNexus — DONE:
   - US-GN-07 `get_cluster_skill` MCP — per-cluster `SKILL.md` (`10b15a0`)
-  - US-GN-08 `get_overview_context` MCP — resource-style overview (`9124959`); formal `resources/read` not yet wired (PARTIAL).
+  - US-GN-08 `get_overview_context` MCP — resource-style overview (`9124959`); formal `resources/read` wired 2026-08-02 — `leankg://overview` + `leankg://overview/wake_up` via RMCP `ServerHandler::{list_resources,read_resource}` + JSON-RPC `resources/list` / `resources/read` (DONE).
 - Team / distribution — DONE:
   - US-14 npm-based installation wrapper (`df0fec2`)
   - US-V2-11 CI/CD auto-graph update — GitHub Actions workflow that reindexes / commits the portable snapshot on release (`eb3d331`)

--- a/src/indexer/sql.rs
+++ b/src/indexer/sql.rs
@@ -30,6 +30,13 @@ static FK_RE: Lazy<Regex> = Lazy::new(|| {
     .unwrap()
 });
 
+/// Inline `REFERENCES` in a column definition (PostgreSQL / MySQL style):
+/// `user_id INTEGER REFERENCES users(id)` — no FOREIGN KEY constraint form.
+/// Captures column name + referenced table.
+static INLINE_FK_RE: Lazy<Regex> = Lazy::new(|| {
+    Regex::new(r#"(?i)\bREFERENCES\s+(?:`|"|\[)?(\w+)(?:`|"|\])?(?:\s*\([^)]*\))?"#).unwrap()
+});
+
 static PK_RE: Lazy<Regex> = Lazy::new(|| Regex::new(r#"(?i)PRIMARY\s+KEY"#).unwrap());
 
 pub struct SqlExtractor<'a> {
@@ -157,6 +164,44 @@ impl<'a> SqlExtractor<'a> {
                     target_qualified: target_qn,
                     rel_type: "references".to_string(),
                     confidence: 0.95,
+                    metadata: serde_json::json!({
+                        "resolution_method": "name",
+                        "fk_column": fk_col,
+                    }),
+                    ..Default::default()
+                });
+            }
+
+            // Inline REFERENCES (PG/MySQL style): `user_id INTEGER REFERENCES users(id)`.
+            // One pass over column definitions; a REFERENCES match after the
+            // column name (not inside a default expression) emits the FK edge.
+            // `nextval('seq')` references never match (no table word after
+            // `REFERENCES` inside a string literal is a false positive only
+            // if the literal contains `REFERENCES tbl` — acceptable for v0).
+            for raw in split_top_level(body) {
+                let trimmed = raw.trim().trim_end_matches(',').trim();
+                if trimmed.is_empty() || is_constraint_keyword(trimmed) {
+                    continue;
+                }
+                let Some(fk_col) = column_name(trimmed) else {
+                    continue;
+                };
+                let Some(cap) = INLINE_FK_RE.captures(trimmed) else {
+                    continue;
+                };
+                let m = cap.get(0).unwrap();
+                if m.start() == 0 {
+                    continue; // column name itself is not `REFERENCES ...`
+                }
+                let target_table = cap[1].to_string();
+                let target_qn = format!("{}::{}", self.file_path, target_table);
+                let source_qn = format!("{}::{}", table_qn, fk_col);
+                relationships.push(Relationship {
+                    id: None,
+                    source_qualified: source_qn,
+                    target_qualified: target_qn,
+                    rel_type: "references".to_string(),
+                    confidence: 0.9,
                     metadata: serde_json::json!({
                         "resolution_method": "name",
                         "fk_column": fk_col,
@@ -323,5 +368,64 @@ CREATE TABLE orders (
         let parts: Vec<&str> = split_top_level(body);
         assert_eq!(parts.len(), 3);
         assert!(parts[0].contains("DEFAULT nextval('seq')"));
+    }
+
+    // US-GF-12 (index-walk half): a typical PostgreSQL dump — SERIAL /
+    // BIGSERIAL identities, `nextval(...)` defaults, quoted identifiers,
+    // inline REFERENCES — must parse into table/column/FK nodes the same
+    // way a live `--postgres <dsn>` introspection would produce them.
+    // The live-DSN half remains an explicit open follow-up (PRD notes).
+    #[test]
+    fn extracts_postgres_dialect_dump() {
+        let sql = r#"
+-- PostgreSQL dump
+CREATE TABLE "users" (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255) NOT NULL UNIQUE,
+    created_at TIMESTAMPTZ DEFAULT now()
+);
+CREATE TABLE orders (
+    id BIGSERIAL PRIMARY KEY,
+    user_id INTEGER REFERENCES users(id),
+    total NUMERIC(10,2) DEFAULT 0
+);
+"#;
+        let (elems, rels) = SqlExtractor::new(sql.as_bytes(), "dump.sql").extract();
+        assert!(elems
+            .iter()
+            .any(|e| e.element_type == "table" && e.name == "users"));
+        assert!(elems
+            .iter()
+            .any(|e| e.element_type == "table" && e.name == "orders"));
+        // SERIAL PK columns: `id` under quoted `"users"` and bare `orders`.
+        let users_id = elems.iter().find(|e| {
+            e.element_type == "column" && e.name == "id" && e.qualified_name.contains("users")
+        });
+        assert!(
+            users_id.is_some(),
+            "users.id column: {:?}",
+            elems
+                .iter()
+                .filter(|e| e.element_type == "column")
+                .map(|e| &e.name)
+                .collect::<Vec<_>>()
+        );
+        let orders_id = elems.iter().find(|e| {
+            e.element_type == "column" && e.name == "id" && e.qualified_name.contains("orders")
+        });
+        assert!(orders_id.is_some(), "orders.id column present");
+        // Inline FK: `user_id INTEGER REFERENCES users(id)`.
+        assert!(
+            rels.iter()
+                .any(|r| r.rel_type == "references" && r.target_qualified.ends_with("::users")),
+            "FK references edge for orders.user_id -> users"
+        );
+        // DDL `DEFAULT now()` / `DEFAULT 0` must not be mistaken for columns.
+        assert!(
+            elems
+                .iter()
+                .all(|e| e.element_type != "column" || e.name != "now"),
+            "now() is a default expression, not a column"
+        );
     }
 }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -21,7 +21,11 @@ use moka::future::Cache;
 use once_cell::sync::Lazy;
 use parking_lot::RwLock;
 use rmcp::handler::server::ServerHandler;
-use rmcp::model::{CallToolRequestParams, CallToolResult, Content, ListToolsResult, Tool};
+use rmcp::model::{
+    AnnotateAble, CallToolRequestParams, CallToolResult, Content, ListResourcesResult,
+    ListToolsResult, RawResource, ReadResourceRequestParams, ReadResourceResult, ResourceContents,
+    Tool,
+};
 use rmcp::service::{serve_server, RoleServer};
 use rmcp::transport::stdio;
 use serde::{Deserialize, Serialize};
@@ -2807,6 +2811,7 @@ impl ServerHandler for MCPServer {
         rmcp::model::ServerInfo::new(
             rmcp::model::ServerCapabilities::builder()
                 .enable_tools()
+                .enable_resources()
                 .build(),
         )
         .with_server_info(
@@ -2834,6 +2839,69 @@ impl ServerHandler for MCPServer {
             })
             .collect();
         Ok(ListToolsResult::with_all_items(rmcp_tools))
+    }
+
+    /// US-GN-08: MCP Resources for session-start overview context.
+    ///
+    /// Two static resources, backed by the same graph-query seam as the
+    /// `get_overview_context` tool:
+    ///   - `leankg://overview`            — L0 identity + L1 critical facts
+    ///   - `leankg://overview/wake_up`    — wake_up_summary project snapshot
+    ///
+    /// The RMCP protocol requests these via `resources/list` +
+    /// `resources/read` (formal Resources API), which the JSON-RPC HTTP
+    /// transport mirrors in `process_jsonrpc_request`.
+    async fn list_resources(
+        &self,
+        _params: Option<rmcp::model::PaginatedRequestParams>,
+        _context: rmcp::service::RequestContext<RoleServer>,
+    ) -> Result<ListResourcesResult, rmcp::model::ErrorData> {
+        let resources = vec![
+            RawResource::new("leankg://overview", "LeanKG overview")
+                .with_description(
+                    "Session-start overview: project identity (L0) + critical facts (L1)",
+                )
+                .with_mime_type("text/markdown")
+                .no_annotation(),
+            RawResource::new("leankg://overview/wake_up", "LeanKG wake-up summary")
+                .with_description(
+                    "Project snapshot: file/function/class counts, languages, top directories",
+                )
+                .with_mime_type("text/markdown")
+                .no_annotation(),
+        ];
+        Ok(ListResourcesResult::with_all_items(resources))
+    }
+
+    async fn read_resource(
+        &self,
+        request: ReadResourceRequestParams,
+        _context: rmcp::service::RequestContext<RoleServer>,
+    ) -> Result<ReadResourceResult, rmcp::model::ErrorData> {
+        let uri = request.uri.as_str();
+        let engine = self.get_graph_engine().map_err(|e| {
+            rmcp::model::ErrorData::internal_error(format!("LeanKG not initialized: {e}"), None)
+        })?;
+        let project_name = "project";
+        let text = match uri {
+            "leankg://overview" => {
+                let l0 = engine.identity_context(project_name).unwrap_or_default();
+                let l1 = engine.critical_facts_context().unwrap_or_default();
+                format!("{}\n{}", l0, l1)
+            }
+            "leankg://overview/wake_up" => engine.wake_up_summary().unwrap_or_default(),
+            _ => {
+                return Err(rmcp::model::ErrorData::resource_not_found(
+                    format!("unknown resource URI: {uri}"),
+                    None,
+                ))
+            }
+        };
+        Ok(ReadResourceResult::new(vec![ResourceContents::text(
+            text,
+            uri.to_string(),
+        )
+        .with_mime_type("text/markdown")]))
     }
 
     async fn call_tool(
@@ -3198,8 +3266,53 @@ async fn process_jsonrpc_request(
             Ok(serde_json::Value::Null)
         }
         "resources/list" => {
-            // LeanKG exposes tools only, no resources
-            Ok(serde_json::json!({ "resources": [] }))
+            // US-GN-08: formal MCP Resources — overview + wake_up snapshot.
+            Ok(serde_json::json!({
+                "resources": [
+                    {
+                        "uri": "leankg://overview",
+                        "name": "LeanKG overview",
+                        "description": "Session-start overview: project identity (L0) + critical facts (L1)",
+                        "mimeType": "text/markdown"
+                    },
+                    {
+                        "uri": "leankg://overview/wake_up",
+                        "name": "LeanKG wake-up summary",
+                        "description": "Project snapshot: file/function/class counts, languages, top directories",
+                        "mimeType": "text/markdown"
+                    }
+                ]
+            }))
+        }
+        "resources/read" => {
+            let uri = params
+                .and_then(|p| p.get("uri"))
+                .and_then(|v| v.as_str())
+                .ok_or("Missing uri for resources/read")?;
+            // Route through `project_param` the same way tools/call does:
+            // the overview content is per-project (identity + critical facts
+            // live in that project's graph).
+            let project_ref = project_param.map(|s| s.to_string());
+            let engine = mcp_server
+                .get_graph_engine_for_path(project_ref.as_ref())
+                .map_err(|e| e.to_string())?;
+            let project_name = "project";
+            let text = match uri {
+                "leankg://overview" => {
+                    let l0 = engine.identity_context(project_name).unwrap_or_default();
+                    let l1 = engine.critical_facts_context().unwrap_or_default();
+                    format!("{}\n{}", l0, l1)
+                }
+                "leankg://overview/wake_up" => engine.wake_up_summary().unwrap_or_default(),
+                _ => return Err(format!("unknown resource URI: {uri}")),
+            };
+            Ok(serde_json::json!({
+                "contents": [{
+                    "uri": uri,
+                    "mimeType": "text/markdown",
+                    "text": text
+                }]
+            }))
         }
         "resources/templates/list" => Ok(serde_json::json!({ "resourceTemplates": [] })),
         "prompts/list" => Ok(serde_json::json!({ "prompts": [] })),
@@ -3488,6 +3601,122 @@ mod tests {
             MCPServer::resolve_project_db_path(bare.to_str().unwrap()),
             None,
             "no .leankg anywhere up the tree -> caller falls back to default db_path"
+        );
+    }
+
+    // ---------------------------------------------------------------------
+    // US-GN-08: MCP Resources — `leankg://overview` + `leankg://overview/wake_up`
+    // via the formal `resources/list` / `resources/read` seam (RMCP + JSON-RPC).
+    // ---------------------------------------------------------------------
+
+    fn make_jsonrpc_request(method: &str, params: Option<serde_json::Value>) -> JsonRpcRequest {
+        JsonRpcRequest {
+            jsonrpc: "2.0".to_string(),
+            id: Some(serde_json::json!(1)),
+            method: method.to_string(),
+            params,
+        }
+    }
+
+    fn admin_auth() -> crate::db::models::AuthContext {
+        crate::db::models::AuthContext {
+            client_id: "anonymous".to_string(),
+            role: crate::db::models::Role::Admin,
+        }
+    }
+
+    #[tokio::test]
+    async fn us_gn08_resources_list_lists_overview_uris() {
+        let server = MCPServer::new(std::path::PathBuf::from(".leankg"));
+        let result = process_jsonrpc_request(
+            &server,
+            &make_jsonrpc_request("resources/list", None),
+            None,
+            admin_auth(),
+        )
+        .await
+        .expect("resources/list must not error even with no DB");
+        let resources = result["resources"].as_array().expect("resources array");
+        let uris: Vec<&str> = resources.iter().filter_map(|r| r["uri"].as_str()).collect();
+        assert!(
+            uris.contains(&"leankg://overview"),
+            "overview URI listed: {uris:?}"
+        );
+        assert!(
+            uris.contains(&"leankg://overview/wake_up"),
+            "wake_up URI listed: {uris:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn us_gn08_resources_read_unknown_uri_is_error() {
+        let server = MCPServer::new(std::path::PathBuf::from(".leankg"));
+        let result = process_jsonrpc_request(
+            &server,
+            &make_jsonrpc_request(
+                "resources/read",
+                Some(serde_json::json!({"uri": "leankg://nope"})),
+            ),
+            None,
+            admin_auth(),
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "unknown resource URI must error (no invented scope)"
+        );
+    }
+
+    #[tokio::test]
+    async fn us_gn08_resources_read_overview_contains_identity_when_indexed() {
+        use crate::db::schema::init_db;
+        use tempfile::TempDir;
+        let tmp = TempDir::new().unwrap();
+        // Project layout mirrors `leankg init`: `<project>/.leankg` dir.
+        let project_root = tmp.path().join("res-project");
+        std::fs::create_dir_all(project_root.join(".leankg")).unwrap();
+        let db = init_db(&project_root.join(".leankg")).unwrap();
+        let graph = crate::graph::GraphEngine::new(db);
+        let element = crate::db::models::CodeElement {
+            qualified_name: "src/app.rs::main".to_string(),
+            element_type: "function".to_string(),
+            name: "main".to_string(),
+            file_path: "src/app.rs".to_string(),
+            line_start: 1,
+            line_end: 5,
+            language: "rust".to_string(),
+            ..Default::default()
+        };
+        graph.insert_element(&element).unwrap();
+
+        let server = MCPServer::new(project_root.join(".leankg"));
+        // Prime the shared engine cache the same way the HTTP path does.
+        server.get_graph_engine().expect("engine init");
+        let result = process_jsonrpc_request(
+            &server,
+            &make_jsonrpc_request(
+                "resources/read",
+                Some(serde_json::json!({"uri": "leankg://overview"})),
+            ),
+            Some(project_root.to_str().unwrap()),
+            admin_auth(),
+        )
+        .await
+        .expect("resources/read on indexed project");
+        let text = result["contents"][0]["text"]
+            .as_str()
+            .expect("text content");
+        assert!(
+            text.contains("Languages"),
+            "overview should include L0 identity: {text}"
+        );
+        assert!(
+            text.contains("Critical facts"),
+            "overview should include L1 critical facts: {text}"
+        );
+        assert!(
+            text.contains("Elements: 1 (functions: 1)"),
+            "overview critical facts should count the indexed element: {text}"
         );
     }
 

--- a/tests/windows_smoke.rs
+++ b/tests/windows_smoke.rs
@@ -1,0 +1,74 @@
+//! US-CBM-C5: Windows build + smoke.
+//!
+//! CI runs a `windows-latest` release build job (`.github/workflows/release.yml`
+//! matrix) but never exercises the binary. This test runs the real CLI
+//! end-to-end (init -> index -> query) on the host OS and is gated to
+//! Windows with `#[cfg(windows)]`; on other platforms the suite compiles
+//! but runs zero tests, so `cargo test` stays green everywhere.
+//!
+//! On Linux/macOS the same flow is already covered by
+//! `tests/cli_full_coverage_tests.rs`; this file is the Windows-specific
+//! smoke that catches path/quoting/CRLF regressions the release job
+//! cannot see.
+
+#![cfg(windows)]
+
+use std::path::Path;
+use std::process::Command;
+use tempfile::TempDir;
+
+const BIN: &str = env!("CARGO_BIN_EXE_leankg");
+
+fn run_cli(cwd: &Path, args: &[&str]) -> String {
+    let out = Command::new(BIN)
+        .current_dir(cwd)
+        .args(args)
+        .output()
+        .unwrap_or_else(|e| panic!("failed to run leankg {:?}: {}", args, e));
+    assert!(
+        out.status.success(),
+        "leankg {:?} failed: stdout={} stderr={}",
+        args,
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+#[test]
+fn windows_smoke_init_index_query_roundtrip() {
+    let tmp = TempDir::new().expect("tempdir");
+    let project = tmp.path().join("win-proj");
+    std::fs::create_dir_all(&project).unwrap();
+
+    let out = run_cli(&project, &["init"]);
+    assert!(
+        out.contains("Initialized LeanKG project"),
+        "init stdout: {out}"
+    );
+    assert!(project.join(".leankg").is_dir(), ".leankg must exist");
+    assert!(
+        project.join("leankg.yaml").exists(),
+        "leankg.yaml must exist"
+    );
+
+    let src = project.join("src");
+    std::fs::create_dir_all(&src).unwrap();
+    std::fs::write(
+        src.join("main.rs"),
+        "fn greet(name: &str) -> String { format!(\"hi {name}\") }\nfn main() {}\n",
+    )
+    .unwrap();
+
+    let out = run_cli(&project, &["index"]);
+    assert!(out.contains("elements"), "index stdout: {out}");
+
+    // Smoke the graph query path — verifies the SQLite DB opened/queried
+    // correctly on Windows (path separators, CozoDB file handle).
+    let out = run_cli(&project, &["query", "greet", "--kind", "name"]);
+    assert!(out.contains("greet"), "query must find greet symbol: {out}");
+
+    // `version` must work from an arbitrary cwd (no project dependency).
+    let out = run_cli(tmp.path(), &["version"]);
+    assert!(out.contains("leankg"), "version stdout: {out}");
+}


### PR DESCRIPTION
## P3 Could Have batch 2 — PR-63 / PR-64 / PR-65

### PR-63 / US-CBM-C5 (windows-smoke) — DONE
- Windows release job exists (`.github/workflows/release.yml` matrix, `windows-latest` / `x86_64-pc-windows-msvc`) but never ran the binary.
- Added `tests/windows_smoke.rs` — `#[cfg(windows)]` real-binary smoke: `init → index → query → version` in a TempDir project (CRLF / path / CozoDB-open coverage). Compiles to zero tests on other platforms.
- Added gated `Windows smoke` step to the release build job: `cargo test --release --test windows_smoke` when `matrix.runs-on == 'windows-latest'`.
- Verified flow manually with release binary on macOS (same CLI path).

### PR-64 / US-GN-08 (mcp-resources-overview) — DONE
- `get_doc_structure` NOT resurrected (hard-removed, stays gone).
- Formal MCP Resources wired on the existing rmcp `ServerHandler` seam:
  - `resources/list` → `leankg://overview` (L0 identity + L1 critical facts) + `leankg://overview/wake_up` (project snapshot)
  - `resources/read` → same content as `get_overview_context`, per-project routed via `project_param`
  - `ServerCapabilities` now `enable_resources()`; JSON-RPC HTTP transport mirrors both methods.
- TDD: 3 new tests in `src/mcp/server.rs` (`resources/list` URIs, unknown-URI error, overview content from a temp `.leankg` project). 826 lib tests pass.

### PR-65 / US-GF-10/12 (lang-breadth-leftover) — DONE (small real work)
- FR-GF-10/12 (god-node importance + architecture hotspots) already shipped by PR-12 (#182, merged) — those FRs are DONE-by-PR-12.
- US-GF-10: DONE (Vue/Svelte index walk, REL-032) — verification note added; long-tail grammars (shell/Scala/Lua/Zig/Astro) remain P3 leftovers.
- US-GF-12: index-walk half DONE (REL-032); live `--postgres <dsn>` introspection remains open (documented). Small real work landed for the index-walk half: **inline `REFERENCES` FK extraction** for PG/MySQL column style (`user_id INTEGER REFERENCES users(id)`) — previously only the `FOREIGN KEY (...)` constraint form parsed. New test `extracts_postgres_dialect_dump` covers SERIAL/BIGSERIAL, quoted identifiers, `nextval()` defaults, inline FK.
- FR-EMBED-R4 left OPEN (not measured), per campaign.

## Gates
- `cargo fmt --all -- --check` PASS
- `cargo clippy --all -- -D warnings` PASS
- `cargo test --lib` PASS (826 passed, 3 ignored)

## Per-ID status
| ID | Status | Reason |
|----|--------|--------|
| US-CBM-C5 | DONE | Windows smoke test + release-job gated step |
| US-GN-08 | DONE | Formal MCP resources/list + resources/read (rmcp + JSON-RPC) |
| US-GF-10 | DONE (verification note) | Shipped by PR-14/REL-032; note + tests in PRD |
| US-GF-12 | PARTIAL → index-walk DONE | Inline REFERENCES FK + PG-dump test; live `--postgres` DSN open |
| FR-GF-10/12 | DONE by PR-12 | god-node scoring + hotspots merged #182 |
| FR-EMBED-R4 | OPEN | Left open unless measured (per campaign) |
