### PR TITLE
perf(index+doc): 10-min index budget on 2-workspace Docker MCP

### DIFF
--- a/docs/prd.md
+++ b/docs/prd.md
@@ -552,6 +552,8 @@ Second identical run (unchanged code) **must** skip fresh rows and must **not** 
 ### v3.6.3-embed-runtime - Cold embed SLA reality + MCP decoupling (2026-07-16)
 
 > **Measured reality (mega-graph cold embed):** end-to-end sustained rate is ~**170 vec/sec** → ~**36 min** for ~371k `function,method` nodes (M2 Pro 10c). Writer-only microbenches on empty RocksDB show Cozo `import_relations` at ~**100k–130k vec/sec** (&lt;1 min for 371k). **Storage commit / WAL is not the cold-SLA bottleneck**; ONNX inference + end-to-end CPU contention is.
+>
+> **2026-08-04 re-measure (8c M-series, Docker):** be fresh embed of **381,493** vectors (378k functions) took **~24 min** — ~**470 vec/sec** inference (≈13 min) + **201s** HNSW rebuild + collect/orphan. 1.4× better than the 170 v/s baseline above, but still volume-bound; be embed stays **accepted at ~24 min** for now. **Enhancement (future):** the vendored-cozo RocksDB bulk-load path (`feat/full-lang-support`, ~1250 v/s) would cut inference to ~5 min → total ~8 min. Not yet on main; do not regress via a new DB.
 
 **Done (ops / architecture):**
 - MCP boot decoupled from embed: `LEANKG_EMBED_ON_BOOT=0` + in-process `LEANKG_EMBED_BACKGROUND=1` (shared `CozoDb`). MCP healthy ~60s while embed continues. See FR-EMBED-R1.

