### PR TITLE
fix(mcp): mega-guard into unguarded full-scan tools (FR-P0-MCP-RC-04)

### DIFF
--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1512,6 +1512,12 @@ impl ToolHandler {
     }
 
     fn get_graph_report(&self, args: &Value) -> Result<Value, String> {
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "get_graph_report",
+        ) {
+            return Ok(refusal);
+        }
         let project_name = args["project_name"].as_str().unwrap_or("project");
         let format = args["format"].as_str().unwrap_or("markdown");
         let report = self
@@ -1547,6 +1553,12 @@ impl ToolHandler {
     }
 
     fn temporal_query(&self, args: &Value) -> Result<Value, String> {
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "temporal_query",
+        ) {
+            return Ok(refusal);
+        }
         let at = args["at"].as_i64().ok_or("Missing 'at' (epoch seconds)")?;
         let rels = self
             .graph_engine
@@ -1560,6 +1572,11 @@ impl ToolHandler {
     }
 
     fn timeline(&self, args: &Value) -> Result<Value, String> {
+        if let Some(refusal) =
+            crate::ontology::safe_discover::refuse_full_scan_if_mega(&self.graph_engine, "timeline")
+        {
+            return Ok(refusal);
+        }
         let qn = args["qualified_name"]
             .as_str()
             .ok_or("Missing 'qualified_name'")?;
@@ -1571,6 +1588,12 @@ impl ToolHandler {
     }
 
     fn check_consistency(&self, _args: &Value) -> Result<Value, String> {
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "check_consistency",
+        ) {
+            return Ok(refusal);
+        }
         let report = self
             .graph_engine
             .check_consistency()
@@ -1852,6 +1875,12 @@ impl ToolHandler {
     }
 
     fn export_graph_snapshot(&self, args: &Value) -> Result<Value, String> {
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "export_graph_snapshot",
+        ) {
+            return Ok(refusal);
+        }
         let out_path = args["out_path"]
             .as_str()
             .unwrap_or(".leankg/graph-snapshot.json");
@@ -1868,6 +1897,19 @@ impl ToolHandler {
     }
 
     fn export_html_handler(&self, args: &Value) -> Result<Value, String> {
+        // FR-P0-MCP-RC-04: scoped exports (file/path/community) are bounded;
+        // only refuse the unscoped full-graph export on a mega-graph.
+        let scoped = args["file"].as_str().is_some()
+            || args["path"].as_str().is_some()
+            || args["community"].as_str().is_some();
+        if !scoped {
+            if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+                &self.graph_engine,
+                "export_html",
+            ) {
+                return Ok(refusal);
+            }
+        }
         let out_path = args["out_path"].as_str().unwrap_or(".leankg/graph.html");
         let path_prefix = args["path"].as_str();
         let community = args["community"].as_str();
@@ -3065,6 +3107,14 @@ impl ToolHandler {
 
         let cluster_id = args["cluster_id"].as_str().ok_or("Missing 'cluster_id'")?;
 
+        // FR-P0-MCP-RC-04: on a mega-graph, live Louvain + full element/rel
+        // materialization is a whole-server stall. Serve precomputed
+        // cluster_id/cluster_label rows instead; refuse if the cluster is not
+        // in the precomputed set.
+        if self.graph_engine.is_mega_graph() {
+            return self.get_cluster_skill_precomputed(cluster_id);
+        }
+
         let detector = CommunityDetector::new(self.graph_engine.db());
         let clusters = detector
             .detect_communities()
@@ -3157,6 +3207,81 @@ impl ToolHandler {
 
         Ok(json!({
             "cluster_id": cluster.id,
+            "markdown": md,
+        }))
+    }
+
+    /// FR-P0-MCP-RC-04: mega-safe `get_cluster_skill` using precomputed
+    /// `cluster_id` / `cluster_label` rows instead of live Louvain. Member
+    /// symbols are hydrated with a bounded paginated lookup; no full-graph
+    /// materialization. Refuses when the requested cluster has no precomputed
+    /// rows.
+    fn get_cluster_skill_precomputed(&self, cluster_id: &str) -> Result<Value, String> {
+        let (clusters, _stats) =
+            crate::graph::clustering::load_precomputed_clusters(&self.graph_engine, 500)
+                .map_err(|e| format!("Failed to load precomputed clusters: {}", e))?;
+        let cluster = clusters
+            .iter()
+            .find(|c| c.id == cluster_id)
+            .cloned()
+            .ok_or_else(|| {
+                format!(
+                    "Cluster {cluster_id} not found in precomputed set. Run offline cluster assign (CommunityDetector::assign_clusters_to_elements) then retry."
+                )
+            })?;
+
+        // Top files by member count (bounded: first 200 members).
+        let member_slice: Vec<&String> = cluster.members.iter().take(200).collect();
+        let mut file_counts: std::collections::HashMap<String, usize> =
+            std::collections::HashMap::new();
+        for m in &member_slice {
+            if let Some((file, _)) = m.rsplit_once("::") {
+                *file_counts.entry(file.to_string()).or_insert(0) += 1;
+            }
+        }
+        let mut top_files: Vec<(String, usize)> = file_counts.into_iter().collect();
+        top_files.sort_by_key(|f| std::cmp::Reverse(f.1));
+        top_files.truncate(5);
+
+        let mut md = String::new();
+        md.push_str(&format!(
+            "# SKILL: {} ({})\n\n",
+            if cluster.label.is_empty() {
+                "(unlabeled)"
+            } else {
+                cluster.label.as_str()
+            },
+            cluster.id
+        ));
+        md.push_str(&format!(
+            "Cluster with **{}** members.\n\n",
+            cluster.members.len()
+        ));
+        if !top_files.is_empty() {
+            md.push_str("## Top files\n\n");
+            for (f, c) in &top_files {
+                md.push_str(&format!("- `{}` ({} elements)\n", f, c));
+            }
+            md.push('\n');
+        }
+        if !cluster.representative_files.is_empty() {
+            md.push_str("## Representative files\n\n");
+            for f in &cluster.representative_files {
+                md.push_str(&format!("- `{}`\n", f));
+            }
+            md.push('\n');
+        }
+        md.push_str("## Usage hints\n\n");
+        md.push_str(
+            "- Use `search_code` scoped to one of the top files to find related symbols.\n",
+        );
+        md.push_str(
+            "- Cluster members served from precomputed cluster_id rows (live Louvain skipped on mega-graph).\n",
+        );
+
+        Ok(json!({
+            "cluster_id": cluster.id,
+            "source": "precomputed",
             "markdown": md,
         }))
     }
@@ -4570,6 +4695,12 @@ impl ToolHandler {
 
     /// FR-B23: Find dead code
     fn find_dead_code(&self, args: &Value) -> Result<Value, String> {
+        if let Some(refusal) = crate::ontology::safe_discover::refuse_full_scan_if_mega(
+            &self.graph_engine,
+            "find_dead_code",
+        ) {
+            return Ok(refusal);
+        }
         let min_lines = args["min_lines"].as_u64().unwrap_or(10) as u32;
         let dead = self
             .graph_engine

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -53,6 +53,11 @@ static WRITE_TOOLS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
         "promote_environment",
         "embed_control",
         "ontology_control",
+        // FR-P0-MCP-RC-04: dynamic ontology writes must serialize under the
+        // write lock like other mutations.
+        "add_ontology_concept",
+        "add_ontology_workflow",
+        "delete_ontology_concept",
     ]
     .into_iter()
     .collect()

--- a/src/ontology/safe_discover.rs
+++ b/src/ontology/safe_discover.rs
@@ -36,11 +36,11 @@ pub fn clamp_limit(limit: usize) -> usize {
 }
 
 /// True when element count exceeds the mega-graph threshold.
+///
+/// FR-P0-MCP-RC-04: delegate to the cached `GraphEngine::is_mega_graph` probe
+/// (limit-1 paginated read) rather than a full `count_elements()`.
 pub fn is_mega_graph(engine: &GraphEngine) -> bool {
-    engine
-        .count_elements()
-        .map(|n| n > mega_graph_threshold())
-        .unwrap_or(true)
+    engine.is_mega_graph()
 }
 
 /// Standard refusal payload when a tool would full-scan a mega-graph.
@@ -65,10 +65,17 @@ pub fn mega_graph_refusal(tool: &str, element_count: usize) -> Value {
 }
 
 /// If mega-graph, return refusal; otherwise None (caller may proceed).
+///
+/// FR-P0-MCP-RC-04: uses the cached `GraphEngine::is_mega_graph` probe (a
+/// limit-1 paginated read) instead of a full `count_elements()` — counting
+/// 662k rows on the async worker was itself a stall. The exact element count
+/// is only fetched when we already know the graph is mega (refusal payload).
 pub fn refuse_full_scan_if_mega(engine: &GraphEngine, tool: &str) -> Option<Value> {
+    if !engine.is_mega_graph() {
+        return None;
+    }
     match engine.count_elements() {
-        Ok(n) if n > mega_graph_threshold() => Some(mega_graph_refusal(tool, n)),
-        Ok(_) => None,
+        Ok(n) => Some(mega_graph_refusal(tool, n)),
         Err(e) => Some(json!({
             "error": format!("{tool} refused: failed to count elements: {e}"),
             "hint": "Use concept_search / semantic_search with pagination."

--- a/tests/mcp_tools_full_tests.rs
+++ b/tests/mcp_tools_full_tests.rs
@@ -895,3 +895,76 @@ mod error_handling {
         }
     }
 }
+// full-scan must return a refusal payload instead of executing. The guard uses
+// the cheap cached `is_mega_graph` probe, not a full `count_elements`.
+mod mega_guard_tests {
+    use super::*;
+    use std::sync::Mutex;
+
+    static MEGA_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Seeded graph of 4 elements > threshold 2 -> mega.
+    fn create_mega_handler() -> (ToolHandler, TempDir) {
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("leankg.db");
+        let db = init_db(db_path.as_path()).unwrap();
+        seed_test_data(&db);
+        let graph = GraphEngine::new(db);
+        (ToolHandler::new(graph, db_path), tmp)
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn full_scan_tools_refuse_on_mega_graph() {
+        // Recover from a poisoned lock (a prior failing test) so env is still
+        // serialized but the suite does not cascade-fail.
+        let _guard = MEGA_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("LEANKG_MAX_CACHE_ELEMENTS", "2");
+        let (handler, _tmp) = create_mega_handler();
+
+        // Each of these tools full-scans on a mega-graph and must refuse.
+        // get_cluster_skill is excluded: it now serves precomputed cluster rows
+        // on mega (better than refusal) — covered by the dedicated test below.
+        let cases: Vec<(&str, serde_json::Value)> = vec![
+            ("find_dead_code", json!({"min_lines": 1})),
+            ("get_graph_report", json!({})),
+            ("export_html", json!({})),
+            ("export_graph_snapshot", json!({})),
+            ("check_consistency", json!({})),
+            ("temporal_query", json!({"at": 1718000000})),
+            ("timeline", json!({"qualified_name": "./src/main.rs::main"})),
+        ];
+
+        for (tool, args) in cases {
+            let result = handler.execute_tool(tool, &args).await;
+            let value = result.expect(&format!("{tool} should return a value on mega"));
+            let text = value.to_string();
+            assert!(
+                text.contains("refused") || text.contains("max 50000"),
+                "{tool} must refuse on mega graph, got: {text}"
+            );
+        }
+
+        std::env::remove_var("LEANKG_MAX_CACHE_ELEMENTS");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn cluster_skill_mega_path_uses_precomputed() {
+        let _guard = MEGA_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("LEANKG_MAX_CACHE_ELEMENTS", "2");
+        let (handler, _tmp) = create_mega_handler();
+
+        // Precomputed cluster_id=1 exists in seed; on mega the tool must serve
+        // from precomputed rows (source:"precomputed") — never run live Louvain.
+        let result = handler
+            .execute_tool("get_cluster_skill", &json!({"cluster_id": "1"}))
+            .await;
+        let value = result.expect("get_cluster_skill must return a value on mega");
+        assert_eq!(value["source"], "precomputed", "got: {value}");
+        assert!(
+            value["markdown"].as_str().unwrap_or("").contains("SKILL"),
+            "markdown must be a SKILL doc, got: {value}"
+        );
+
+        std::env::remove_var("LEANKG_MAX_CACHE_ELEMENTS");
+    }
+}


### PR DESCRIPTION
## Summary
FR-P0-MCP-RC-04: wire `refuse_full_scan_if_mega` into all unguarded full-scan tools; use the cached `is_mega_graph` probe; `get_cluster_skill` skips live Louvain on mega; ontology writes in `WRITE_TOOLS`.

- `refuse_full_scan_if_mega` now uses cached `GraphEngine::is_mega_graph` (limit-1 paginated) instead of full `count_elements()`.
- Guards added: find_dead_code, get_graph_report, export_graph_snapshot, check_consistency, temporal_query, timeline, export_html (unscoped only).
- `get_cluster_skill` serves precomputed cluster_id rows on mega (no Louvain, no all_elements).
- `WRITE_TOOLS` + ontology writes.

## TDD
`full_scan_tools_refuse_on_mega_graph`, `cluster_skill_mega_path_uses_precomputed` (LEANKG_MAX_CACHE_ELEMENTS=2).

## Verification
- mcp_tools_full_tests 49 passed; lib 791 passed; clippy clean.