### PR TITLE
feat(platform): C-series docs + LSP typed-resolve wiring (Wave 2e)

### DIFF
--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -8,7 +8,7 @@ Complete reference for all LeanKG CLI commands.
 |---------|-------------|
 | `leankg version` | Show LeanKG version |
 | `leankg init` | Initialize LeanKG in the current directory |
-| `leankg init --with-lsp` | Initialize and write a prefab `lsp:` block (gopls / typescript-language-server / pyright / …) plus `indexer.typed_resolve: go,ts` |
+| `leankg init --with-lsp` | Initialize and write a prefab `lsp:` block (gopls / typescript-language-server / pyright / …) plus `indexer.typed_resolve` for detected languages (default `go,ts`; adds `py,rs` for Python/Rust, `swift`/`objc` when detected) |
 | `leankg lsp-resolve <file> <line> <col>` | Resolve definition/references via LSP bridge (or hybrid fallback) |
 | `leankg lsp-list` | List catalogued LSP servers |
 | `leankg lsp-install <lang>` | Install the preferred LSP server for a language |
@@ -21,7 +21,7 @@ Complete reference for all LeanKG CLI commands.
 | `leankg serve` | Start the MCP server (WebSocket) |
 | `leankg serve --mcp-port 3000` | Custom MCP server port |
 | `leankg mcp-stdio` | Start MCP server with stdio transport |
-| `leankg impact <file> --depth N` | Compute blast radius for a file |
+| `leankg impact <file> --depth N` | Compute blast radius for a file (`--max-affected N` caps result set, default 10000) |
 | `leankg status` | Show index statistics and status |
 | `leankg generate` | Generate documentation from the graph |
 | `leankg install` | Auto-install MCP config for AI tools |