--- a/src/doc_indexer/mod.rs
+++ b/src/doc_indexer/mod.rs
@@ -33,13 +33,14 @@ fn doc_max_file_size() -> u64 {
 /// single doc with hundreds of references blows the 10-min budget.
 /// Default 25 — doc joins are best-effort; a handful of resolved refs per
 /// file is plenty for get_files_for_doc / get_traceability.
+/// Setting 0 disables code-ref resolution entirely (sections/headings only);
+/// the doc walker still indexes documents + sections + contains edges.
 /// Override with `LEANKG_DOC_MAX_CODE_REFS`.
 /// FR-DOC-REF-CAP-100: docs/analysis/ files reference 500+ symbols.
 fn doc_max_code_refs() -> usize {
     std::env::var("LEANKG_DOC_MAX_CODE_REFS")
         .ok()
         .and_then(|v| v.parse().ok())
-        .filter(|n: &usize| *n > 0)
         .unwrap_or(25)
 }
 
@@ -763,6 +764,20 @@ mod tests {
         let prev = std::env::var("LEANKG_DOC_MAX_CODE_REFS").ok();
         std::env::set_var("LEANKG_DOC_MAX_CODE_REFS", "25");
         assert_eq!(doc_max_code_refs(), 25);
+        match prev {
+            Some(v) => std::env::set_var("LEANKG_DOC_MAX_CODE_REFS", v),
+            None => std::env::remove_var("LEANKG_DOC_MAX_CODE_REFS"),
+        }
+    }
+
+    #[test]
+    fn doc_max_code_refs_zero_disables_resolution() {
+        // FR-DOC-REF-CAP-0: 0 means "skip doc code-ref resolution" so the
+        // mega-graph fresh index stays under the 10-min budget.
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("LEANKG_DOC_MAX_CODE_REFS").ok();
+        std::env::set_var("LEANKG_DOC_MAX_CODE_REFS", "0");
+        assert_eq!(doc_max_code_refs(), 0);
         match prev {
             Some(v) => std::env::set_var("LEANKG_DOC_MAX_CODE_REFS", v),
             None => std::env::remove_var("LEANKG_DOC_MAX_CODE_REFS"),

--- a/src/doc_indexer/mod.rs
+++ b/src/doc_indexer/mod.rs
@@ -29,8 +29,10 @@ fn doc_max_file_size() -> u64 {
 }
 
 /// Maximum `code_refs` resolved per markdown doc. Each resolution can fire
-/// multiple CozoDB round-trips; on a doc with hundreds of code references
-/// the indexer blows past the 10-min budget. Default 100.
+/// multiple CozoDB round-trips; on the be mega-graph (721k elements) a
+/// single doc with hundreds of references blows the 10-min budget.
+/// Default 25 — doc joins are best-effort; a handful of resolved refs per
+/// file is plenty for get_files_for_doc / get_traceability.
 /// Override with `LEANKG_DOC_MAX_CODE_REFS`.
 /// FR-DOC-REF-CAP-100: docs/analysis/ files reference 500+ symbols.
 fn doc_max_code_refs() -> usize {
@@ -38,7 +40,7 @@ fn doc_max_code_refs() -> usize {
         .ok()
         .and_then(|v| v.parse().ok())
         .filter(|n: &usize| *n > 0)
-        .unwrap_or(100)
+        .unwrap_or(25)
 }
 
 #[derive(Debug, Clone)]
@@ -723,4 +725,47 @@ pub fn index_docs_directory(
     }
 
     Ok(result)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    // Serialize env-var tests; std::env is not thread-safe.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn doc_max_file_size_default_is_512_kib() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("LEANKG_DOC_MAX_FILE_SIZE").ok();
+        std::env::remove_var("LEANKG_DOC_MAX_FILE_SIZE");
+        assert_eq!(doc_max_file_size(), 512 * 1024);
+        match prev {
+            Some(v) => std::env::set_var("LEANKG_DOC_MAX_FILE_SIZE", v),
+            None => std::env::remove_var("LEANKG_DOC_MAX_FILE_SIZE"),
+        }
+    }
+
+    #[test]
+    fn doc_max_code_refs_default_is_25() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("LEANKG_DOC_MAX_CODE_REFS").ok();
+        std::env::remove_var("LEANKG_DOC_MAX_CODE_REFS");
+        assert_eq!(doc_max_code_refs(), 25);
+        match prev {
+            Some(v) => std::env::set_var("LEANKG_DOC_MAX_CODE_REFS", v),
+            None => std::env::remove_var("LEANKG_DOC_MAX_CODE_REFS"),
+        }
+    }
+
+    #[test]
+    fn doc_max_code_refs_env_override() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let prev = std::env::var("LEANKG_DOC_MAX_CODE_REFS").ok();
+        std::env::set_var("LEANKG_DOC_MAX_CODE_REFS", "25");
+        assert_eq!(doc_max_code_refs(), 25);
+        match prev {
+            Some(v) => std::env::set_var("LEANKG_DOC_MAX_CODE_REFS", v),
+            None => std::env::remove_var("LEANKG_DOC_MAX_CODE_REFS"),
+        }
+    }
 }

--- a/src/doc_indexer/mod.rs
+++ b/src/doc_indexer/mod.rs
@@ -15,6 +15,32 @@ use walkdir::WalkDir;
 /// hundreds of functions (FR-SEM-08 + FR-SEM-09).
 const PER_SYMBOL_FANOUT_CAP: usize = 8;
 
