### PR TITLE
perf(docker): build only core languages in MCP HTTP image

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -59,12 +59,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -435,12 +429,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "castaway"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -496,33 +484,6 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link",
-]
-
-[[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
 ]
 
 [[package]]
@@ -674,42 +635,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
 dependencies = [
  "cfg-if",
-]
-
-[[package]]
-name = "criterion"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b12d017a929603d80db1831cd3a24082f8137ce19c69e6447f54f5fc8d692f"
-dependencies = [
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "is-terminal",
- "itertools 0.10.5",
- "num-traits",
- "once_cell",
- "oorandom",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_derive",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b50826342786a51a89e2da3a28f1c32b06e387201bc2d19791f622c673706b1"
-dependencies = [
- "cast",
- "itertools 0.10.5",
 ]
 
 [[package]]
@@ -1429,12 +1354,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
 name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1886,30 +1805,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "is-terminal"
-version = "0.4.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
-dependencies = [
- "hermit-abi",
- "libc",
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
-
-[[package]]
-name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
 
 [[package]]
 name = "itertools"
@@ -1983,7 +1882,6 @@ dependencies = [
  "axum",
  "blake3",
  "clap",
- "criterion",
  "crossbeam-channel",
  "dirs 5.0.1",
  "fastembed",
@@ -2025,47 +1923,32 @@ dependencies = [
  "tower-http",
  "tracing",
  "tracing-subscriber",
- "tree-sitter 0.26.8",
- "tree-sitter-ada",
- "tree-sitter-agda",
+ "tree-sitter",
  "tree-sitter-bash",
  "tree-sitter-c",
  "tree-sitter-c-sharp",
- "tree-sitter-cairo",
- "tree-sitter-cmake",
  "tree-sitter-cpp",
  "tree-sitter-crystal",
  "tree-sitter-css",
  "tree-sitter-cuda",
  "tree-sitter-dart",
- "tree-sitter-dockerfile",
  "tree-sitter-elixir",
  "tree-sitter-elm",
  "tree-sitter-erlang",
- "tree-sitter-fortran",
  "tree-sitter-fsharp",
- "tree-sitter-func",
- "tree-sitter-gleam",
  "tree-sitter-glsl",
  "tree-sitter-go",
  "tree-sitter-graphql",
- "tree-sitter-groovy",
- "tree-sitter-hare",
  "tree-sitter-haskell",
  "tree-sitter-hlsl",
  "tree-sitter-html",
  "tree-sitter-java",
- "tree-sitter-jinja",
  "tree-sitter-json",
- "tree-sitter-julia",
  "tree-sitter-kotlin-ng",
  "tree-sitter-lua",
- "tree-sitter-make",
- "tree-sitter-matlab",
  "tree-sitter-nim",
  "tree-sitter-objc",
  "tree-sitter-ocaml",
- "tree-sitter-odin",
  "tree-sitter-perl",
  "tree-sitter-php",
  "tree-sitter-powershell",
@@ -2075,17 +1958,12 @@ dependencies = [
  "tree-sitter-r",
  "tree-sitter-ruby",
  "tree-sitter-rust",
- "tree-sitter-sas",
  "tree-sitter-scala",
  "tree-sitter-solidity",
- "tree-sitter-starlark",
  "tree-sitter-swift",
  "tree-sitter-systemverilog",
- "tree-sitter-toml",
  "tree-sitter-typescript",
- "tree-sitter-v",
  "tree-sitter-verilog",
- "tree-sitter-vhdl",
  "tree-sitter-yaml",
  "tree-sitter-zig",
  "uuid",
@@ -2578,12 +2456,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
 name = "openssl"
 version = "0.10.81"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2757,34 +2629,6 @@ name = "plain"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
-
-[[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
 
 [[package]]
 name = "png"
@@ -3102,7 +2946,7 @@ dependencies = [
  "built",
  "cfg-if",
  "interpolate_name",
- "itertools 0.14.0",
+ "itertools",
  "libc",
  "libfuzzer-sys",
  "log",
@@ -3159,7 +3003,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964d0cf57a3e7a06e8183d14a8b527195c706b7983549cd5462d5aa3747438f"
 dependencies = [
  "either",
- "itertools 0.14.0",
+ "itertools",
  "rayon",
 ]
 
@@ -4010,16 +3854,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "tinyvec"
 version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4047,7 +3881,7 @@ dependencies = [
  "derive_builder",
  "esaxx-rs",
  "getrandom 0.3.4",
- "itertools 0.14.0",
+ "itertools",
  "log",
  "macro_rules_attribute",
  "monostate",
@@ -4270,16 +4104,6 @@ dependencies = [
 
 [[package]]
 name = "tree-sitter"
-version = "0.20.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e747b1f9b7b931ed39a548c1fae149101497de3c1fc8d9e18c62c1a66c683d3d"
-dependencies = [
- "cc",
- "regex",
-]
-
-[[package]]
-name = "tree-sitter"
 version = "0.26.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "887bd495d0582c5e3e0d8ece2233666169fa56a9644d172fc22ad179ab2d0538"
@@ -4289,26 +4113,6 @@ dependencies = [
  "regex-syntax",
  "serde_json",
  "streaming-iterator",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-ada"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8d9fcdd64359c98fcc99d72f6d3d6ca5d6d76ce325ac39430b1d283a0fb61ca1"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-agda"
-version = "1.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79170741bc75a42d93a69f7e2d39bece006bea602af30650f7f323645094d693"
-dependencies = [
- "cc",
  "tree-sitter-language",
 ]
 
@@ -4337,26 +4141,6 @@ name = "tree-sitter-c-sharp"
 version = "0.23.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1aac67f1ad71de1d6d39708d34811081c26dfa495658de6c14c34200849357c"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-cairo"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037a976972f49ef190929bf318330eb5eb92277522e045d3293845203eb646f1"
-dependencies = [
- "cc",
- "tree-sitter 0.20.10",
-]
-
-[[package]]
-name = "tree-sitter-cmake"
-version = "0.7.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "164e0c4f4236ec5ceff14824a5528615cf462e100467e49826442ff57d327061"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4413,16 +4197,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-dockerfile"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba46310efcac616744ca79aa4b0e228202e388913ebcd4a1ba107072f7f4432a"
-dependencies = [
- "cc",
- "tree-sitter 0.20.10",
-]
-
-[[package]]
 name = "tree-sitter-elixir"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4453,40 +4227,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-fortran"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea5fea41363a9b59666001dc26c4b356d4e164da27c6ce31145e00aba6bf9b16"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
 name = "tree-sitter-fsharp"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b069005841682d258b95e9ee8cb0c0a0f16b77318ff56000504169c80690c67b"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-func"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db04893538ffffa8dc821c2541506931c929c0796ccf67511d8e633394ad5167"
-dependencies = [
- "cc",
- "tree-sitter 0.20.10",
-]
-
-[[package]]
-name = "tree-sitter-gleam"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0175c53793bda5d444360dd5add25463d18d66afb7f521d6791e2fc61bf2fb3"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4520,26 +4264,6 @@ checksum = "efedc4cac157161cc23a0adc4553a2cedc908e1cd754b6cd033a919bb81ce5d6"
 dependencies = [
  "cc",
  "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-groovy"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a20016017f0865ba902ca50354f92429de5de8df994e64ab7fae087a13c40ed"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-hare"
-version = "0.20.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cbd59e015721be7de5449fad7b7d5302f0f8544b1589f818d9a38afd4ff198b"
-dependencies = [
- "cc",
- "tree-sitter 0.20.10",
 ]
 
 [[package]]
@@ -4583,30 +4307,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-jinja"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "815dd76677ef2727aa06e6b37f49d34cae25875c694eca020613dfa169fd9b16"
-dependencies = [
- "cc",
- "tree-sitter 0.26.8",
-]
-
-[[package]]
 name = "tree-sitter-json"
 version = "0.24.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-julia"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4144731a178812ee867619b1e98b3b91e54c1652304b26e5ebe3175b701de323"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4633,26 +4337,6 @@ name = "tree-sitter-lua"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8daaf5f4235188a58603c39760d5fa5d4b920d36a299c934adddae757f32a10c"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-make"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5998dc7cbcbdab19fae8aefef982bf2d6544513d8d2e69cc44aec4c63810104"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-matlab"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e8d8831a78547f54860dd8467166b1ab0c466d03d43c4bb447af55c024281f7"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4689,23 +4373,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-odin"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "24db210fe9ba2237c71c5030d7b146c7025420ba72dd8013d13cd822c3a8d77a"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
 name = "tree-sitter-perl"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e79d4ae71b42e595c24c354b59905ade8162bd400ebc53ab916ea8aec54da92d"
 dependencies = [
  "cc",
- "tree-sitter 0.26.8",
+ "tree-sitter",
  "tree-sitter-language",
 ]
 
@@ -4790,16 +4464,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-sas"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4d6233b3cf8a9d495ecc6ed8fec7e6a29ec15a0c5808ef046504c28e52334c"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
 name = "tree-sitter-scala"
 version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4814,16 +4478,6 @@ name = "tree-sitter-solidity"
 version = "1.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4eacf8875b70879f0cb670c60b233ad0b68752d9e1474e6c3ef168eea8a90b25"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-starlark"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8934f282d085cc4b9ee28aa688aa3fbe8aa3766201c2a6252f411d45b4c3a721"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -4850,16 +4504,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-toml"
-version = "0.20.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca517f578a98b23d20780247cc2688407fa81effad5b627a5a364ec3339b53e8"
-dependencies = [
- "cc",
- "tree-sitter 0.20.10",
-]
-
-[[package]]
 name = "tree-sitter-typescript"
 version = "0.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4870,30 +4514,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-v"
-version = "0.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3adacdb2ffeee75b0e52e828f4a481db3cfd96f9cc50023d7c17318f5e563e7"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
 name = "tree-sitter-verilog"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e7e0360395852f1f6ff5b7b82c72dc6557d181073188df1d60ec469ea69c66"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-vhdl"
-version = "1.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0feb025ddf87c45bb98335ef2a2493cac08ec6b74d33201d1bf75df2be08de23"
 dependencies = [
  "cc",
  "tree-sitter-language",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,12 +15,26 @@ categories = ["command-line-utilities", "data-structures"]
 crate-type = ["rlib"]
 
 [features]
-default = []
+default = ["lang-extras"]
 # Enable vector retrieval + cross-encoder rerank + adaptive KG traversal.
 # Adds fastembed (embedding + reranker inference via ONNX). Vectors are stored
 # in Postgres pgvector (HNSW index on `embedding_vectors`).
 # Off by default to keep the default binary slim.
 embeddings = ["dep:fastembed", "dep:ort", "dep:tokenizers", "dep:ndarray"]
+# Non-core language grammars. Off in the slim Docker build (--no-default-features)
+# so only core languages (go/ts/py/rust/java/kotlin/bash/ruby/php/perl/r/elixir/
+# swift/c/cpp/objc/dart) are compiled into the MCP HTTP server binary.
+lang-extras = [
+  "dep:tree-sitter-scala", "dep:tree-sitter-zig", "dep:tree-sitter-solidity",
+  "dep:tree-sitter-lua", "dep:tree-sitter-json", "dep:tree-sitter-yaml",
+  "dep:tree-sitter-css", "dep:tree-sitter-html", "dep:tree-sitter-graphql",
+  "dep:tree-sitter-proto", "dep:tree-sitter-c-sharp", "dep:tree-sitter-haskell",
+  "dep:tree-sitter-elm", "dep:tree-sitter-ocaml", "dep:tree-sitter-fsharp",
+  "dep:tree-sitter-erlang", "dep:tree-sitter-nim", "dep:tree-sitter-powershell",
+  "dep:tree-sitter-crystal", "dep:tree-sitter-cuda", "dep:tree-sitter-hlsl",
+  "dep:tree-sitter-glsl", "dep:tree-sitter-verilog", "dep:tree-sitter-systemverilog",
+  "dep:tree-sitter-qsharp",
+]
 
 [dependencies]
 clap = { version = "4", features = ["derive"] }
@@ -89,51 +103,31 @@ tokenizers = { version = "0.21", optional = true, default-features = false, feat
 ndarray = { version = "0.16", optional = true }
 tree-sitter-c = "0.24.2"
 tree-sitter-cpp = "0.23.4"
-tree-sitter-scala = "0.26.0"
-tree-sitter-zig = "1.1.2"
-tree-sitter-solidity = "1.2.13"
-tree-sitter-lua = "0.5.0"
-tree-sitter-json = "0.24.8"
-tree-sitter-yaml = "0.7.2"
-tree-sitter-css = "0.25.0"
-tree-sitter-html = "0.23.2"
-tree-sitter-graphql = "0.1.0"
-tree-sitter-proto = "0.4.0"
-tree-sitter-c-sharp = "0.23.5"
-tree-sitter-haskell = "0.23.1"
-tree-sitter-elm = "5.9.4"
-tree-sitter-ocaml = "0.25.0"
-tree-sitter-fsharp = "0.3.11"
-tree-sitter-erlang = "0.20.0"
-tree-sitter-nim = "0.1.0"
-tree-sitter-powershell = "0.26.4"
-tree-sitter-v = "0.0.4"
-tree-sitter-odin = "1.3"
-tree-sitter-hare = "0.20"
-tree-sitter-gleam = "1.0"
-tree-sitter-agda = "1.3"
-tree-sitter-cuda = "0.21"
-tree-sitter-hlsl = "0.2"
-tree-sitter-glsl = "0.2"
-tree-sitter-verilog = "1.0"
-tree-sitter-systemverilog = "0.4"
-tree-sitter-qsharp = "0.2"
-tree-sitter-fortran = "0.6"
-tree-sitter-ada = "0.1"
-tree-sitter-julia = "0.23"
-tree-sitter-matlab = "1.3"
-tree-sitter-sas = "0.4"
-tree-sitter-jinja = "0.13"
-tree-sitter-cairo = "0.0.1"
-tree-sitter-func = "1.0"
-tree-sitter-cmake = "0.7"
-tree-sitter-make = "1.1"
-tree-sitter-starlark = "1.3"
-tree-sitter-groovy = "0.1"
-tree-sitter-crystal = "0.1.0"
-tree-sitter-toml = "0.20.0"
-tree-sitter-dockerfile = "0.2.0"
-tree-sitter-vhdl = "1.4.0"
+tree-sitter-scala = { version = "0.26.0", optional = true }
+tree-sitter-zig = { version = "1.1.2", optional = true }
+tree-sitter-solidity = { version = "1.2.13", optional = true }
+tree-sitter-lua = { version = "0.5.0", optional = true }
+tree-sitter-json = { version = "0.24.8", optional = true }
+tree-sitter-yaml = { version = "0.7.2", optional = true }
+tree-sitter-css = { version = "0.25.0", optional = true }
+tree-sitter-html = { version = "0.23.2", optional = true }
+tree-sitter-graphql = { version = "0.1.0", optional = true }
+tree-sitter-proto = { version = "0.4.0", optional = true }
+tree-sitter-c-sharp = { version = "0.23.5", optional = true }
+tree-sitter-haskell = { version = "0.23.1", optional = true }
+tree-sitter-elm = { version = "5.9.4", optional = true }
+tree-sitter-ocaml = { version = "0.25.0", optional = true }
+tree-sitter-fsharp = { version = "0.3.11", optional = true }
+tree-sitter-erlang = { version = "0.20.0", optional = true }
+tree-sitter-nim = { version = "0.1.0", optional = true }
+tree-sitter-powershell = { version = "0.26.4", optional = true }
+tree-sitter-cuda = { version = "0.21", optional = true }
+tree-sitter-hlsl = { version = "0.2", optional = true }
+tree-sitter-glsl = { version = "0.2", optional = true }
+tree-sitter-verilog = { version = "1.0", optional = true }
+tree-sitter-systemverilog = { version = "0.4", optional = true }
+tree-sitter-qsharp = { version = "0.2", optional = true }
+tree-sitter-crystal = { version = "0.1.0", optional = true }
 
 [target.'cfg(unix)'.dependencies]
 libc = "0.2"
@@ -169,28 +163,3 @@ moka = { version = "0.12", features = ["future"] }
 postgres = { version = "0.19", features = ["with-serde_json-1"] }
 
 [dev-dependencies]
-criterion = { version = "0.5", features = ["html_reports"] }
-
-[[example]]
-name = "bench_embed_stress"
-required-features = ["embeddings"]
-
-[[example]]
-name = "bench_fastembed_smoke"
-required-features = ["embeddings"]
-
-[[example]]
-name = "bench_embed_infer"
-required-features = ["embeddings"]
-
-[[bench]]
-name = "orchestrator_bench"
-harness = false
-
-[[bench]]
-name = "orchestrator_real_bench"
-harness = false
-
-[[bench]]
-name = "redundant_tool_overhead"
-harness = false

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,9 @@ FROM rust:1-bookworm AS builder
 WORKDIR /app
 
 # Starter Render build pipeline: 2 CPU, 8 GB RAM (docs.render.com/build-pipeline).
-# embeddings → fastembed → hf-hub → native-tls → openssl-sys needs libssl-dev.
+# Default build has no embeddings → no fastembed/openssl in the dep graph, so
+# clang/libclang-dev/libssl-dev are unnecessary (they were for an old bindgen
+# path). pkg-config is still needed by some tree-sitter C build scripts.
 ENV CARGO_BUILD_JOBS=1 \
     CARGO_PROFILE_RELEASE_LTO=false \
     CARGO_INCREMENTAL=0 \
@@ -24,23 +26,20 @@ Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
 EOF
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        clang \
-        libclang-dev \
         pkg-config \
-        libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
-# benches/ required — Cargo.toml [[bench]] targets fail manifest parse if missing.
-COPY benches ./benches
-# examples/ required — Cargo.toml [[example]] targets (embeddings feature) fail
-# manifest parse if missing.
-COPY examples ./examples
+# examples/ + benches/ are not copied: their [[example]]/[[bench]] manifest
+# targets were removed, so Cargo no longer needs the source files present.
 COPY ontology/ ./ontology/
 COPY leankg.yaml ./leankg.yaml
 
-RUN cargo build --release \
+# --no-default-features: build only core languages (go/ts/py/rust/java/kotlin/
+# bash/ruby/php/perl/r/elixir/swift/c/cpp/objc/dart). The lang-extras grammars
+# (scala, csharp, cuda, …) are compiled out, cutting build time substantially.
+RUN cargo build --release --no-default-features \
     && strip target/release/leankg \
     && cp target/release/leankg /usr/local/bin/leankg
 

--- a/src/indexer/extractor.rs
+++ b/src/indexer/extractor.rs
@@ -4477,6 +4477,10 @@ mod tests {
         parser.parse(source, None)
     }
 
+    // lang-extras grammars: only compiled when the feature is on. In the slim
+    // Docker core build (--no-default-features) these test helpers and their
+    // tests are compiled out.
+    #[cfg(feature = "lang-extras")]
     fn parse_scala(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_scala::LANGUAGE.into();
@@ -4484,6 +4488,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_zig(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_zig::LANGUAGE.into();
@@ -4491,6 +4496,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_solidity(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_solidity::LANGUAGE.into();
@@ -4498,6 +4504,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_lua(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_lua::LANGUAGE.into();
@@ -4505,6 +4512,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_json(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_json::LANGUAGE.into();
@@ -4512,6 +4520,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_yaml(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_yaml::LANGUAGE.into();
@@ -4519,6 +4528,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_csharp(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_c_sharp::LANGUAGE.into();
@@ -4526,6 +4536,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_haskell(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_haskell::LANGUAGE.into();
@@ -4533,6 +4544,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_elm(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_elm::LANGUAGE.into();
@@ -4540,6 +4552,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_ocaml(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_ocaml::LANGUAGE_OCAML.into();
@@ -4547,6 +4560,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_fsharp(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_fsharp::LANGUAGE_FSHARP.into();
@@ -4554,6 +4568,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_erlang(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_erlang::LANGUAGE.into();
@@ -4561,6 +4576,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_nim(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_nim::LANGUAGE.into();
@@ -4568,6 +4584,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_powershell(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_powershell::LANGUAGE.into();
@@ -4575,6 +4592,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_crystal(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_crystal::LANGUAGE.into();
@@ -4582,6 +4600,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_cuda(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_cuda::LANGUAGE.into();
@@ -4589,6 +4608,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_hlsl(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_hlsl::LANGUAGE_HLSL.into();
@@ -4596,6 +4616,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_glsl(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_glsl::LANGUAGE_GLSL.into();
@@ -4603,6 +4624,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_verilog(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_verilog::LANGUAGE.into();
@@ -4610,6 +4632,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_systemverilog(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_systemverilog::LANGUAGE.into();
@@ -4617,6 +4640,7 @@ mod tests {
         parser.parse(source, None)
     }
 
+    #[cfg(feature = "lang-extras")]
     fn parse_qsharp(source: &[u8]) -> Option<tree_sitter::Tree> {
         let mut parser = Parser::new();
         let lang: tree_sitter::Language = tree_sitter_qsharp::LANGUAGE.into();
@@ -4870,6 +4894,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_scala_class_and_function() {
         let source = b"package com.example\nimport scala.collection.mutable\nclass User(name: String) {\n  def greet: String = s\"hi $name\"\n}\ntrait Greetable {\n  def hello: String\n}\ndef helper(x: Int): Int = x + 1";
         if let Some(tree) = parse_scala(source) {
@@ -4903,6 +4928,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_zig_functions() {
         let source = b"const std = @import(\"std\");\nfn add(a: i32, b: i32) i32 {\n    return a + b;\n}\nconst Point = struct { x: i32, y: i32 };\ntest \"basic\" {\n    try std.testing.expect(add(1, 2) == 3);\n}";
         if let Some(tree) = parse_zig(source) {
@@ -4921,6 +4947,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_solidity_contract_and_function() {
         let source = b"pragma solidity ^0.8.0;\nimport \"./Helper.sol\";\ncontract Counter {\n    uint256 private count;\n    function increment() public {\n        count += 1;\n    }\n}";
         if let Some(tree) = parse_solidity(source) {
@@ -4957,6 +4984,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_lua_functions() {
         let source = b"local m = require(\"math\")\nfunction add(a, b)\n  return a + b\nend\nlocal function square(x)\n  return x * x\nend";
         if let Some(tree) = parse_lua(source) {
@@ -4980,6 +5008,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_json_minimal_document() {
         let source = b"{\"name\": \"test\", \"count\": 3}";
         if let Some(tree) = parse_json(source) {
@@ -4995,6 +5024,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_yaml_minimal_document() {
         let source = b"name: test\nversion: 1.0\n";
         if let Some(tree) = parse_yaml(source) {
@@ -5009,6 +5039,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_csharp_class_and_method() {
         let source = b"using System;\nnamespace Demo {\n  public class User {\n    public string Greet(string name) {\n      return \"hi \" + name;\n    }\n  }\n}";
         if let Some(tree) = parse_csharp(source) {
@@ -5042,6 +5073,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_haskell_function_and_import() {
         let source = b"module Main where\nimport Data.List (sort)\ndouble :: Int -> Int\ndouble x = x * 2\nmain :: IO ()\nmain = putStrLn \"hi\"";
         if let Some(tree) = parse_haskell(source) {
@@ -5069,6 +5101,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_elm_function_and_type() {
         let source = b"module Main exposing (main)\nimport Html exposing (text)\ntype Msg = Increment | Decrement\ndouble : Int -> Int\ndouble x = x * 2";
         if let Some(tree) = parse_elm(source) {
@@ -5089,6 +5122,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_ocaml_module_and_function() {
         let source =
             b"open List\nlet double x = x * 2\nmodule Math = struct\n  let add a b = a + b\nend";
@@ -5117,6 +5151,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_fsharp_module_and_function() {
         let source = b"module Math\nlet double x = x * 2\nlet add a b = a + b";
         if let Some(tree) = parse_fsharp(source) {
@@ -5135,6 +5170,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_erlang_function_and_module() {
         let source = b"-module(math).\n-export([double/1]).\ndouble(X) -> X * 2.";
         if let Some(tree) = parse_erlang(source) {
@@ -5153,6 +5189,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_nim_function_and_type() {
         let source = b"import std/strutils\nproc double(x: int): int =\n  x * 2\nfunc add(a, b: int): int = a + b";
         if let Some(tree) = parse_nim(source) {
@@ -5176,6 +5213,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_powershell_function() {
         let source = b"function Get-User {\n  param($id)\n  return $id\n}\nfunction Test-Helper { Write-Host 'hi' }";
         if let Some(tree) = parse_powershell(source) {
@@ -5194,6 +5232,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_crystal_class_and_method() {
         let source = b"require \"json\"\nclass User\n  def initialize(name)\n    @name = name\n  end\n  def greet\n    \"hi #{@name}\"\n  end\nend";
         if let Some(tree) = parse_crystal(source) {
@@ -6178,6 +6217,7 @@ class OldService {
     // ── GPU / HDL / Quantum tests (cluster A) ─────────────────────────────
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_cuda_function() {
         let source = b"__global__ void add(int a, int b) { return a + b; }\n";
         if let Some(tree) = parse_cuda(source) {
@@ -6192,6 +6232,7 @@ class OldService {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_hlsl_function() {
         let source = b"float4 main_ps(float4 pos : SV_POSITION) : SV_Target { return pos; }\n";
         if let Some(tree) = parse_hlsl(source) {
@@ -6206,6 +6247,7 @@ class OldService {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_glsl_function() {
         let source = b"void main() { gl_Position = vec4(0.0, 0.0, 0.0, 1.0); }\n";
         if let Some(tree) = parse_glsl(source) {
@@ -6220,6 +6262,7 @@ class OldService {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_verilog_module() {
         let source = b"module top; endmodule\n";
         let tree = parse_verilog(source).expect("verilog parse");
@@ -6230,6 +6273,7 @@ class OldService {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_systemverilog_class() {
         let source = b"class packet; int length; function int get_length(); return length; endfunction endclass\n";
         if let Some(tree) = parse_systemverilog(source) {
@@ -6244,6 +6288,7 @@ class OldService {
     }
 
     #[test]
+    #[cfg(feature = "lang-extras")]
     fn test_extract_qsharp_operation() {
         let source = b"operation BellPair() : (Qubit, Qubit) { use qs = Qubit[2]; H(qs[0]); CNOT(qs[0], qs[1]); return (qs[0], qs[1]); }\n";
         if let Some(tree) = parse_qsharp(source) {

--- a/src/indexer/lang/registry.rs
+++ b/src/indexer/lang/registry.rs
@@ -4,12 +4,86 @@
 //! extractor.rs / call_graph.rs.
 
 use tree_sitter::{Language, Parser};
+#[cfg(feature = "lang-extras")]
 use tree_sitter_cuda;
+#[cfg(feature = "lang-extras")]
 use tree_sitter_glsl;
+#[cfg(feature = "lang-extras")]
 use tree_sitter_hlsl;
+#[cfg(feature = "lang-extras")]
 use tree_sitter_qsharp;
+#[cfg(feature = "lang-extras")]
 use tree_sitter_systemverilog;
+#[cfg(feature = "lang-extras")]
 use tree_sitter_verilog;
+
+/// Grammar for a `lang-extras` language. Compiles to `Some(producer)` when the
+/// feature is on, `None` when off (--no-default-features, the slim Docker core
+/// build). The spec row stays in LANG_SPECS either way; only the grammar is
+/// dropped, so `language_for_path` still maps the extension but no parser loads.
+///
+/// `$prod` is a plain fn turning the crate's `LANGUAGE` const into a
+/// `tree_sitter::Language`; `$wrap` is the const fn referenced from the static
+/// LANG_SPECS `grammar:` field (statics only allow const calls, hence the
+/// `const fn` — a closure would also fail here).
+macro_rules! lang_extras_grammar {
+    ($prod:ident, $wrap:ident, $lang_expr:path) => {
+        #[cfg(feature = "lang-extras")]
+        fn $prod() -> Language {
+            $lang_expr.into()
+        }
+        #[cfg(feature = "lang-extras")]
+        const fn $wrap() -> Option<fn() -> Language> {
+            Some($prod)
+        }
+        #[cfg(not(feature = "lang-extras"))]
+        const fn $wrap() -> Option<fn() -> Language> {
+            None
+        }
+    };
+}
+
+lang_extras_grammar!(scala_lang, scala_grammar, tree_sitter_scala::LANGUAGE);
+lang_extras_grammar!(zig_lang, zig_grammar, tree_sitter_zig::LANGUAGE);
+lang_extras_grammar!(
+    solidity_lang,
+    solidity_grammar,
+    tree_sitter_solidity::LANGUAGE
+);
+lang_extras_grammar!(lua_lang, lua_grammar, tree_sitter_lua::LANGUAGE);
+lang_extras_grammar!(json_lang, json_grammar, tree_sitter_json::LANGUAGE);
+lang_extras_grammar!(yaml_lang, yaml_grammar, tree_sitter_yaml::LANGUAGE);
+lang_extras_grammar!(css_lang, css_grammar, tree_sitter_css::LANGUAGE);
+lang_extras_grammar!(html_lang, html_grammar, tree_sitter_html::LANGUAGE);
+lang_extras_grammar!(graphql_lang, graphql_grammar, tree_sitter_graphql::LANGUAGE);
+lang_extras_grammar!(proto_lang, proto_grammar, tree_sitter_proto::LANGUAGE);
+lang_extras_grammar!(csharp_lang, csharp_grammar, tree_sitter_c_sharp::LANGUAGE);
+lang_extras_grammar!(haskell_lang, haskell_grammar, tree_sitter_haskell::LANGUAGE);
+lang_extras_grammar!(elm_lang, elm_grammar, tree_sitter_elm::LANGUAGE);
+lang_extras_grammar!(ocaml_lang, ocaml_grammar, tree_sitter_ocaml::LANGUAGE_OCAML);
+lang_extras_grammar!(
+    fsharp_lang,
+    fsharp_grammar,
+    tree_sitter_fsharp::LANGUAGE_FSHARP
+);
+lang_extras_grammar!(erlang_lang, erlang_grammar, tree_sitter_erlang::LANGUAGE);
+lang_extras_grammar!(nim_lang, nim_grammar, tree_sitter_nim::LANGUAGE);
+lang_extras_grammar!(
+    powershell_lang,
+    powershell_grammar,
+    tree_sitter_powershell::LANGUAGE
+);
+lang_extras_grammar!(crystal_lang, crystal_grammar, tree_sitter_crystal::LANGUAGE);
+lang_extras_grammar!(cuda_lang, cuda_grammar, tree_sitter_cuda::LANGUAGE);
+lang_extras_grammar!(hlsl_lang, hlsl_grammar, tree_sitter_hlsl::LANGUAGE_HLSL);
+lang_extras_grammar!(glsl_lang, glsl_grammar, tree_sitter_glsl::LANGUAGE_GLSL);
+lang_extras_grammar!(verilog_lang, verilog_grammar, tree_sitter_verilog::LANGUAGE);
+lang_extras_grammar!(
+    systemverilog_lang,
+    systemverilog_grammar,
+    tree_sitter_systemverilog::LANGUAGE
+);
+lang_extras_grammar!(qsharp_lang, qsharp_grammar, tree_sitter_qsharp::LANGUAGE);
 
 /// Extraction fidelity tier.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -235,7 +309,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["import_declaration", "import"],
             calls: &["generic_function", "function_definition"],
         },
-        grammar: Some(|| tree_sitter_scala::LANGUAGE.into()),
+        grammar: scala_grammar(),
     },
     LanguageSpec {
         name: "zig",
@@ -255,7 +329,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["using_namespace_declaration", "usingnamespace"],
             calls: &["builtin_function", "function_call"],
         },
-        grammar: Some(|| tree_sitter_zig::LANGUAGE.into()),
+        grammar: zig_grammar(),
     },
     LanguageSpec {
         name: "solidity",
@@ -280,7 +354,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["import_directive", "import"],
             calls: &["function_call_expression", "call"],
         },
-        grammar: Some(|| tree_sitter_solidity::LANGUAGE.into()),
+        grammar: solidity_grammar(),
     },
     LanguageSpec {
         name: "lua",
@@ -295,7 +369,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["require"],
             calls: &["function_call", "function"],
         },
-        grammar: Some(|| tree_sitter_lua::LANGUAGE.into()),
+        grammar: lua_grammar(),
     },
     LanguageSpec {
         name: "json",
@@ -310,7 +384,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_json::LANGUAGE.into()),
+        grammar: json_grammar(),
     },
     LanguageSpec {
         name: "toml",
@@ -341,7 +415,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_yaml::LANGUAGE.into()),
+        grammar: yaml_grammar(),
     },
     LanguageSpec {
         name: "css",
@@ -356,7 +430,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_css::LANGUAGE.into()),
+        grammar: css_grammar(),
     },
     LanguageSpec {
         name: "html",
@@ -371,7 +445,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_html::LANGUAGE.into()),
+        grammar: html_grammar(),
     },
     LanguageSpec {
         name: "graphql",
@@ -386,7 +460,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_graphql::LANGUAGE.into()),
+        grammar: graphql_grammar(),
     },
     LanguageSpec {
         name: "protobuf",
@@ -401,7 +475,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_proto::LANGUAGE.into()),
+        grammar: proto_grammar(),
     },
     LanguageSpec {
         name: "dockerfile",
@@ -437,7 +511,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["using_directive"],
             calls: &["invocation_expression", "object_creation_expression"],
         },
-        grammar: Some(|| tree_sitter_c_sharp::LANGUAGE.into()),
+        grammar: csharp_grammar(),
     },
     LanguageSpec {
         name: "haskell",
@@ -452,7 +526,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["import"],
             calls: &["function_call_expression"],
         },
-        grammar: Some(|| tree_sitter_haskell::LANGUAGE.into()),
+        grammar: haskell_grammar(),
     },
     LanguageSpec {
         name: "elm",
@@ -471,7 +545,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["import_clause", "import"],
             calls: &["function_call_expr"],
         },
-        grammar: Some(|| tree_sitter_elm::LANGUAGE.into()),
+        grammar: elm_grammar(),
     },
     LanguageSpec {
         name: "ocaml",
@@ -491,7 +565,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["open", "include", "module_binding"],
             calls: &["application_expression", "call_expression"],
         },
-        grammar: Some(|| tree_sitter_ocaml::LANGUAGE_OCAML.into()),
+        grammar: ocaml_grammar(),
     },
     LanguageSpec {
         name: "fsharp",
@@ -511,7 +585,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["open", "open_declaration", "import"],
             calls: &["function_call_expression"],
         },
-        grammar: Some(|| tree_sitter_fsharp::LANGUAGE_FSHARP.into()),
+        grammar: fsharp_grammar(),
     },
     LanguageSpec {
         name: "erlang",
@@ -531,7 +605,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             ],
             calls: &["call", "external_fun"],
         },
-        grammar: Some(|| tree_sitter_erlang::LANGUAGE.into()),
+        grammar: erlang_grammar(),
     },
     LanguageSpec {
         name: "nim",
@@ -546,7 +620,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["import_declaration", "import"],
             calls: &["call"],
         },
-        grammar: Some(|| tree_sitter_nim::LANGUAGE.into()),
+        grammar: nim_grammar(),
     },
     LanguageSpec {
         name: "powershell",
@@ -561,7 +635,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["using_statement", "import_module"],
             calls: &["command", "call_expression"],
         },
-        grammar: Some(|| tree_sitter_powershell::LANGUAGE.into()),
+        grammar: powershell_grammar(),
     },
     LanguageSpec {
         name: "crystal",
@@ -576,7 +650,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["require", "import"],
             calls: &["call"],
         },
-        grammar: Some(|| tree_sitter_crystal::LANGUAGE.into()),
+        grammar: crystal_grammar(),
     },
     LanguageSpec {
         name: "toml",
@@ -843,96 +917,6 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
         config_files: EMPTY,
         tier: Tier::Full,
         kinds: NodeKinds {
-            functions: EMPTY,
-            classes: EMPTY,
-            interfaces: EMPTY,
-            properties: EMPTY,
-            imports: EMPTY,
-            calls: EMPTY,
-        },
-        grammar: None,
-    },
-    LanguageSpec {
-        name: "hlsl",
-        extensions: &["hlsl", "fx", "fxh", "hlsli"],
-        config_files: EMPTY,
-        tier: Tier::Full,
-        kinds: NodeKinds {
-            functions: EMPTY,
-            classes: EMPTY,
-            interfaces: EMPTY,
-            properties: EMPTY,
-            imports: EMPTY,
-            calls: EMPTY,
-        },
-        grammar: None,
-    },
-    LanguageSpec {
-        name: "glsl",
-        extensions: &["glsl", "vert", "frag", "geom", "tesc", "tese", "comp"],
-        config_files: EMPTY,
-        tier: Tier::Full,
-        kinds: NodeKinds {
-            functions: EMPTY,
-            classes: EMPTY,
-            interfaces: EMPTY,
-            properties: EMPTY,
-            imports: EMPTY,
-            calls: EMPTY,
-        },
-        grammar: None,
-    },
-    LanguageSpec {
-        name: "verilog",
-        extensions: &["v", "vh"],
-        config_files: EMPTY,
-        tier: Tier::Full,
-        kinds: NodeKinds {
-            functions: EMPTY,
-            classes: EMPTY,
-            interfaces: EMPTY,
-            properties: EMPTY,
-            imports: EMPTY,
-            calls: EMPTY,
-        },
-        grammar: None,
-    },
-    LanguageSpec {
-        name: "systemverilog",
-        extensions: &["sv", "svh"],
-        config_files: EMPTY,
-        tier: Tier::Full,
-        kinds: NodeKinds {
-            functions: EMPTY,
-            classes: EMPTY,
-            interfaces: EMPTY,
-            properties: EMPTY,
-            imports: EMPTY,
-            calls: EMPTY,
-        },
-        grammar: None,
-    },
-    LanguageSpec {
-        name: "qsharp",
-        extensions: &["qs"],
-        config_files: EMPTY,
-        tier: Tier::Full,
-        kinds: NodeKinds {
-            functions: EMPTY,
-            classes: EMPTY,
-            interfaces: EMPTY,
-            properties: EMPTY,
-            imports: EMPTY,
-            calls: EMPTY,
-        },
-        grammar: None,
-    },
-    LanguageSpec {
-        name: "cuda",
-        extensions: &["cu", "cuh"],
-        config_files: EMPTY,
-        tier: Tier::Full,
-        kinds: NodeKinds {
             functions: &["function_definition"],
             classes: EMPTY,
             interfaces: EMPTY,
@@ -940,7 +924,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["preproc_include", "using_declaration"],
             calls: &["call_expression"],
         },
-        grammar: Some(|| tree_sitter_cuda::LANGUAGE.into()),
+        grammar: cuda_grammar(),
     },
     LanguageSpec {
         name: "hlsl",
@@ -955,7 +939,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: &["preproc_include"],
             calls: &["call_expression"],
         },
-        grammar: Some(|| tree_sitter_hlsl::LANGUAGE_HLSL.into()),
+        grammar: hlsl_grammar(),
     },
     LanguageSpec {
         name: "glsl",
@@ -970,7 +954,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: &["call_expression"],
         },
-        grammar: Some(|| tree_sitter_glsl::LANGUAGE_GLSL.into()),
+        grammar: glsl_grammar(),
     },
     LanguageSpec {
         name: "verilog",
@@ -985,7 +969,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_verilog::LANGUAGE.into()),
+        grammar: verilog_grammar(),
     },
     LanguageSpec {
         name: "systemverilog",
@@ -1000,7 +984,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_systemverilog::LANGUAGE.into()),
+        grammar: systemverilog_grammar(),
     },
     LanguageSpec {
         name: "qsharp",
@@ -1015,7 +999,7 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
             imports: EMPTY,
             calls: EMPTY,
         },
-        grammar: Some(|| tree_sitter_qsharp::LANGUAGE.into()),
+        grammar: qsharp_grammar(),
     },
     LanguageSpec {
         name: "vyper",
@@ -2424,10 +2408,33 @@ mod tests {
         assert!(parsers.contains_key("c"));
     }
 
-    /// Every grammar-backed language must parse a representative snippet without
-    /// a parse error — guards against grammars that fail to load at runtime.
+    /// lang-extras feature gates the 25 non-core grammars. When disabled
+    /// (--no-default-features, the Docker core build), those languages keep
+    /// their LANG_SPECS row but report no grammar; core grammars stay loaded.
+    #[cfg(not(feature = "lang-extras"))]
     #[test]
-    fn all_grammar_languages_parse_snippet() {
+    fn lang_extras_grammars_absent_when_disabled() {
+        assert!(language_spec("scala").unwrap().grammar.is_none());
+        assert!(language_spec("cuda").unwrap().grammar.is_none());
+        assert!(language_spec("qsharp").unwrap().grammar.is_none());
+        // Core languages still carry a grammar in the slim build.
+        assert!(language_spec("rust").unwrap().grammar.is_some());
+        assert!(language_spec("go").unwrap().grammar.is_some());
+        assert!(language_spec("objc").unwrap().grammar.is_some());
+        assert!(language_spec("dart").unwrap().grammar.is_some());
+    }
+
+    #[cfg(feature = "lang-extras")]
+    #[test]
+    fn lang_extras_grammars_present_when_enabled() {
+        assert!(language_spec("scala").unwrap().grammar.is_some());
+        assert!(language_spec("cuda").unwrap().grammar.is_some());
+    }
+
+    /// Every core grammar-backed language must parse a representative snippet
+    /// without a parse error — guards against grammars that fail to load.
+    #[test]
+    fn all_core_grammar_languages_parse_snippet() {
         let samples: &[(&str, &str)] = &[
             ("c", "int main(void) { return 0; }"),
             ("cpp", "class Foo {}; int main() { return 0; }"),
@@ -2437,6 +2444,23 @@ mod tests {
             ("perl", "package Foo;\nsub bar { return 1; }"),
             ("r", "square <- function(x) x * x\n"),
             ("elixir", "defmodule M do\n  def f, do: 1\nend"),
+        ];
+        for (lang, src) in samples {
+            let spec = language_spec(lang).expect("spec");
+            assert!(spec.grammar.is_some(), "{} missing grammar", lang);
+            let mut parser = parser_for(lang).expect("parser");
+            let tree = parser
+                .parse(src, None)
+                .unwrap_or_else(|| panic!("{} parse failed", lang));
+            assert!(!tree.root_node().has_error(), "{} parse has errors", lang);
+        }
+    }
+
+    /// lang-extras grammar-backed languages (only present when the feature is on).
+    #[cfg(feature = "lang-extras")]
+    #[test]
+    fn lang_extras_grammar_languages_parse_snippet() {
+        let samples: &[(&str, &str)] = &[
             ("scala", "class User\nobject Main { def main() = () }"),
             ("zig", "fn add(a: i32) i32 { return a; }"),
             ("solidity", "contract C { function f() public {} }"),

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -2510,20 +2510,15 @@ include("web-app")"#;
     }
 
     // Bulk path (extract_elements_for_file) must index registry languages.
+    // scala/solidity are lang-extras grammars: only assert them when enabled.
     #[test]
     fn test_bulk_path_indexes_registry_languages() {
         let dir = tempfile::tempdir().expect("tempdir");
-        let files = [
-            "main.c",
-            "main.rb",
-            "main.php",
-            "math.R",
-            "User.scala",
-            "Counter.sol",
-            "config.json",
-        ];
-        for f in files {
-            let content = match f {
+        let mut files: Vec<&str> = vec!["main.c", "main.rb", "main.php", "math.R"];
+        #[cfg(feature = "lang-extras")]
+        files.extend(["User.scala", "Counter.sol", "config.json"]);
+        for f in &files {
+            let content = match *f {
                 "main.c" => "int add(int a, int b) { return a + b; }\nstruct Point { int x; };",
                 "main.rb" => "class User\n  def greet\n    'hi'\n  end\nend",
                 "main.php" => "<?php\nclass Foo {\n  public function bar() { return 1; }\n}",
@@ -2536,7 +2531,7 @@ include("web-app")"#;
             std::fs::write(dir.path().join(f), content).expect("write");
         }
 
-        for f in files {
+        for f in &files {
             let path = dir.path().join(f);
             let parsed = extract_elements_for_file(path.to_str().unwrap()).expect("extract");
             assert!(


### PR DESCRIPTION
## Summary
Slim the MCP HTTP Docker image by compiling only core language grammars instead of all 42, and dropping dead/build-only targets.

**Baseline:** full build compiled all 42 tree-sitter grammars (~7m51s host). Slim image: **164MB**, health `{"status":"ok"}` verified live.

## Changes

### 1. Feature-gate 25 non-core grammars behind `lang-extras`
- `Cargo.toml`: `default = ["lang-extras"]`; the 25 gated crates become optional deps.
- `Dockerfile`: `cargo build --release --no-default-features` → 17 core grammars only (go/ts/py/rust/java/kotlin/bash/ruby/php/perl/r/elixir/swift/c/cpp/objc/dart).
- `registry.rs`: `lang_extras_grammar!` macro emits a `const fn` per gated crate → `grammar: Some(fn)` with feature, `None` without. Spec rows stay, so `language_for_path` still maps extensions; `parser_for` returns `None` and indexing skips gracefully (`src/indexer/mod.rs:1216`).
- `extractor.rs`: 21 gated test helpers + their tests carry `#[cfg(feature = "lang-extras")]`.

### 2. Delete 20 dead grammar deps (zero refs in src)
`ada agda cairo cmake dockerfile fortran func gleam groovy hare jinja julia make matlab odin sas starlark toml v vhdl`

### 3. Drop build-only targets + junk from Docker
- Removed `[[example]]` (3) + `[[bench]]` (3) targets and `criterion` dev-dep (only used by benches). Dockerfile no longer `COPY`s `examples/`/`benches/` (372K).
- Builder apt trimmed: removed `clang`, `libclang-dev`, `libssl-dev` (not in default dep graph). Kept `pkg-config`.

### 4. Bug fix found by tests
Deleted 6 duplicate cuda/hlsl/glsl/verilog/systemverilog/qsharp stub specs that shadowed their real grammar-backed entries (`.find()` returned the `grammar: None` stub).

## Tests
- `cargo test` (default): **939/939**
- `cargo test --no-default-features` (Docker core): **917/917**, including new `lang_extras_grammars_absent_when_disabled` / `lang_extras_grammars_present_when_enabled`
- Docker image builds and `/health` returns `{"status":"ok"}`
- `cargo fmt` clean; pre-commit hook passed

## Notes
- To build with all languages: `cargo build --release` (default) or Docker without `--no-default-features`.
- Runtime image deps unchanged (libstdc++6, curl, ca-certificates).