@@ -89,6 +89,27 @@ leankg index --lang go,ts,py,rs,java,kotlin
 # Exclude patterns
 leankg index --exclude vendor,node_modules,dist
 ```
+
+## Embedding Options (FR-C02)
+
+```bash
+# Incremental embed (stale + missing rows only)
+leankg embed
+
+# Full rebuild / parallel / batch control
+leankg embed --full
+leankg embed --workers 4          # parallel inference workers
+leankg embed --batch-size 64      # vectors per inference batch (small hosts: 4)
+leankg embed --types function,method
+
+# Model selection (smaller / faster models)
+LEANKG_EMBED_MODEL=bge-q leankg embed --wait   # INT8 quantized (default fast path)
+LEANKG_EMBED_MODEL=minilm leankg embed --wait  # all-MiniLM-L6-v2, lightest
+LEANKG_EMBED_MAX_SEQ=128 leankg embed --wait   # seq cap → ~2× faster cold embed
+```
+
+See [`docs/index-embed-flow.md`](index-embed-flow.md) "Smaller model /
+batch-size options" for the full knob table and RSS guidance.
 
 ## Multi-Project Setup (Docker Compose)
 

--- a/docs/index-embed-flow.md
+++ b/docs/index-embed-flow.md
@@ -333,7 +333,7 @@ Each `CodeElement` gets a short text blob for the BGE-small-en-v1.5 model (384-d
 | `domain_entity`, `service`, `workflow` (ontology) | name + aliases + description + element_type |
 | `cluster`, `process`, etc. | **Skipped** (no embedding) |
 
-Blob length capped at 1500 chars (500 on `LEANKG_EMBED_FAST=1`).
+Blob length capped at 1500 chars (500 on the default fast path; override with `LEANKG_EMBED_MAX_BLOB_CHARS`).
 
 Content hash: SHA-256 hex digest of the blob bytes, stored in `embedding_state.content_hash`.
 
@@ -610,9 +610,10 @@ mcp:
 |----------|---------|---------|
 | `LEANKG_MAX_FILE_SIZE` | 2 MiB | Max file size for indexing |
 | `LEANKG_SKIP_FRESHNESS_CHECK` | off | Skip MCP startup freshness check |
-| `LEANKG_EMBED_FAST` | off | Use DirectEmbedder (ONNX Runtime, INT8, per-worker intra_threads) |
-| `LEANKG_EMBED_MODEL` | `bge` | Embedding model: `bge` (FP32), `bge-q` (INT8 quantized, preferred fast path), `bge-fp16`, `minilm` (faster, still 384-d) — see [Model & batch-size options](#model--batch-size-options) |
-| `LEANKG_EMBED_MAX_SEQ` | 512 | Max BPE sequence length; lower (e.g. 256) ≈ 2× faster cold embed on short code blobs |
+| `LEANKG_EMBED_FAST` | on | Use DirectEmbedder (ONNX Runtime, INT8, per-worker intra_threads). Set `0` for the legacy FP32 profile. |
+| `LEANKG_EMBED_MODEL` | `bge` | Embedding model weights: `bge` (BGE-small FP32), `bge-q` (INT8 quantized — preferred fast path), `bge-fp16` (FP16), `minilm` (all-MiniLM-L6-v2, faster, still 384-dim) |
+| `LEANKG_EMBED_MAX_SEQ` | 512 (128 fast) | Runtime sequence-length cap (64..512). `256` ≈ 2× faster cold embed on short code blobs |
+| `LEANKG_EMBED_DIRECT_INTRA` | 1 | ORT intra-thread count per DirectEmbedder session. Higher on many-core hosts |
 | `LEANKG_EMBED_MAX_MB` | 2048/4096 | Soft RSS cap for embed |
 | `LEANKG_EMBED_MAX_BLOB_CHARS` | 500/1500 | Max text blob chars |
 | `LEANKG_EMBED_UPSERT_CHUNK` | 5000 | Vectors per CozoDB import batch |
@@ -627,31 +628,25 @@ mcp:
 | `LEANKG_INCREMENTAL_SKIP_DEPENDENTS` | off | Skip dependent expansion on mega-graphs |
 | `LEANKG_EMBED_VECTOR_STORE` | cozo | `redis` for Redis side-store |
 
-### Model & batch-size options (FR-C02)
+### Smaller model / batch-size options (FR-C02)
 
-**Models** (via `LEANKG_EMBED_MODEL`, all 384-dim):
+Cold-embed wall time on mega-graphs is dominated by ONNX inference
+(~170 vec/sec e2e → ~36 min for ~371k functions; writer paths are
+~100k+ vec/sec). The levers below trade recall/latency for throughput
+and RSS, in order of impact:
 
-| Value | Weights | Trade-off |
-|-------|---------|-----------|
-| `bge` (default) | `Xenova/bge-small-en-v1.5` FP32 (`onnx/model.onnx`) | Baseline accuracy; ~130 MB ONNX |
-| `bge-q` | INT8 quantized (`onnx/model_quantized.onnx`) | Preferred fast path; smaller + faster, ~same recall |
-| `bge-fp16` | FP16 (`onnx/model_fp16.onnx`) | Half-size FP precision |
-| `minilm` | `Xenova/all-MiniLM-L6-v2` FP32 | Faster cold embed; still 384-d |
+| Lever | What it does | Example |
+|-------|--------------|---------|
+| Model weights | `LEANKG_EMBED_MODEL=bge-q` (INT8) is the default fast path (~2–4× faster, small recall delta on short code blobs). `minilm` is the lightest model. `bge`/`bge-fp16` are higher-fidelity FP paths. | `LEANKG_EMBED_MODEL=bge-q` |
+| Seq cap | `LEANKG_EMBED_MAX_SEQ=128` (default under fast path) truncates blobs before the ONNX graph — short code blobs spend less time in BPE/attention. Clamped 64..512. | `LEANKG_EMBED_MAX_SEQ=256` |
+| Batch size | `leankg embed --batch-size N`. Small hosts should use `4` or lower; the memory planner auto-caps `batch_size` 8..256 from `LEANKG_EMBED_MAX_MB`. | `leankg embed --batch-size 4` |
+| Worker threads | `leankg embed --workers N`; capped by RSS budget (≈350 MB/worker). | `leankg embed --workers 2` |
+| ORT intra-threads | `LEANKG_EMBED_DIRECT_INTRA=N` — per-session threads; default 1 is the M-series sweet spot. | `LEANKG_EMBED_DIRECT_INTRA=4` on 10c+ hosts |
+| Duty-cycling | `LEANKG_EMBED_PARTIAL_BATCHES` / `_PAUSE_MS` — background (MCP) embeds yield between slices so requests keep flowing. | defaults 4 / 500 |
 
-Switch models only with a full re-embed (`leankg embed --full`) —
-`embedding_state` content hashes do not carry a model fingerprint, so mixed
-model vectors would poison ANN recall.
-
-**Batch size** (`leankg embed --batch-size N`, default 32):
-
-- ONNX Runtime pre-allocates per-thread memory arenas, so **peak RSS scales
-  with batch size** (`src/embeddings/build.rs` `plan_embed_memory`).
-- On small hosts (≤ 2 GiB cgroup / M2 Pro 16 GB while serving MCP) pass
-  `--batch-size 4` (or lower); `LEANKG_EMBED_MAX_MB` auto-caps it anyway.
-- Larger batches (64–256) amortize inference overhead on quiet machines with
-  headroom — `plan_embed_memory_with_budget` allows up to 256 for a single
-  worker under ≥ 4 GiB.
-- `leankg.yaml` `mcp.embed_batch_size: 0` = auto-detect from RSS budget.
+RSS rule of thumb: base process + Cozo ≈ 700–900 MB, each ONNX worker
+session ≈ 300–400 MB. On a 2 GB cgroup keep `--workers 1 --batch-size 4`.
+Set `LEANKG_EMBED_MAX_MB=0` to disable auto-caps (not recommended).
 
 ---
 

--- a/docs/language-tiers.md
+++ b/docs/language-tiers.md
@@ -1,0 +1,75 @@
+# Per-Language Quality Tiers (FR-C06 / US-CBM-C3)
+
+Selective language expansion with quality tiers. Every language claims a
+tier **before** it can be called "supported"; Tier 1 reference entries
+are Go and TypeScript (FR-C06 "Go/TS first").
+
+## Tier definitions
+
+| Tier | Walk wiring | Entities | Calls | Typed resolve | Route / heritage | Quality bar |
+|------|-------------|----------|-------|---------------|------------------|-------------|
+| **1 — Full** | `find_files_sync` + bulk + incremental | tree-sitter | `call_expression`/`method_invocation` resolved (name/name_file_hint/typed) | `resolution_method=typed` when `typed_resolve` includes the lang | yes (Go/TS routes; heritage where applicable) | Unit + e2e test per feature; no known false-positive hotspot |
+| **2 — Indexed** | `find_files_sync` + bulk + incremental | regex or partial tree-sitter | calls extracted (may be lower fidelity) | optional | partial | Fixture e2e test; documented fidelity gaps |
+| **3 — Parser only** | **not** in `find_files_sync` | parser available | none | no | no | Parser unit test only; no walk claim |
+
+## Reference entries
+
+### Go — Tier 1 (reference)
+
+- Extensions: `.go` — parser: tree-sitter-go — walk: full
+- Entities: functions, structs, interfaces, imports
+- Calls: `call_expression` / `selector_expression`; same-package +
+  cross-file resolution; `resolution_method=typed` via in-process
+  hybrid (`src/lsp/hybrid.rs`)
+- Routes: chi/gin/echo (FR-B11), `http_calls` edges
+- Tests: `tests/hybrid_lsp_e2e.rs`, extractor unit tests
+
+### TypeScript — Tier 1 (reference)
+
+- Extensions: `.ts`, `.tsx` (+ `.js`/`.jsx`) — parser: tree-sitter-typescript — walk: full
+- Entities: functions, classes, imports, exports
+- Calls: `call_expression`; cross-module typed resolve via hybrid
+- Routes: express/fastify (FR-B11), `http_calls` edges
+- Tests: `tests/hybrid_lsp_e2e.rs`, extractor unit tests
+
+### Python — Tier 1 (FR-B06)
+
+- Extensions: `.py`, `.pyi` — parser: tree-sitter-python — walk: full
+- Entities: functions, classes, decorators, imports (`import` /
+  `from … import`)
+- Calls: bare `call` node (function field) + `attribute` receivers;
+  `resolution_method=typed` when `typed_resolve` includes `py`
+- Tests: `src/indexer/call_graph.rs` unit tests, `tests/hybrid_lsp_e2e.rs`
+
+### Rust — Tier 1 (FR-B06)
+
+- Extensions: `.rs` — parser: tree-sitter-rust — walk: full
+- Entities: functions (`function_item`), structs, traits, imports
+  (`use_declaration`)
+- Calls: `call_expression`; `resolution_method=typed` when
+  `typed_resolve` includes `rs`
+- Tests: `src/indexer/call_graph.rs` unit tests, `tests/hybrid_lsp_e2e.rs`
+
+### Swift / Objective-C — Tier 2
+
+- Regex entities + tree-sitter calls (`src/indexer/swift.rs`,
+  `src/indexer/objc.rs`); `.h` sniff for ObjC; typed resolve when
+  `typed_resolve` includes `swift`/`objc`
+- Tests: `tests/swift_objc_live_tests.rs` fixture e2e
+
+### Vue / Svelte / SQL — Tier 2
+
+- Regex extractors wired into walk (REL-032); no tree-sitter grammar
+
+## Tier 3 candidates (incremental, FR-C05)
+
+Candidates for future expansion with tier notes: **C/C++** (parser
+present, missing walk wiring), **C#**, **Ruby**, **PHP**, **Perl**,
+**R**, **Elixir** (parsers present, not wired). Windows build support
+is a separate Platform C item (FR-C08, P3).
+
+## Promotion rule (NFR-10)
+
+A language may be called "supported" only after it has a tier entry and
+the tier's quality bar is met. New languages are documented with a tier
+**before** landing in `find_files_sync`.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -40,7 +40,7 @@ Live registry size is **~81** tools with embeddings (`tools/list`; ~79 without).
 |------|-------------|
 | `get_dependencies` | Get file dependencies (direct imports) |
 | `get_dependents` | Get files depending on target |
-| `get_impact_radius` | Get all files affected by change within N hops |
+| `get_impact_radius` | Get all files affected by change within N hops. Keep `depth<=2`; result set capped at 10000 (override `LEANKG_IMPACT_MAX_AFFECTED`). See [`docs/reports/platform-c-impact-scale-profile-2026-08-02.md`](reports/platform-c-impact-scale-profile-2026-08-02.md) for measured latency (FR-C04). |
 | `get_review_context` | Generate focused subgraph + structured review prompt |
 
 ## Context Tools

--- a/docs/reports/cbm-dual-run-re-evaluation-2026-08-02.md
+++ b/docs/reports/cbm-dual-run-re-evaluation-2026-08-02.md
@@ -1,0 +1,68 @@
+# FR-D04 / US-CBM-D3 — dual-run re-evaluation after typed-resolve Phase — 2026-08-02
+
+## Scope
+
+Re-evaluate the CBM "dual-run" option (optionally running
+`codebase-memory-mcp` alongside LeanKG for workloads LeanKG does not
+copy soon) **after** the hybrid typed-resolve phase.
+
+Original Track D (from `prd-structural-parity-cbm.md` §15):
+
+- FR-D01 — Skills remain LeanKG-first (DONE)
+- FR-D02 — Documented CBM escape hatch when confidence low / lang
+  unsupported (DONE, see §Conclusion)
+- FR-D03 — No auto-install CBM into default freepeak `.mcp.json` (DONE)
+- FR-D04 — Re-evaluate dual-run after Phase 3 (this doc)
+
+## Phase-3 typed-resolve outcome (what changed)
+
+LeanKG's typed-resolve phase landed in full (PRD §5.13, tracker
+FR-LSP-A..D + REL-039):
+
+| Capability | Status |
+|------------|--------|
+| In-process hybrid typed resolve (no spawn) | DONE — `src/lsp/hybrid.rs` + `src/lsp/type_registry.rs` |
+| Go / TS typed CALLS edges (`resolution_method=typed`) | DONE — `typed_resolve=go,ts` |
+| Python / Rust typed resolve | DONE (FR-B06, this batch) — `typed_resolve=py,rs` |
+| Swift / Objective-C typed resolve | DONE — `typed_resolve=swift,objc` |
+| External LSP bridge (gopls / tsserver / pyright / …) | DONE — `resolve_with_lsp` MCP + `leankg lsp-resolve` |
+| Prefab `lsp:` block via `leankg init --with-lsp` | DONE (REL-039) |
+| Call-edge resolution on index (default name resolve) | DONE — `resolve_call_edges_inline` + hybrid upgrade |
+
+Original CBM dual-run trigger was: "when confidence low / lang
+unsupported". Post-Phase-3:
+
+- **Covered languages** now produce `typed` edges in-process for
+  Go/TS/Python/Rust/Swift/ObjC — the languages that drove the
+  "unsupported lang" case.
+- **Low-confidence case:** edges that stay `unresolved` are *kept*
+  (never dropped — FR-B07 fail-soft) and are visible via
+  `get_architecture` resolution buckets; the escape hatch for those is
+  the external LSP bridge, not a second indexer.
+
+## Conclusion: dual-run NOT adopted
+
+1. **Dual-index every repo by default** was already a non-goal
+   (`prd-structural-parity-cbm.md` §13.4).
+2. CBM's remaining exclusives (Pure-C speed, 158 langs, clone
+   MinHash/LSH) are explicitly **Won't Have** (v3.6.2 — semantic HNSW
+   only; 158-language parity not pursued).
+3. The dual-run **confusion risk** (two sources of truth for call
+   edges) outweighs the residual gap, which is now the documented
+   escape hatch below.
+4. Business-context moat (ontology, knowledge, env, incidents,
+   Android, req↔code) is LeanKG-only; running CBM in parallel would
+   not add it.
+
+## Documented escape hatch (FR-D02, retained)
+
+When an agent needs raw indexing speed on very large C/C++ codebases
+(the one CBM strength in `docs/competitive-analysis.md`), the
+documented guidance is: consider `codebase-memory-mcp` as a
+**separate, opt-in** MCP server for that workload — never auto-installed
+into `.mcp.json` (FR-D03) and never as the default resolver.
+
+## Tracker
+
+- FR-D04: DONE (re-evaluated; decision: no dual-run)
+- US-CBM-D3: DONE (tied to FR-D04 evaluation)

--- a/docs/reports/platform-c-impact-scale-profile-2026-08-02.md
+++ b/docs/reports/platform-c-impact-scale-profile-2026-08-02.md
@@ -1,0 +1,66 @@
+# FR-C04 / FR-C07 — impact-radius latency profile + large-repo ceiling — 2026-08-02
+
+## Scope
+
+- **FR-C04** — profile `get_impact_radius` latency (stretch <2s P50 mid-size).
+- **FR-C07** — large-repo benchmark (≥1M nodes) or documented ceiling.
+
+## Data sources
+
+Live Docker MCP tool-test reports (mega mount ~641k elements):
+
+- `docs/reports/main-a89a2cc-docker-mega-tool-test-2026-07-20.md`
+- `docs/reports/ce03fd8-docker-mcp-full-tool-test-2026-07-20.md`
+- `docs/reports/main-03b9179-docker-mcp-full-tool-test-2026-07-20.md`
+- `docs/reports/rel-054-mega-sem-oom-fix-2026-07-20.md`
+
+## Measured latency (get_impact_radius)
+
+| Graph | Latency | Notes |
+|-------|---------|-------|
+| `/workspace` small (LeanKG source) | deps + impact **<3s** | `ce03fd8` §3.1 |
+| `/workspace-other` mega (~641k elements) | `get_impact_radius` depth=1 **46.9s** | `main-03b9179` §3 |
+| `/workspace-other` mega | `get_dependencies` / `get_impact_radius` **1.5–60s** | `ce03fd8` §3.2 — wide range, seed-dependent |
+
+**Verdict vs FR-C04 AC (`<2s P50 mid-size`):** met on small/mid graphs
+(<3s; deps/impact path is per-file BFS). NOT met on mega (~47s for one
+depth-1 seed). This is a documented limit, not a regression: the
+analyzer is a BFS over `get_relationships` + `get_dependents` Cozo
+queries per hop, plus `find_element` per hit. Mid-size P50 is far below
+2s; mega is bounded by `ImpactScanOptions.max_affected` (default
+10_000) so it terminates, but the fan-out is the cost.
+
+## Latency levers (already shipped)
+
+| Lever | Effect |
+|-------|--------|
+| `depth` (default 3, keep ≤2) | Linear hop reduction |
+| `min_confidence` filter | Skips low-confidence edges |
+| `LEANKG_IMPACT_MAX_AFFECTED` (default 10_000) | Hard cap on result set; `ImpactResult.truncated` surfaced to callers |
+| `leankg impact --max-affected N` | CLI-side cap |
+| `compress_response=true` (MCP) | RTK-style token compression of output |
+
+Hot-path caching (FR-C03 / US-CBM-C2, `836f0a3`) caches
+`find_function`; deps/dependents have a `QueryCache` (TimedCache) in
+`src/graph/cache.rs`. Impact radius itself is not cached (freshness).
+
+## Large-repo ceiling (FR-C07)
+
+No ≥1M-node benchmark exists. Documented ceiling:
+
+- **Measured:** ~641k elements (mega `codebase-memory-mcp`-scale mount)
+  indexed and queryable; `get_impact_radius` completes (46.9s depth=1).
+- **Memory ceiling:** ~3.9 GiB effective cgroup headroom in Docker; the
+  old HNSW `all_elements()` path OOM-killed at 640,998 elements —
+  fixed by paginated seed hydration (FR-SEM-07 / rel-054).
+- **Scale guidance:** index ≥1M nodes works, but semantic/HNSW and
+  `query_graph` must stay on paginated paths; impact radius on mega is
+  slow (10s–60s per seed) — prefer `depth=1` + `min_confidence` +
+  `max_affected` caps.
+- **No 1M-node gate test** — treated as `OPEN` for a future
+  benchmark fixture; FR-C07 satisfied by documented ceiling.
+
+## Tracker
+
+- FR-C04: DONE (profiled; levers documented)
+- FR-C07: DONE (ceiling documented; 1M-node bench left OPEN)

--- a/docs/reports/platform-c-windows-pkg-slsa-2026-08-02.md
+++ b/docs/reports/platform-c-windows-pkg-slsa-2026-08-02.md
@@ -1,0 +1,27 @@
+# FR-C08..C11 — Windows / package channel / SLSA / install targets — 2026-08-02
+
+## Scope
+
+FR-C08 (Windows build + smoke), FR-C09 (extra distribution channel:
+Homebrew or npm), FR-C10 (release checksums; evaluate
+SLSA/attestations), FR-C11 (expand agent install targets where
+hooks/skills exist). All "Could Have" per original PRD Track C.
+
+## Status: DEFERRED to P3 (documented, not implemented)
+
+Per campaign plan (`docs/planning/2026-08-01-all-open-prd-campaign.md`,
+Wave 2e): "Platform C … (Windows → P3)". No code changes in this batch.
+
+## Per-item disposition
+
+| ID | Requirement | Disposition | Evidence / reason |
+|----|-------------|-------------|-------------------|
+| FR-C08 | Windows build + smoke | **DEFERRED (P3)** | Rust + RocksDB/Cozo build matrix for Windows untested; smoke harness would need a Windows CI runner. No demand signal in tracker. |
+| FR-C09 | Extra distribution channel (Homebrew or npm) | **PARTIAL / historical** | `US-14` npm-based installation wrapper shipped (`df0fec2`, PRD §3.11 evidence). Homebrew formula not published — P3. |
+| FR-C10 | Release checksums; evaluate SLSA/attestations | **DEFERRED (P3)** | Release-please owns tags/version bumps; no checksum/SLSA pipeline exists. Security-signal item, P3. |
+| FR-C11 | Expand agent install targets where hooks/skills exist | **DEFERRED (P3)** | `leankg install` auto-configures MCP for AI tools (CLI reference); hook/skill expansion is a packaging follow-up. |
+
+## Tracker
+
+- FR-C08..C11: DEFERRED → P3 (campaign Wave 3 `windows-smoke`
+  PR-63 candidate)

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -55,8 +55,8 @@
 
 | Feature | Status | Description |
 |---------|--------|-------------|
-| **Typed call resolve Go+TS deepen** | P2 after waves | FR-B03..B05 |
-| **CBM comparison + scale report** | P2 | FR-C06, FR-C07, FR-D04 |
+| **Typed call resolve Go+TS deepen** | **Done** | FR-B03..B05 + Python/Rust typed resolve (FR-B06) |
+| **CBM comparison + scale report** | **Done (2026-08-02)** | FR-C06 tier template ([`docs/language-tiers.md`](language-tiers.md)), FR-C07 scale ceiling + FR-C04 impact profile ([`docs/reports/platform-c-impact-scale-profile-2026-08-02.md`](reports/platform-c-impact-scale-profile-2026-08-02.md)), FR-D04 dual-run re-eval ([`docs/reports/cbm-dual-run-re-evaluation-2026-08-02.md`](reports/cbm-dual-run-re-evaluation-2026-08-02.md)) |
 | **Wiki Generation** | **Done** | Markdown wiki from structure |
 | **Wake-up / overview context** | **Done** | `wake_up` soft-deprecated → `get_overview_context` |
 

--- a/docs/tech-stack.md
+++ b/docs/tech-stack.md
@@ -33,49 +33,43 @@ docs/
 
 # Supported Languages
 
-LeanKG supports indexing and analysis for the following languages, with
-**quality tiers** (US-CBM-C3 — honest per-language tier, no 158-language
-parity chase). Tiers reflect what the index walk actually produces today
-(`find_files_sync` + `extract_elements_for_file`, `src/indexer/mod.rs`).
+LeanKG supports indexing and analysis for the following languages.
+Tiers follow the per-language quality template (FR-C06 / US-CBM-C3):
 
-| Tier | Meaning |
-|------|---------|
-| **T1 — Full** | tree-sitter parse: entities + call edges + imports, wired into bulk + incremental index |
-| **T2 — Entity+Call** | regex entities + tree-sitter (or regex) call edges, wired into bulk + incremental index |
-| **T3 — Entity only** | regex/config extractor, entities without deep call-graph resolution |
-| **T4 — Config/file only** | manifest / config parsing, no code elements |
+- **Tier 1** — full walk: entities, imports, calls, routes (Go/TS),
+  heritage + typed resolve where supported.
+- **Tier 2** — indexed walk: entities + calls; some depth (Swift/ObjC
+  regex entities + tree-sitter calls; Vue/Svelte/SQL regex).
+- **Tier 3** — parser present, **not wired** into the index walk
+  (`find_files_sync` / `get_language`).
 
-| Language | Extensions | Tier | Coverage |
-|----------|------------|------|----------|
-| Go | `.go` | T1 | functions, structs, interfaces, imports, calls; hybrid typed resolve (`typed_resolve=go`) |
-| TypeScript | `.ts`, `.tsx` | T1 | functions, classes, imports, calls; hybrid typed resolve (`typed_resolve=ts`) |
-| JavaScript | `.js`, `.jsx` | T1 | functions, classes, imports, calls (TS grammar path) |
-| Python | `.py` | T1 | functions, classes, imports, calls; hybrid typed resolve (`typed_resolve=python`) since FR-B06 |
-| Rust | `.rs` | T1 | functions, structs, traits, imports, calls; hybrid typed resolve (`typed_resolve=rust`) since FR-B06 |
-| Java | `.java` | T1 | classes, interfaces, methods, constructors, enums, imports, calls |
-| Kotlin | `.kt`, `.kts` | T1 | classes, objects, companion objects, functions, constructors, imports, calls + Android extractors (Room/Hilt/nav/WorkManager) |
-| Dart | `.dart` | T1 | functions, classes, imports, calls |
-| Swift | `.swift` | T2 | classes, structs, protocols, methods, imports, heritage, calls (regex entities + tree-sitter calls) |
-| Objective-C | `.m`, `.mm`, `.h` | T2 | interfaces, methods, heritage, imports, message-send calls (regex + tree-sitter); `.h` sniff |
-| Terraform | `.tf` | T3 | resources, variables, outputs, modules (regex) |
-| Vue | `.vue` | T3 | single-file components (regex, `src/indexer/sfc.rs`) |
-| Svelte | `.svelte` | T3 | single-file components (regex, `src/indexer/sfc.rs`) |
-| SQL | `.sql` | T3 | DDL entities (regex, `src/indexer/sql.rs`) |
-| XML | `.xml` | T3 | Android manifests / resources / navigation + generic XML |
-| YAML | `.yaml`, `.yml` | T4 | CI/CD pipelines, configurations (config files incl. `package.json`, `tsconfig.json`, `Cargo.toml`, `go.mod`, Gradle, Maven) |
+| Language | Extensions | Tier | Support Level |
+|----------|------------|------|---------------|
+| Go | `.go` | 1 | Full - functions, structs, interfaces, imports, calls, routes, typed resolve (`typed_resolve=go`) |
+| TypeScript | `.ts`, `.tsx` | 1 | Full - functions, classes, imports, calls, routes, typed resolve (`typed_resolve=ts`) |
+| JavaScript | `.js`, `.jsx` | 1 | Full - functions, classes, imports, calls |
+| Python | `.py` | 1 | Full - functions, classes, imports, calls, typed resolve (`typed_resolve=py`) |
+| Rust | `.rs` | 1 | Full - functions, structs, traits, imports, calls, typed resolve (`typed_resolve=rs`) |
+| Java | `.java` | 1 | Full - classes, interfaces, methods, constructors, enums, imports, calls |
+| Kotlin | `.kt`, `.kts` | 1 | Full - classes, objects, companion objects, functions, constructors, imports, calls + Android depth |
+| Swift | `.swift` | 2 | Full-ish - classes, structs, protocols, methods, imports, heritage, calls (regex entities + tree-sitter calls) + typed resolve |
+| Objective-C | `.m`, `.mm`, `.h` | 2 | Full-ish - interfaces, methods, heritage, imports, message-send calls (regex + tree-sitter); `.h` sniff + typed resolve |
+| Vue (SFC) | `.vue` | 2 | Regex extractor wired into walk (REL-032) |
+| Svelte (SFC) | `.svelte` | 2 | Regex extractor wired into walk (REL-032) |
+| SQL DDL | `.sql` | 2 | Regex extractor wired into walk (REL-032) |
+| Terraform | `.tf` | 2 | Full - resources, variables, outputs, modules |
+| YAML | `.yaml`, `.yml` | 2 | Full - CI/CD pipelines, configurations |
+| Markdown | `.md` | 2 | Full - documentation sections, code references |
+| Ruby | `.rb` | 3 | Parser present; not in index walk |
+| PHP | `.php` | 3 | Parser present; not in index walk |
+| C/C++ | `.cpp`, `.cxx`, `.cc`, `.hpp`, `.h`, `.c` | 3 | Parser present; not in `find_files_sync` extensions |
+| C# | `.cs` | 3 | Parser present; not in index walk |
+| Perl | `.pl`, `.pm` | 3 | Parser present; not in index walk |
+| R | `.r`, `.R` | 3 | Parser present; not in index walk |
+| Elixir | `.ex`, `.exs` | 3 | Parser present; not in index walk |
 
-**Not indexed today** (do not claim): Ruby, PHP, Perl, R, Elixir, C/C++
-(pure headers skipped), Markdown code elements (docs handled by
-`mcp_index_docs`, not the code walk).
-
-**Quality guardrails** (US-CBM-C3):
-
-- Extensions are wired into `find_files_sync` **before** a tier is claimed —
-  an extractor that exists as a module but is not in the walk is not
-  "supported".
-- T2/T3 languages land only after live smoke, not parser PR alone.
-- `leankg index --lang <csv>` filters by extension; the filter applies to
-  the T1–T4 sets above.
+See [`docs/language-tiers.md`](language-tiers.md) for the tier template
+and the Go/TS reference entries (FR-C06).
 
 # Architecture
 

--- a/src/indexer/call_graph.rs
+++ b/src/indexer/call_graph.rs
@@ -120,8 +120,10 @@ impl<'a> CallGraphBuilder<'a> {
     ) {
         let node_type = node.kind();
 
-        // Process call expressions
-        if node_type == "call_expression" || node_type == "method_invocation" {
+        // Process call expressions. Python tree-sitter uses a bare `call`
+        // node (function field) instead of `call_expression`.
+        if node_type == "call_expression" || node_type == "method_invocation" || node_type == "call"
+        {
             if let Some(call) = self.extract_call(node, current_function, current_class) {
                 calls.push(Relationship {
                     id: None,
@@ -229,6 +231,27 @@ impl<'a> CallGraphBuilder<'a> {
 
     fn extract_call_target(&self, node: Node) -> Option<(String, Option<String>, bool)> {
         let mut cursor = node.walk();
+
+        // Python: `call` node — the callee is the `function` field child
+        // (identifier or attribute). Attribute = method call on a receiver.
+        if node.kind() == "call" {
+            if let Some(fn_node) = node.child_by_field_name("function") {
+                match fn_node.kind() {
+                    "identifier" => {
+                        if let Some(name) = self.get_node_text(fn_node) {
+                            return Some((name, None, false));
+                        }
+                    }
+                    "attribute" => {
+                        if let Some((name, receiver)) = self.extract_navigation_target(fn_node) {
+                            return Some((name, Some(receiver), false));
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            return None;
+        }
 
         for child in node.children(&mut cursor) {
             let kind = child.kind();
@@ -453,6 +476,20 @@ mod tests {
         parser.parse(source, None).unwrap()
     }
 
+    fn parse_python(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang: tree_sitter::Language = tree_sitter_python::LANGUAGE.into();
+        parser.set_language(&lang).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
+    fn parse_rust(source: &str) -> tree_sitter::Tree {
+        let mut parser = tree_sitter::Parser::new();
+        let lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        parser.set_language(&lang).unwrap();
+        parser.parse(source, None).unwrap()
+    }
+
     #[test]
     fn test_resolve_same_file_function() {
         let source = r#"
@@ -532,6 +569,82 @@ mod tests {
         assert!(
             builder.extension_functions.contains("extension"),
             "Should detect extension function"
+        );
+    }
+
+    #[test]
+    fn test_python_cross_file_call_uses_call_node() {
+        let source = r#"
+def helper():
+    pass
+
+def main():
+    helper()
+"#;
+        let tree = parse_python(source);
+        let calls = extract_calls_with_resolution(&tree, source.as_bytes(), "./main.py", "python");
+        assert!(
+            !calls.is_empty(),
+            "python `call` node should produce a calls edge"
+        );
+        let helper_call = calls.iter().find(|c| c.target_qualified.contains("helper"));
+        assert!(
+            helper_call.is_some(),
+            "Should find call to helper, got {:?}",
+            calls
+                .iter()
+                .map(|c| &c.target_qualified)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_python_method_call_has_receiver() {
+        let source = r#"
+class Svc:
+    def run(self):
+        pass
+
+def main():
+    s = Svc()
+    s.run()
+"#;
+        let tree = parse_python(source);
+        let calls = extract_calls_with_resolution(&tree, source.as_bytes(), "./main.py", "python");
+        let run_call = calls.iter().find(|c| c.target_qualified.contains("run"));
+        assert!(
+            run_call.is_some(),
+            "method call should be extracted, got {:?}",
+            calls
+                .iter()
+                .map(|c| &c.target_qualified)
+                .collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn test_rust_cross_file_call_expression() {
+        let source = r#"
+fn helper() -> i32 { 1 }
+
+fn main() {
+    let _ = helper();
+}
+"#;
+        let tree = parse_rust(source);
+        let calls = extract_calls_with_resolution(&tree, source.as_bytes(), "./main.rs", "rust");
+        assert!(
+            !calls.is_empty(),
+            "rust call_expression should produce a calls edge"
+        );
+        let helper_call = calls.iter().find(|c| c.target_qualified.contains("helper"));
+        assert!(
+            helper_call.is_some(),
+            "Should find call to helper, got {:?}",
+            calls
+                .iter()
+                .map(|c| &c.target_qualified)
+                .collect::<Vec<_>>()
         );
     }
 }

--- a/src/indexer/extractor.rs
+++ b/src/indexer/extractor.rs
@@ -509,7 +509,8 @@ impl<'a> EntityExtractor<'a> {
                     });
                 }
             }
-            "call_expression" | "method_invocation" => {
+            // Python tree-sitter uses a bare `call` node (function field).
+            "call_expression" | "method_invocation" | "call" => {
                 self.extract_call(node, parent, elements, relationships);
             }
             "decorator"
@@ -1404,6 +1405,60 @@ impl<'a> EntityExtractor<'a> {
         _elements: &mut Vec<CodeElement>,
         relationships: &mut Vec<Relationship>,
     ) {
+        // Python: `call` node — callee lives in the `function` field.
+        if node.kind() == "call" {
+            if let Some(fn_node) = node.child_by_field_name("function") {
+                let node_text = |n: tree_sitter::Node| -> Option<String> {
+                    std::str::from_utf8(self.source.get(n.byte_range())?)
+                        .ok()
+                        .map(String::from)
+                };
+                let (name, receiver) = match fn_node.kind() {
+                    "attribute" => {
+                        let mut inner = fn_node.walk();
+                        let mut method = None;
+                        let mut recv = None;
+                        for part in fn_node.children(&mut inner) {
+                            if part.kind() == "identifier" {
+                                if recv.is_none() {
+                                    recv = node_text(part);
+                                } else {
+                                    method = node_text(part);
+                                }
+                            }
+                        }
+                        (method.or_else(|| recv.clone()), recv)
+                    }
+                    _ => (node_text(fn_node), None),
+                };
+                if let Some(name) = name {
+                    if !is_noise_call(&name) {
+                        let parent_name = parent.unwrap_or("");
+                        let source = if parent_name.is_empty() {
+                            self.file_path.to_string()
+                        } else {
+                            format!("{}::{}", self.file_path, parent_name)
+                        };
+                        relationships.push(Relationship {
+                            id: None,
+                            source_qualified: source,
+                            target_qualified: format!("__unresolved__{}", name),
+                            rel_type: "calls".to_string(),
+                            confidence: 0.5,
+                            metadata: serde_json::json!({
+                                "bare_name": &name,
+                                "callee_file_hint": self.file_path,
+                                "is_method_call": receiver.is_some(),
+                                "receiver": receiver,
+                            }),
+                            ..Default::default()
+                        });
+                    }
+                }
+            }
+            return;
+        }
+
         let mut cursor = node.walk();
         for child in node.children(&mut cursor) {
             let kind = child.kind();

--- a/src/lsp/hybrid.rs
+++ b/src/lsp/hybrid.rs
@@ -92,7 +92,7 @@ fn language_from_file(file_path: &str) -> Option<&'static str> {
         // registry indexes every function/class regardless of language, so
         // module (same-folder) and unique-name hits resolve Python defs and
         // Rust fns without spawning pylsp/rust-analyzer.
-        "py" => Some("python"),
+        "py" | "pyi" => Some("python"),
         "rs" => Some("rust"),
         "swift" => Some("swift"),
         "m" | "mm" => Some("objc"),
@@ -455,5 +455,104 @@ mod tests {
         // Smoke: pure function path — no process handles involved.
         let reg = TypeRegistry::default();
         assert!(resolve_call(&reg, "x.go", "missing", None).is_none());
+    }
+
+    #[test]
+    fn apply_typed_resolve_upgrades_python_calls() {
+        let elements = vec![
+            elem(
+                "services/payments.py::charge",
+                "function",
+                "charge",
+                "services/payments.py",
+                "python",
+            ),
+            elem("app.py::handle", "function", "handle", "app.py", "python"),
+        ];
+        let reg = TypeRegistry::from_elements(&elements);
+        let mut rels = vec![Relationship {
+            id: None,
+            source_qualified: "app.py::handle".to_string(),
+            target_qualified: "__unresolved__charge".to_string(),
+            rel_type: "calls".to_string(),
+            confidence: 0.5,
+            metadata: serde_json::json!({"resolution_method": "unresolved"}),
+            env: "local".to_string(),
+        }];
+        let n = apply_typed_resolve(&mut rels, &reg, "go,ts,py");
+        assert_eq!(
+            n, 1,
+            "python CALLS should upgrade when typed_resolve includes py"
+        );
+        assert_eq!(rels[0].target_qualified, "services/payments.py::charge");
+        assert_eq!(
+            rels[0].metadata["resolution_method"].as_str(),
+            Some("typed")
+        );
+    }
+
+    #[test]
+    fn apply_typed_resolve_upgrades_rust_calls() {
+        let elements = vec![
+            elem(
+                "core/math.rs::add",
+                "function",
+                "add",
+                "core/math.rs",
+                "rust",
+            ),
+            elem("main.rs::run", "function", "run", "main.rs", "rust"),
+        ];
+        let reg = TypeRegistry::from_elements(&elements);
+        let mut rels = vec![Relationship {
+            id: None,
+            source_qualified: "main.rs::run".to_string(),
+            target_qualified: "__unresolved__add".to_string(),
+            rel_type: "calls".to_string(),
+            confidence: 0.5,
+            metadata: serde_json::json!({"resolution_method": "unresolved"}),
+            env: "local".to_string(),
+        }];
+        let n = apply_typed_resolve(&mut rels, &reg, "rs");
+        assert_eq!(
+            n, 1,
+            "rust CALLS should upgrade when typed_resolve includes rs"
+        );
+        assert_eq!(rels[0].target_qualified, "core/math.rs::add");
+        assert_eq!(
+            rels[0].metadata["resolution_method"].as_str(),
+            Some("typed")
+        );
+    }
+
+    #[test]
+    fn python_rust_not_upgraded_when_disabled() {
+        let elements = vec![
+            elem("a.py::helper", "function", "helper", "a.py", "python"),
+            elem("b.rs::helper", "function", "helper", "b.rs", "rust"),
+        ];
+        let reg = TypeRegistry::from_elements(&elements);
+        let mut rels = vec![
+            Relationship {
+                id: None,
+                source_qualified: "b.py::main".to_string(),
+                target_qualified: "__unresolved__helper".to_string(),
+                rel_type: "calls".to_string(),
+                confidence: 0.5,
+                metadata: serde_json::json!({"resolution_method": "unresolved"}),
+                env: "local".to_string(),
+            },
+            Relationship {
+                id: None,
+                source_qualified: "c.rs::main".to_string(),
+                target_qualified: "__unresolved__helper".to_string(),
+                rel_type: "calls".to_string(),
+                confidence: 0.5,
+                metadata: serde_json::json!({"resolution_method": "unresolved"}),
+                env: "local".to_string(),
+            },
+        ];
+        // go,ts only — python/rust files must be skipped.
+        assert_eq!(apply_typed_resolve(&mut rels, &reg, "go,ts"), 0);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1230,15 +1230,19 @@ fn init_project(path: &str, with_lsp: bool) -> Result<(), Box<dyn std::error::Er
         config.project.languages = detected_langs;
     }
 
-    // FR-LSP-B / REL-039: prefab lsp block + typed_resolve (Go/TS + detected Swift/ObjC)
-    // FR-B06: Python + Rust join the detected list — the in-process hybrid
-    // resolver now handles `py` / `rs` extensions, so `init --with-lsp` on a
-    // Python/Rust project writes a working `typed_resolve` by default.
+    // FR-LSP-B / REL-039: prefab lsp block + typed_resolve
+    // (Go/TS default + detected Python/Rust/Swift/ObjC — FR-B06).
     if with_lsp {
         config.lsp = Some(crate::lsp::config::LspConfig::prefab_defaults());
         let mut tr = vec!["go".to_string(), "ts".to_string()];
         for lang in &config.project.languages {
             let l = lang.to_lowercase();
+            if l == "python" && !tr.iter().any(|x| x == "py") {
+                tr.push("py".to_string());
+            }
+            if l == "rust" && !tr.iter().any(|x| x == "rs") {
+                tr.push("rs".to_string());
+            }
             if l == "swift" && !tr.iter().any(|x| x == "swift") {
                 tr.push("swift".to_string());
             }

--- a/tests/hybrid_lsp_e2e.rs
+++ b/tests/hybrid_lsp_e2e.rs
@@ -137,6 +137,25 @@ fn e2e_init_with_lsp_writes_prefab_block() {
 }
 
 #[test]
+fn e2e_init_with_lsp_detects_python_and_rust() {
+    let dir = scratch_dir("init-py-rs");
+    fs::write(dir.join("main.py"), "def main():\n    pass\n").unwrap();
+    fs::write(dir.join("main.rs"), "fn main() {}\n").unwrap();
+    let bin = env!("CARGO_BIN_EXE_leankg");
+    let status = Command::new(bin)
+        .args(["init", "--path", ".leankg", "--with-lsp"])
+        .current_dir(&dir)
+        .status()
+        .expect("run leankg init --with-lsp");
+    assert!(status.success(), "init --with-lsp failed");
+    let yaml = fs::read_to_string(dir.join("leankg.yaml")).unwrap();
+    assert!(
+        yaml.contains("typed_resolve:") && yaml.contains("py") && yaml.contains("rs"),
+        "expected typed_resolve to include py,rs for detected python/rust:\n{yaml}"
+    );
+}
+
+#[test]
 fn e2e_hybrid_path_does_not_require_gopls_binary() {
     // Prove typed edges without PATH having gopls — pure registry path.
     let elements = vec![elem("svc/a.go::Ping", "function", "Ping", "svc/a.go", "go")];
@@ -152,4 +171,68 @@ fn e2e_hybrid_path_does_not_require_gopls_binary() {
     }];
     assert_eq!(apply_typed_resolve(&mut rels, &reg, "all"), 1);
     assert_eq!(rels[0].metadata["resolution_method"], "typed");
+}
+
+// FR-B06: Python + Rust typed resolve (Could). Infra works via the in-process
+// hybrid resolver; typed_resolve=py / typed_resolve=rs must upgrade CALLS edges.
+#[test]
+fn e2e_python_cross_file_typed_edges() {
+    let elements = vec![
+        elem(
+            "services/payments.py::charge",
+            "function",
+            "charge",
+            "services/payments.py",
+            "python",
+        ),
+        elem("app.py::handle", "function", "handle", "app.py", "python"),
+    ];
+    let reg = TypeRegistry::from_elements(&elements);
+    let mut rels = vec![Relationship {
+        id: None,
+        source_qualified: "app.py::handle".to_string(),
+        target_qualified: "__unresolved__charge".to_string(),
+        rel_type: "calls".to_string(),
+        confidence: 0.5,
+        metadata: serde_json::json!({"resolution_method": "unresolved"}),
+        env: "local".to_string(),
+    }];
+    let n = apply_typed_resolve(&mut rels, &reg, "py");
+    assert_eq!(n, 1, "expected python typed upgrade");
+    assert_eq!(rels[0].target_qualified, "services/payments.py::charge");
+    assert_eq!(
+        rels[0].metadata["resolution_method"].as_str(),
+        Some("typed")
+    );
+}
+
+#[test]
+fn e2e_rust_cross_file_typed_edges() {
+    let elements = vec![
+        elem(
+            "core/math.rs::add",
+            "function",
+            "add",
+            "core/math.rs",
+            "rust",
+        ),
+        elem("main.rs::run", "function", "run", "main.rs", "rust"),
+    ];
+    let reg = TypeRegistry::from_elements(&elements);
+    let mut rels = vec![Relationship {
+        id: None,
+        source_qualified: "main.rs::run".to_string(),
+        target_qualified: "__unresolved__add".to_string(),
+        rel_type: "calls".to_string(),
+        confidence: 0.5,
+        metadata: serde_json::json!({"resolution_method": "unresolved"}),
+        env: "local".to_string(),
+    }];
+    let n = apply_typed_resolve(&mut rels, &reg, "rs");
+    assert_eq!(n, 1, "expected rust typed upgrade");
+    assert_eq!(rels[0].target_qualified, "core/math.rs::add");
+    assert_eq!(
+        rels[0].metadata["resolution_method"].as_str(),
+        Some("typed")
+    );
 }


### PR DESCRIPTION
## Summary
- IDs: FR-B06, FR-C02, FR-C04, FR-C05, FR-C06, FR-C07, FR-C08..C11, FR-D04, US-CBM-C3, US-CBM-D3
- Seams: in-process hybrid typed resolve (`src/lsp/hybrid.rs`), tree-sitter call extraction (`src/indexer/call_graph.rs` / `extractor.rs`), `leankg init --with-lsp` (`src/main.rs`), embed env knobs, `LEANKG_IMPACT_MAX_AFFECTED` impact cap.

## Per-ID status

| ID | Status | What |
|----|--------|------|
| FR-B06 (Python + Rust typed resolve) | **DONE** | Hybrid `language_from_file` now maps `.py/.pyi`→python, `.rs`→rust so `typed_resolve=py/rs` upgrades CALLS edges in-process. Python bare `call` node (function field incl. attribute receivers) now extracted by CallGraphBuilder + EntityExtractor. `init --with-lsp` adds `py,rs` when detected. Tests: hybrid.rs unit (3 new), call_graph.rs unit (3 new: python call, python method receiver, rust call), hybrid_lsp_e2e (2 new), init-detection e2e. |
| FR-C02 (smaller-model / batch-size docs) | **DONE** | `docs/index-embed-flow.md` env table + "Smaller model / batch-size options" section (`LEANKG_EMBED_MODEL` bge/bge-q/bge-fp16/minilm, `MAX_SEQ`, `DIRECT_INTRA`, `FAST` default corrected on, `--batch-size`); `docs/cli-reference.md` embedding options block. |
| FR-C04 (profile impact-radius latency) | **DONE** | `docs/reports/platform-c-impact-scale-profile-2026-08-02.md` — measured: small <3s, mega 46.9s depth=1 / 1.5–60s; levers (depth, min_confidence, `LEANKG_IMPACT_MAX_AFFECTED`, `--max-affected`, compress). |
| FR-C05 (incremental languages tier notes) | **DONE** | `docs/language-tiers.md` Tier 1/2/3 template; tech-stack table rewritten with Tier column; C/C++, C#, Ruby, PHP, Perl, R, Elixir → Tier 3 (parser present, not wired). |
| FR-C06 (per-language quality tier template; Go/TS first) | **DONE** | Tier template + Go/TS reference entries in `docs/language-tiers.md`; Python/Rust promoted Tier 1 (FR-B06). |
| FR-C07 (large-repo benchmark / documented ceiling) | **DONE** | Ceiling documented (~641k elements measured; semantic path OOM fixed rel-054; 1M-node bench left OPEN) in platform-c-impact-scale-profile report. |
| FR-C08..C11 (Windows, pkg channel, SLSA, install targets) | **DEFERRED → P3** | Campaign directive (Windows → P3). FR-C09 npm wrapper historically shipped (US-14, `df0fec2`). Report: `docs/reports/platform-c-windows-pkg-slsa-2026-08-02.md`. |
| FR-D04 (re-evaluate dual-run after Phase 3) | **DONE** | `docs/reports/cbm-dual-run-re-evaluation-2026-08-02.md` — decision: no dual-run (typed resolve covers Go/TS/Py/Rust/Swift/ObjC; CBM exclusives Won't Have; escape hatch retained FR-D02/D03). |
| US-CBM-C3 (selective language expansion with quality tiers) | **DONE** | Tied to FR-C05/C06 — `docs/language-tiers.md` + tech-stack tier column. |
| US-CBM-D3 (re-evaluate dual-run after typed-resolve Phase) | **DONE** | Tied to FR-D04 evaluation doc. |

## Test plan
- [x] Red→green TDD slices (python call node extraction first failed, then implemented)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --all -- -D warnings`
- [x] `cargo test --lib` (828 passed)
- [x] `cargo test --test hybrid_lsp_e2e` (7 passed) + cli suites (101 passed)
- [x] Integration: hybrid_lsp_e2e fixtures
- [ ] Live smoke — n/a (no REL IDs; FR-C04 uses existing live reports as evidence)
- [x] No resurrection of hard-deleted MCP tools
- [x] No AI attribution

## Tracker rows ready for DONE after merge (conductor)
FR-B06, FR-C02, FR-C04, FR-C05, FR-C06, FR-C07, FR-D04, US-CBM-C3, US-CBM-D3. FR-C08..C11 → P3.