### PR TITLE
feat(config): add db: block to leankg.yaml for Postgres defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,7 +141,15 @@ LeanKG stores everything in PostgreSQL + pgvector (the only storage engine). Loc
 
 ```bash
 docker compose up postgres
-export LEANKG_PG_URL=postgresql://postgres:postgres@localhost:5432/leankg
+```
+
+The connection defaults to the dev Postgres (`postgresql://postgres:postgres@localhost:5433/leankg`). Override it via the `db:` block in `leankg.yaml` (env vars `LEANKG_PG_URL` / `LEANKG_PG_POOL_SIZE` / `LEANKG_PG_LOCK` take precedence over the file):
+
+```yaml
+db:
+  url: postgresql://postgres:postgres@localhost:5432/leankg
+  pool_size: 10
+  lock: true
 ```
 
 See [docs/analysis/pg-migration-report.md](docs/analysis/pg-migration-report.md) for the migration details and env-var reference.

--- a/leankg.yaml
+++ b/leankg.yaml
@@ -4,6 +4,12 @@ project:
   languages:
   - javascript
   - rust
+# Postgres connection defaults. Env LEANKG_PG_URL / LEANKG_PG_POOL_SIZE /
+# LEANKG_PG_LOCK override these; unset fields fall back to built-in defaults.
+db:
+  url: postgresql://postgres:postgres@localhost:5433/leankg
+  pool_size: 5
+  lock: true
 indexer:
   exclude:
   - '**/node_modules/**'

--- a/src/config/project.rs
+++ b/src/config/project.rs
@@ -19,6 +19,43 @@ pub struct ProjectConfig {
     /// and `--ref-name` take precedence over config values.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub source: Option<SourceConfig>,
+    /// Optional Postgres connection settings. When unset, the backend uses
+    /// `LEANKG_PG_URL` or its built-in dev default.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub db: Option<DbConfig>,
+}
+
+/// Optional Postgres settings that override the compiled-in defaults.
+/// Read by the DB backend as `env LEANKG_PG_URL / LEANKG_PG_POOL_SIZE /
+/// LEANKG_PG_LOCK` > `db:` yaml block > built-in default. Every field is
+/// optional so a minimal `db: {}` or a partial block is valid.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq)]
+#[serde(default)]
+pub struct DbConfig {
+    /// Connection URL, e.g. `postgresql://postgres:postgres@localhost:5433/leankg`.
+    pub url: Option<String>,
+    /// Lazy connection pool size (default 5, clamped >= 1).
+    pub pool_size: Option<usize>,
+    /// `false` disables the index advisory lock (default true).
+    pub lock: Option<bool>,
+}
+
+/// Load the `db:` block from the nearest `leankg.yaml` walking up from the
+/// current directory (same resolution as [`crate::find_project_root`] in
+/// `main.rs`). Returns `None` when no config file or `db:` block exists.
+/// The backend uses this as the middle precedence tier:
+/// `LEANKG_PG_URL` env > `db:` yaml > built-in default.
+pub fn db_config_from_cwd() -> Option<DbConfig> {
+    let cwd = std::env::current_dir().ok()?;
+    for dir in cwd.ancestors() {
+        let cfg_path = dir.join("leankg.yaml");
+        if cfg_path.is_file() {
+            let content = std::fs::read_to_string(cfg_path).ok()?;
+            let config: ProjectConfig = serde_yaml::from_str(&content).ok()?;
+            return config.db;
+        }
+    }
+    None
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -268,6 +305,7 @@ impl Default for ProjectConfig {
             auth: AuthSettings::default(),
             lsp: None,
             source: None,
+            db: None,
         }
     }
 }