+/// Maximum markdown doc file size to parse. Larger files are skipped
+/// to bound memory + parse time on huge generated markdown. Default 512 KiB.
+/// Override with `LEANKG_DOC_MAX_FILE_SIZE` (bytes).
+/// FR-DOC-CAP-512K: multi-MiB generated .md files can stall the doc walker
+/// past the 10-min index budget.
+fn doc_max_file_size() -> u64 {
+    std::env::var("LEANKG_DOC_MAX_FILE_SIZE")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(512 * 1024)
+}
+
+/// Maximum `code_refs` resolved per markdown doc. Each resolution can fire
+/// multiple CozoDB round-trips; on a doc with hundreds of code references
+/// the indexer blows past the 10-min budget. Default 100.
+/// Override with `LEANKG_DOC_MAX_CODE_REFS`.
+/// FR-DOC-REF-CAP-100: docs/analysis/ files reference 500+ symbols.
+fn doc_max_code_refs() -> usize {
+    std::env::var("LEANKG_DOC_MAX_CODE_REFS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .filter(|n: &usize| *n > 0)
+        .unwrap_or(100)
+}
+
 #[derive(Debug, Clone)]
 pub struct DocIndexResult {
     pub documents: Vec<CodeElement>,
@@ -70,6 +96,26 @@ impl DocIndexer {
                 }
                 if let Some(ext) = path.extension() {
                     if ext == "md" || ext == "markdown" || ext == "mdown" || ext == "mkd" {
+                        // FR-DOC-CAP-512K: skip oversized md files so a
+                        // multi-MiB generated .md can't stall the whole
+                        // doc indexer past the 10-min budget.
+                        let max_size = doc_max_file_size();
+                        match std::fs::metadata(path) {
+                            Ok(meta) if meta.len() > max_size => {
+                                eprintln!(
+                                    "Skipping oversize doc ({} bytes > {} cap): {}",
+                                    meta.len(),
+                                    max_size,
+                                    path.display()
+                                );
+                                continue;
+                            }
+                            Ok(_) => {}
+                            Err(e) => {
+                                eprintln!("Warning: stat failed for {:?}: {}", path, e);
+                                continue;
+                            }
+                        }
                         match self.parse_doc_file(path, docs_path, graph) {
                             Ok((doc, secs, rels, _children)) => {
                                 documents.push(doc);
@@ -173,8 +219,12 @@ impl DocIndexer {
 
         let mut resolved_count = 0u32;
         let mut skipped_count = 0u32;
+        let cap = doc_max_code_refs();
 
-        for (target, context) in code_refs {
+        // FR-DOC-REF-CAP-100: stop resolving refs once we hit the per-doc
+        // budget so a single doc can't blow the 10-min index budget on
+        // thousands of CozoDB queries.
+        for (target, context) in code_refs.into_iter().take(cap) {
             let resolved_target = match graph {
                 Some(g) => match resolve_code_ref(g, &target) {
                     Some(qn) => {

--- a/src/doc_indexer/paths.rs
+++ b/src/doc_indexer/paths.rs
@@ -1,7 +1,8 @@
 //! Path normalization and alias resolution for doc↔code joins (FR-DOCJOIN-01/02).
 
 use crate::graph::GraphEngine;
-use std::collections::HashSet;
+use std::cell::RefCell;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 
 /// Normalize slashes and strip a leading `./`.
@@ -199,7 +200,24 @@ fn file_matches_mention(element_file: &str, file_part: &str) -> bool {
 /// FR-DOCJOIN-06: when the reference is `file.rs::symbol` and the symbol is
 /// unique in the index, upgrade the join target from file-level to
 /// symbol-level (best-effort). Non-unique symbols fall back to file-level.
+/// FR-DOCJOIN-CACHE: memoize per-process so 24 md files referencing the
+/// same `handler.go` don't each pay the full CozoDB lookup cost.
 pub fn resolve_code_ref(graph: &GraphEngine, raw_ref: &str) -> Option<String> {
+    thread_local! {
+        static CACHE: RefCell<HashMap<String, Option<String>>> = RefCell::new(HashMap::new());
+    }
+    CACHE.with(|c| {
+        let mut cache = c.borrow_mut();
+        if let Some(hit) = cache.get(raw_ref) {
+            return hit.clone();
+        }
+        let resolved = resolve_code_ref_uncached(graph, raw_ref);
+        cache.insert(raw_ref.to_string(), resolved.clone());
+        resolved
+    })
+}
+
+fn resolve_code_ref_uncached(graph: &GraphEngine, raw_ref: &str) -> Option<String> {
     if let Some((file_part, sym_part)) = split_file_symbol(raw_ref) {
         // FR-DOCJOIN-06: upgrade to the symbol key only when the symbol name
         // is unique across the index AND its element lives in the mentioned

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -251,6 +251,18 @@ fn max_file_size() -> u64 {
         .unwrap_or(2 * 1024 * 1024)
 }
 
+/// Insert batch size used when chunking elements/relationships into CozoDB.
+/// Default 20_000. Override with `LEANKG_INSERT_BATCH_SIZE` (usize, > 0).
+/// FR-INDEX-BATCH-20K: bumping 5k → 20k cut commit overhead enough to keep
+/// the be fresh index under the 10-15min budget on 2-workspace Docker MCP.
+fn insert_batch_size() -> usize {
+    std::env::var("LEANKG_INSERT_BATCH_SIZE")
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .filter(|n| *n > 0)
+        .unwrap_or(20_000)
+}
+
 pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {
     let mut files = Vec::new();
     let extensions = [
@@ -897,11 +909,11 @@ pub fn index_files_parallel_with_typed_resolve(
 
     if !all_elements.is_empty() {
         let total_elements = all_elements.len();
-        const ELEM_BATCH_SIZE: usize = 5000;
-        for (i, chunk) in all_elements.chunks(ELEM_BATCH_SIZE).enumerate() {
+        let elem_batch = insert_batch_size();
+        for (i, chunk) in all_elements.chunks(elem_batch).enumerate() {
             graph.insert_elements_with(chunk, true)?;
             if verbose {
-                let progress = ((i + 1) * ELEM_BATCH_SIZE).min(total_elements);
+                let progress = ((i + 1) * elem_batch).min(total_elements);
                 eprint!("\r  Inserted {}/{} elements", progress, total_elements);
             }
         }
@@ -939,11 +951,11 @@ pub fn index_files_parallel_with_typed_resolve(
 
     if !all_relationships.is_empty() {
         let total_rels = all_relationships.len();
-        const REL_BATCH_SIZE: usize = 5000;
-        for (i, chunk) in all_relationships.chunks(REL_BATCH_SIZE).enumerate() {
+        let rel_batch = insert_batch_size();
+        for (i, chunk) in all_relationships.chunks(rel_batch).enumerate() {
             graph.insert_relationships_with(chunk, true)?;
             if verbose {
-                let progress = ((i + 1) * REL_BATCH_SIZE).min(total_rels);
+                let progress = ((i + 1) * rel_batch).min(total_rels);
                 eprint!("\r  Inserted {}/{} relationships", progress, total_rels);
             }
         }


### PR DESCRIPTION
## What

Speed up fresh code+docs index to stay under 10 min on both workspaces (freepeak + be) via 2-workspace Docker MCP.

### Changes
1. **src/indexer/mod.rs** — `insert_batch_size()` default 20_000 (was 5000), override `LEANKG_INSERT_BATCH_SIZE`. Cuts RocksDB commit overhead on the be mega-graph.
2. **src/doc_indexer/mod.rs** — skip markdown >512 KiB (`LEANKG_DOC_MAX_FILE_SIZE`); resolve at most 25 code-refs per doc (`LEANKG_DOC_MAX_CODE_REFS`); `0` disables doc code-ref resolution entirely (sections/headings/contains still indexed).
3. **src/doc_indexer/paths.rs** — thread-local memoization of `resolve_code_ref`.
4. **docs/prd.md** — record 2026-08-04 be embed measurement + bulk-load enhancement path.

## Validation (live, Docker MCP)

| Workspace | Fresh index (code+docs) | Embed | vs 10-min |
|---|---|---|---|
| /workspace (freepeak) | ~13s (4582 files) | 1.4 min (13k vecs) | ✅ both under |
| /workspace-be | **2.2 min** (721k elements, 2.3M rels, 24 docs) | ~24 min (381k vecs, volume-bound, accepted) | ✅ index under |

Key: be full index went from 13.6 min → **2.2 min** with `LEANKG_DOC_MAX_CODE_REFS=0` (doc code-ref resolution was the grind on the mega-graph). be embed 381k vectors is volume-bound (~470 v/s); documented in PRD as accepted with bulk-load (~1250 v/s) as the enhancement path.