@@ -336,6 +374,41 @@ mod tests {
         let config = ProjectConfig::default();
         assert_eq!(config.documentation.output, PathBuf::from("./docs"));
         assert_eq!(config.documentation.templates, vec!["agents", "claude"]);
+    }
+
+    #[test]
+    fn db_block_parses_from_yaml() {
+        let yaml = r#"
+db:
+  url: postgresql://u:p@host:9999/bar
+  pool_size: 12
+  lock: false
+"#;
+        let config: ProjectConfig = serde_yaml::from_str(yaml).unwrap();
+        let db = config.db.expect("db block parsed");
+        assert_eq!(db.url.as_deref(), Some("postgresql://u:p@host:9999/bar"));
+        assert_eq!(db.pool_size, Some(12));
+        assert_eq!(db.lock, Some(false));
+    }
+
+    #[test]
+    fn db_defaults_to_none_when_absent() {
+        let config = ProjectConfig::default();
+        assert!(config.db.is_none());
+        // Serializing a default config must not emit a db: block.
+        let yaml = serde_yaml::to_string(&config).unwrap();
+        assert!(
+            !yaml.contains("db:"),
+            "default config serializes without db:\n{yaml}"
+        );
+    }
+
+    #[test]
+    fn db_empty_block_is_valid() {
+        let yaml = "db: {}\n";
+        let config: ProjectConfig = serde_yaml::from_str(yaml).unwrap();
+        let db = config.db.expect("empty db block parsed");
+        assert!(db.url.is_none() && db.pool_size.is_none() && db.lock.is_none());
     }
 
     // US-CBM-B10: typed_resolve flag

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -168,16 +168,27 @@ impl ClientPool {
 
     /// Read `LEANKG_PG_POOL_SIZE` (default 5, clamped >= 1).
     pub fn size_from_env() -> usize {
+        Self::size_from_env_or(None)
+    }
+
+    /// Pool size: `LEANKG_PG_POOL_SIZE` env > `db.pool_size` yaml > 5.
+    pub fn size_from_env_or(yaml: Option<usize>) -> usize {
         std::env::var("LEANKG_PG_POOL_SIZE")
             .ok()
             .and_then(|v| v.parse::<usize>().ok())
             .filter(|v| *v >= 1)
+            .or(yaml.filter(|v| *v >= 1))
             .unwrap_or(5)
     }
 
     /// Total live + idle clients (used by tests to assert pool reuse).
     pub fn live_count(&self) -> usize {
         self.inner.state.lock().unwrap().live
+    }
+
+    /// Configured pool cap (used by tests to assert pool sizing).
+    pub fn max_size(&self) -> usize {
+        self.inner.max
     }
 
     /// Check out a client, connecting a new one up to `max` live, else
@@ -221,21 +232,33 @@ impl std::fmt::Debug for PostgresBackend {
 }
 
 impl PostgresBackend {
-    /// Format-check `LEANKG_PG_URL`. Returns Err with a clear message when
-    /// the env var is missing or does not look like a Postgres URL.
+    /// Format-check the resolved Postgres URL. Precedence:
+    /// `LEANKG_PG_URL` env > `db:` block in `leankg.yaml` > built-in dev
+    /// default (`postgresql://postgres:postgres@localhost:5433/leankg`,
+    /// matches the container-gated dev Postgres). Returns Err when the
+    /// resolved URL does not look like a Postgres URL.
     pub fn from_env() -> Result<Self, String> {
         let url = std::env::var("LEANKG_PG_URL")
-            .map_err(|_| "LEANKG_PG_URL is not set; the Postgres backend requires it (run `docker compose up postgres`)")?;
+            .ok()
+            .filter(|v| !v.trim().is_empty())
+            .or_else(|| {
+                crate::config::db_config_from_cwd()
+                    .and_then(|db| db.url.filter(|u| !u.trim().is_empty()))
+            })
+            .unwrap_or_else(|| "postgresql://postgres:postgres@localhost:5433/leankg".to_string());
         if !url.starts_with("postgres://") && !url.starts_with("postgresql://") {
             return Err(format!(
                 "LEANKG_PG_URL must be a postgres:// URL, got: {}",
                 redact_url(&url)
             ));
         }
+        let pool_size = ClientPool::size_from_env_or(
+            crate::config::db_config_from_cwd().and_then(|db| db.pool_size),
+        );
         Ok(Self {
             pg_url: url,
-            pool: Arc::new(ClientPool::new(ClientPool::size_from_env())),
-            ro_pool: Arc::new(ClientPool::new(ClientPool::size_from_env())),
+            pool: Arc::new(ClientPool::new(pool_size)),
+            ro_pool: Arc::new(ClientPool::new(pool_size)),
             read_only: false,
         })
     }
@@ -1066,12 +1089,17 @@ pub fn init_db_pg() -> Result<SharedDb, Box<dyn std::error::Error>> {
 /// `LEANKG_PG_LOCK=0` disables the advisory lock (operators who manage
 /// exclusivity externally, e.g. a job queue). Default: on.
 pub fn index_advisory_lock() -> Result<Option<AdvisoryLock>, Box<dyn std::error::Error>> {
-    if std::env::var("LEANKG_PG_LOCK")
+    // Disable when `LEANKG_PG_LOCK=0` env, or `db.lock: false` in leankg.yaml.
+    let env_disables = std::env::var("LEANKG_PG_LOCK")
         .ok()
         .map(|v| v.eq_ignore_ascii_case("0") || v.eq_ignore_ascii_case("false"))
-        .unwrap_or(false)
-    {
-        tracing::info!("LEANKG_PG_LOCK=0 — index advisory lock disabled");
+        .unwrap_or(false);
+    let yaml_disables = crate::config::db_config_from_cwd()
+        .and_then(|db| db.lock)
+        .map(|v| !v)
+        .unwrap_or(false);
+    if env_disables || yaml_disables {
+        tracing::info!("PG index advisory lock disabled (LEANKG_PG_LOCK=0 or db.lock: false)");
         return Ok(None);
     }
     let key = PostgresBackend::INDEX_LOCK_KEY;
@@ -1124,7 +1152,10 @@ mod tests {
     #[test]
     fn postgres_backend_validates_url_and_redacts() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        assert!(PostgresBackend::from_env().is_err(), "no env -> error");
+        // No env + no db: block -> built-in dev default (not an error).
+        std::env::remove_var("LEANKG_PG_URL");
+        let ok = PostgresBackend::from_env().expect("no env -> dev default");
+        assert!(ok.pg_url.starts_with("postgresql://"));
         std::env::set_var("LEANKG_PG_URL", "not-a-url");
         let err = PostgresBackend::from_env().unwrap_err();
         assert!(err.contains("not-a-url"));
@@ -1138,11 +1169,63 @@ mod tests {
     fn postgres_backend_requires_url() {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         std::env::remove_var("LEANKG_PG_URL");
-        // Production path: no URL -> hard error.
-        assert!(init_db_pg().is_err(), "no LEANKG_PG_URL -> error");
+        // Production path: no env and no leankg.yaml -> built-in dev default.
+        let pg = init_db_pg().expect("built-in default URL applies");
+        assert!(pg.redacted_url().starts_with("postgresql://"));
         // Test-mode init falls back to the dev-container default (a real,
         // lazily-connected PostgresBackend is still produced).
         assert!(init_db(std::path::Path::new("/tmp/none.db")).is_ok());
+    }
+
+    #[test]
+    fn pg_url_from_leankg_yaml_db_block() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("LEANKG_PG_URL");
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("leankg.yaml"),
+            "db:\n  url: postgresql://u:p@yaml-host:7777/mydb\n",
+        )
+        .unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let pg = PostgresBackend::from_env();
+        std::env::set_current_dir(prev).unwrap();
+        let pg = pg.expect("yaml db.url applies");
+        assert!(pg.pg_url.contains("yaml-host:7777/mydb"));
+    }
+
+    #[test]
+    fn pg_url_env_wins_over_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::set_var("LEANKG_PG_URL", "postgresql://u:p@env-host:1111/envdb");
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("leankg.yaml"),
+            "db:\n  url: postgresql://u:p@yaml-host:7777/mydb\n",
+        )
+        .unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let pg = PostgresBackend::from_env();
+        std::env::set_current_dir(prev).unwrap();
+        std::env::remove_var("LEANKG_PG_URL");
+        let pg = pg.expect("env URL wins");
+        assert!(pg.pg_url.contains("env-host:1111"));
+    }
+
+    #[test]
+    fn pg_pool_size_from_yaml() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("LEANKG_PG_POOL_SIZE");
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(dir.path().join("leankg.yaml"), "db:\n  pool_size: 12\n").unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        let pg = PostgresBackend::from_env();
+        std::env::set_current_dir(prev).unwrap();
+        let pg = pg.expect("yaml pool_size applies");
+        assert_eq!(pg.pool.max_size(), 12);
     }
 
     #[test]

--- a/src/db/pg/migrations.rs
+++ b/src/db/pg/migrations.rs
@@ -36,10 +36,17 @@ pub struct MigrationReport {
     pub skipped: Vec<String>,
 }
 
-/// Connect string for the Postgres backend (`LEANKG_PG_URL`, default local).
+/// Connect string for the Postgres backend. Precedence: `LEANKG_PG_URL`
+/// env > `db:` block in `leankg.yaml` > dev default (local).
 pub fn pg_url() -> String {
     std::env::var("LEANKG_PG_URL")
-        .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost:5433/leankg".to_string())
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .or_else(|| {
+            crate::config::db_config_from_cwd()
+                .and_then(|db| db.url.filter(|u| !u.trim().is_empty()))
+        })
+        .unwrap_or_else(|| "postgresql://postgres:postgres@localhost:5433/leankg".to_string())
 }
 
 /// Create the `migrations` table if absent, then apply every MIGRATIONS step
@@ -76,6 +83,30 @@ pub fn run_migrations(client: &mut Client) -> Result<MigrationReport, postgres::
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Serialize tests that mutate LEANKG_PG_URL (process-global env).
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn pg_url_prefers_env_then_yaml_then_default() {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        std::env::remove_var("LEANKG_PG_URL");
+        // No env, no leankg.yaml at cwd -> dev default.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join("leankg.yaml"),
+            "db:\n  url: postgresql://u:p@yaml-host:7777/mydb\n",
+        )
+        .unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+        assert_eq!(pg_url(), "postgresql://u:p@yaml-host:7777/mydb");
+        // Env wins over yaml.
+        std::env::set_var("LEANKG_PG_URL", "postgresql://u:p@env-host:1111/envdb");
+        assert_eq!(pg_url(), "postgresql://u:p@env-host:1111/envdb");
+        std::env::remove_var("LEANKG_PG_URL");
+        std::env::set_current_dir(prev).unwrap();
+    }
 
     /// Migration IDs are unique and in strictly ascending order (no
     /// framework here — this is the ordering guarantee).


### PR DESCRIPTION
## What
Add a `db:` block to `leankg.yaml` so Postgres connection defaults are configurable in the project config file instead of env vars only.

```yaml
db:
  url: postgresql://postgres:postgres@localhost:5433/leankg
  pool_size: 5
  lock: true
```

## Precedence
`LEANKG_PG_URL` / `LEANKG_PG_POOL_SIZE` / `LEANKG_PG_LOCK` env vars > `db:` yaml block > built-in dev default (`postgresql://postgres:postgres@localhost:5433/leankg`).

## Changes
- `src/config/project.rs` — `DbConfig { url, pool_size, lock }` (all optional), `ProjectConfig.db`, loader `db_config_from_cwd()` (walks up to nearest `leankg.yaml`). `db` omitted from serialized config when unset, so `leankg init` output is unchanged.
- `src/db/backend.rs` — `PostgresBackend::from_env()` resolves env > yaml > default for URL and pool size; `index_advisory_lock()` honors `db.lock: false`.
- `src/db/pg/migrations.rs` — `pg_url()` same precedence (migrate command).
- `leankg.yaml` — self-documenting `db:` block.
- `README.md` — §0 documents the config.

## Tests
- 7 new unit tests (yaml parse, empty-block, default-none, yaml url, env-wins, pool-size, pg_url precedence). 944 lib tests pass. Clippy `-D warnings` clean. `cargo fmt` clean.
- Live-verified against a fresh `pgvector/pgvector:pg18` on :5439: `leankg migrate` + `leankg index` + `leankg query` all work via the `db:` block; env override confirmed to win.

## Behavior change
`from_env()`/`pg_url()` no longer error when `LEANKG_PG_URL` is unset — they fall back to the built-in dev default (was: hard error "requires it"). `postgres_backend_requires_url` rewritten accordingly.

## Notes
- `tests/batch_delete_stress_tests.rs` (2 tests) require a live PG on :5433; they fail without one (pre-existing, env-gated, unrelated to this change).