### PR TITLE
fix(embed): live embedding against a running MCP server (PG pool, dirty-collect, Dockerfile)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,16 @@
 # LeanKG — lean Postgres-only image: Rust binary + HTTP MCP server.
 # No UI build, no source indexing bake. Postgres (pgvector) is the only
 # storage engine (D4); the container connects via LEANKG_PG_URL.
+#
+# Embeddings are opt-in via --build-arg LEANKG_FEATURES=embeddings (the
+# fastembed/ONNX stack adds ~hundreds of MB and several minutes to the build).
+# The MCP HTTP server's in-process background embed + embed_control tool only
+# exist when this feature is compiled in — build with it if you want live
+# embedding without a separate worker container.
 FROM rust:1-bookworm AS builder
 WORKDIR /app
+
+ARG LEANKG_FEATURES=""
 
 # Starter Render build pipeline: 2 CPU, 8 GB RAM (docs.render.com/build-pipeline).
 # Default build has no embeddings → no fastembed/openssl in the dep graph, so
@@ -14,12 +22,12 @@ ENV CARGO_BUILD_JOBS=1 \
     RUSTFLAGS="-C debuginfo=0" \
     CARGO_TERM_COLOR=always
 
-# Deb.debian.org / ftp.debian.org (Fastly CDN) are unreachable from some build
-# networks. ftp.us.debian.org is on a different network and is reachable.
+# HTTPS apt mirror. Plain HTTP mirrors (ftp.us.debian.org) are unreachable
+# from sandboxed build networks; deb.debian.org (Fastly CDN) over HTTPS works.
 # Sources file in its own RUN (heredoc must end the instruction).
 RUN cat > /etc/apt/sources.list.d/debian.sources <<'EOF'
 Types: deb
-URIs: http://ftp.us.debian.org/debian
+URIs: https://deb.debian.org/debian
 Suites: bookworm bookworm-updates
 Components: main
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg
@@ -27,6 +35,7 @@ EOF
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         pkg-config \
+        libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
 COPY Cargo.toml Cargo.lock ./
@@ -39,7 +48,8 @@ COPY leankg.yaml ./leankg.yaml
 # --no-default-features: build only core languages (go/ts/py/rust/java/kotlin/
 # bash/ruby/php/perl/r/elixir/swift/c/cpp/objc/dart). The lang-extras grammars
 # (scala, csharp, cuda, …) are compiled out, cutting build time substantially.
-RUN cargo build --release --no-default-features \
+# Embeddings opt-in via --build-arg LEANKG_FEATURES=embeddings (fastembed/ONNX).
+RUN cargo build --release --no-default-features --features "$LEANKG_FEATURES" \
     && strip target/release/leankg \
     && cp target/release/leankg /usr/local/bin/leankg
 
@@ -49,7 +59,7 @@ COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/ca-certifi
 
 RUN cat > /etc/apt/sources.list.d/debian.sources <<'EOF'
 Types: deb
-URIs: http://ftp.us.debian.org/debian
+URIs: https://deb.debian.org/debian
 Suites: bookworm bookworm-updates
 Components: main
 Signed-By: /usr/share/keyrings/debian-archive-keyring.gpg

--- a/docs/analysis/embed-inference-throughput-2026-08-06.md
+++ b/docs/analysis/embed-inference-throughput-2026-08-06.md
@@ -1,0 +1,56 @@
+# Embed Inference Throughput Investigation (2026-08-06)
+
+## Conclusion: hardware-bound, ~60-80 v/s ceiling on this Mac
+
+Pure-inference benchmark (`examples/bench_embed_infer`, no DB) on this 10-core
+Apple Silicon host — the same CPU the Docker containers share:
+
+| Model | workers | intra_threads | batch | rate v/s |
+|-------|---------|---------------|-------|----------|
+| bge-q (BGE-small int8) | 4 | 1 | 128 | 58.5 |
+| bge-q | 2 | 4 | 128 | **77.8** |
+| bge-q | 2 | 8 | 128 | 63.9 |
+| minilm (all-MiniLM-L6-v2) | 4 | 1 | 128 | 48.4 |
+| minilm | 2 | 4 | 128 | 69.3 |
+| minilm | 1 | 8 | 128 | 65.8 |
+| bge-q | 2 | 4 | 512 | 30.5 |
+
+## Key findings
+
+1. **Model choice doesn't matter** — bge-q int8 and minilm both plateau ~70 v/s.
+   MiniLM-L6 is FP32; the int8 quantization of BGE is the real speed lever,
+   not model size. The user's assumption "Qdrant/all-MiniLM-L6-v2 is faster"
+   is **wrong on this hardware** (48 vs 58 v/s at the same config).
+2. **`intra_threads=4` beats `=1`** (77.8 vs 58.5 v/s) — the hardcoded
+   `intra_threads=1` default (models.rs comment claiming "max throughput on
+   10c") undershoots. `LEANKG_EMBED_DIRECT_INTRA=4` + 2 workers is the best
+   measured config.
+3. **Bigger batch hurts** (512: 30 v/s) — ONNX batch > ~256 degrades.
+4. The models.rs:250 comment claiming "~600 vec/sec (4 workers, batch=128,
+   intra_threads=1)" does **not** reproduce on this host (58 v/s). Either the
+   comment was from a different CPU or stale.
+
+## For later investigation
+
+- **Why 600 v/s was claimed vs 58 measured**: verify the original benchmark
+  conditions (CPU model, ORT version, batch packing). The DirectEmbedder was
+  built to beat fastembed's ~120 v/s; 58 v/s is *below* that — suspicious.
+- **ORT graph optimization**: check `session.add_pre_optimized_models` /
+  graph-level optimizations (`ORT_ENABLE_ALL`). The int8 model may not be
+  using a fused graph.
+- **Alternative executors**: `onnxruntime` on this M-series may benefit from
+  CoreML EP (`ort` + `coreml`). Not wired in the crate today.
+- **Tokenize+build overhead**: profile the non-ONNX portion of `embed()`
+  (tokenizer, flat-array build) — at batch 128, per-batch overhead could
+  dominate. `bench_embed_infer` includes it, so the 77.8 v/s already
+  accounts for it, but splitting the phases would show the real ONNX-only
+  rate.
+- **GPU/MPS**: Apple MPS (Metal) for ONNX is a potential 3-5x. Requires
+  testing `ort` with the MPS execution provider.
+
+## Decision (per user 2026-08-06)
+
+Hardware cannot reach 200-500 v/s with the current stack. Ship the
+function-only embed scope (the incremental dirty-collect fix already treats
+never-state'd `function` elements as dirty). Revisit inference speed when
+MPS/GPU or a different host is available.

--- a/scripts/test-live-embed-no-stop.sh
+++ b/scripts/test-live-embed-no-stop.sh
@@ -1,0 +1,134 @@
+#!/usr/bin/env bash
+# Live-embed regression test: embedding (and indexing) must be triggerable
+# while the leankg-mcp server stays up and healthy — no `docker compose stop
+# leankg`, no `--force-recreate`. The RocksDB single-writer era is over;
+# Postgres is multi-writer.
+#
+# TDD: this test FAILS against freepeak/leankg:latest (no `embed` subcommand
+# — image built without --features=embeddings) and PASSES against an image
+# built with embeddings enabled.
+#
+# Usage (from repo root):
+#   LEANKG_IMAGE=freepeak/leankg:embeddings bash scripts/test-live-embed-no-stop.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+IMAGE="${LEANKG_IMAGE:-freepeak/leankg:embeddings}"
+PORT="${MCP_HTTP_PORT:-9699}"
+PASS=0; FAIL=0
+step() { echo "--- $*"; }
+ok()   { PASS=$((PASS+1)); echo "  PASS: $*"; }
+bad()  { FAIL=$((FAIL+1)); echo "  FAIL: $*"; }
+
+step "1. Image ${IMAGE} has the embed subcommand"
+embed_help=$(docker run --rm --entrypoint leankg "$IMAGE" embed --help 2>&1 || true)
+if echo "$embed_help" | grep -q "Build or refresh the embedding index"; then
+  ok "image exposes embed subcommand"
+else
+  bad "image lacks embed subcommand (built without --features=embeddings)"
+  echo "  (red) exiting before live checks — image is the blocker"
+  exit 1
+fi
+
+step "2. MCP server is up and stays up through the test"
+health_before=""
+for _ in $(seq 1 30); do
+  if health_before=$(curl -fsS -m 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null); then
+    break
+  fi
+  sleep 2
+done
+if echo "$health_before" | grep -qE '"status"\s*:\s*"ok"'; then
+  ok "server healthy before embed: ${health_before}"
+else
+  bad "server not healthy before embed: ${health_before}"
+  exit 1
+fi
+
+step "3. Server container name unchanged (no stop/recreate)"
+before_id=$(docker ps -q --filter "publish=${PORT}")
+after_id="$before_id"
+if [[ -n "$before_id" ]]; then
+  ok "server container running (id ${before_id:0:12})"
+else
+  bad "no server container on :${PORT}"
+  exit 1
+fi
+
+step "4. embedding_vectors row count baseline"
+DB_COUNT_QUERY="select count(*) from embedding_vectors"
+baseline=$(docker exec leankg-db psql -U postgres -d leankg -tAc "$DB_COUNT_QUERY" 2>/dev/null || echo "query-failed")
+echo "  baseline embedding_vectors rows: ${baseline}"
+ok "baseline read ok (${baseline})"
+
+step "5. Trigger embed via a throwaway embed container (same PG, no server touch)"
+# First run downloads ONNX models (bge-small-en-v1.5 + reranker) into the
+# shared model volume; subsequent runs reuse them.
+model_count=$(docker run --rm -v leankg-models:/root/.cache/leankg \
+  --entrypoint sh "$IMAGE" \
+  -c 'find /root/.cache/leankg -name "*.onnx" 2>/dev/null | wc -l')
+if [[ "$model_count" =~ ^[0-9]+$ && "$model_count" -gt 0 ]]; then
+  ok "models already cached (${model_count} onnx)"
+else
+  echo "  models absent; running embed --init (network download)..."
+  docker run --rm -v leankg-models:/root/.cache/leankg \
+    --entrypoint leankg "$IMAGE" embed --init --project /workspace 2>&1 | tail -3 \
+    || { bad "embed --init failed"; exit 1; }
+  ok "models downloaded"
+fi
+# The mcp container mounts ${LEANKG_PROJECT_DIR} as /workspace. Mirror it so
+# the embed container sees the same indexed project. Default: the mcp
+# container's actual /workspace source if discoverable, else the repo root.
+HOST_PROJECT="${LEANKG_PROJECT_DIR:-}"
+if [[ -z "$HOST_PROJECT" ]]; then
+  HOST_PROJECT=$(docker inspect leankg-mcp --format '{{range .Mounts}}{{if eq .Destination "/workspace"}}{{.Source}}{{end}}{{end}}' 2>/dev/null)
+fi
+if [[ -z "$HOST_PROJECT" || ! -d "${HOST_PROJECT}/.leankg" ]]; then
+  HOST_PROJECT="$(pwd)"
+fi
+echo "  host project mount: ${HOST_PROJECT} -> /workspace"
+embed_out=$(docker run --rm \
+  -e LEANKG_PG_URL="postgresql://postgres:postgres@host.docker.internal:5432/leankg" \
+  -e LEANKG_EMBED_FAST=1 \
+  -e LEANKG_EMBED_MODEL=bge-q \
+  -e LEANKG_EMBED_MAX_SEQ=128 \
+  -e LEANKG_EMBED_MAX_MB=2048 \
+  -e LEANKG_EMBED_MAX_BLOB_CHARS=500 \
+  -e LEANKG_MCP_PROJECT=/workspace \
+  -e OMP_NUM_THREADS=1 \
+  -v "${HOST_PROJECT}":/workspace \
+  -v leankg-models:/root/.cache/leankg \
+  --entrypoint leankg "$IMAGE" \
+  embed --wait --project /workspace --workers 1 --batch-size 16 --types function \
+  2>&1 | tail -8) || { bad "embed run failed"; echo "$embed_out"; exit 1; }
+echo "$embed_out"
+ok "embed ran to completion"
+
+step "6. Server still up after embed (same container id)"
+after_id=$(docker ps -q --filter "publish=${PORT}")
+if [[ -n "$after_id" && "$after_id" == "$before_id" ]]; then
+  ok "server container unchanged (${after_id:0:12})"
+else
+  bad "server container changed or stopped: before=${before_id:0:12} after=${after_id:0:12}"
+fi
+health_after=$(curl -fsS -m 2 "http://127.0.0.1:${PORT}/health" 2>/dev/null || echo "unhealthy")
+if echo "$health_after" | grep -qE '"status"\s*:\s*"ok"'; then
+  ok "server healthy after embed: ${health_after}"
+else
+  bad "server unhealthy after embed: ${health_after}"
+fi
+
+step "7. Vectors landed in PG (grew, or embed correctly reported converged)"
+after_count=$(docker exec leankg-db psql -U postgres -d leankg -tAc "$DB_COUNT_QUERY" 2>/dev/null || echo "query-failed")
+echo "  after embed embedding_vectors rows: ${after_count}"
+# A converged project reports "nothing to embed" (all fresh) — that's a pass.
+# A partial project must show growth. Either way the server stayed up.
+if [[ "$after_count" =~ ^[0-9]+$ && "$after_count" -ge "$baseline" ]]; then
+  ok "embedding_vectors ok (${baseline} -> ${after_count})"
+else
+  bad "embedding_vectors count invalid or shrank: ${baseline} -> ${after_count}"
+fi
+
+echo
+echo "PASS=${PASS} FAIL=${FAIL}"
+[[ "$FAIL" -eq 0 ]]

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -198,6 +198,16 @@ impl ClientPool {
         let pool_arc = Arc::new(self.clone());
         loop {
             if let Some(c) = guard.idle.pop_front() {
+                if c.is_closed() {
+                    // Stale connection (server closed it — idle timeout,
+                    // network blip, OrbStack host.docker.internal flap).
+                    // Drop it and open a fresh one; never hand a dead
+                    // client to a caller (that surfaces as opaque
+                    // `Error::Closed` from every subsequent query).
+                    guard.live -= 1;
+                    tracing::warn!("pg pool: dropped closed idle client; live={}", guard.live);
+                    continue;
+                }
                 return Ok(PooledClient::new(c, pool_arc.clone()));
             }
             if guard.live < self.inner.max {
@@ -216,7 +226,15 @@ impl ClientPool {
 
     fn release(&self, client: postgres::Client) {
         let mut guard = self.inner.state.lock().unwrap();
-        guard.idle.push_back(client);
+        if client.is_closed() {
+            guard.live -= 1;
+            tracing::warn!(
+                "pg pool: dropped closed client on release; live={}",
+                guard.live
+            );
+        } else {
+            guard.idle.push_back(client);
+        }
         self.inner.has_slot.notify_one();
     }
 }
@@ -1129,6 +1147,13 @@ mod tests {
     /// LEANKG_PG_POOL_SIZE / LEANKG_PG_LOCK) — Rust runs tests in parallel
     /// and env is process-global.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    // Pool self-heal for stale/closed idle clients is exercised end-to-end by
+    // tests/tmp_pool_isolation.rs against a live PG (LEANKG_PG_URL): before
+    // the fix, the second sequential query failed with `connection closed`;
+    // after it, `count_elements` returns the real 804k. The `postgres::Client`
+    // API (`close(self)` consumes) makes a focused unit test awkward, so the
+    // integration test is the coverage.
 
     #[test]
     fn postgres_backend_stub_returns_documented_error() {

--- a/src/db/fake.rs
+++ b/src/db/fake.rs
@@ -861,7 +861,6 @@ fn apply_filters(
         // `or` group: `(a = $x or b = $y)` / `str_includes(...) or ...` /
         // `(file_path = "x" or regex_matches(...) or regex_matches(...))`.
         if c.contains(" or ") {
-            let inner = c.trim_start_matches('(').trim_end_matches(')');
             // Only trim the outer parens when the WHOLE clause is parenthesized.
             let inner = if c.starts_with('(') && c.ends_with(')') {
                 c[1..c.len().saturating_sub(1)].trim()

--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -350,6 +350,20 @@ pub(crate) fn vector_state_inconsistent(vectors_existing: usize, fresh_state_row
     vectors_existing == 0 && fresh_state_rows > 0
 }
 
+/// Incremental-mode guard: escalate to a Full walk when Incremental would
+/// do nothing, either because the state table lies about existing vectors
+/// ([`vector_state_inconsistent`]) or because nothing was ever embedded
+/// (0 vectors AND 0 state rows — a fresh project's first `leankg embed`).
+/// Without this, `list_stale` on an empty state table returns nothing and
+/// the first embed reports a silent "nothing to embed".
+pub(crate) fn should_escalate_incremental_to_full(
+    vectors_existing: usize,
+    fresh_state_rows: u64,
+) -> bool {
+    let cold_first_run = vectors_existing == 0 && fresh_state_rows == 0;
+    vector_state_inconsistent(vectors_existing, fresh_state_rows) || cold_first_run
+}
+
 /// FR-EMBED-RESUME-02: when nothing needs embedding and there are no
 /// orphans to reap, skip HNSW drop+rebuild (day-2 no-op must stay cheap).
 ///
@@ -404,13 +418,24 @@ fn collect_incremental_dirty_work(
         .unwrap_or(0);
     let mut work = Vec::with_capacity(stale_rows.len().min(65_536));
     if stale_rows.len() > INCREMENTAL_POINT_LOOKUP_CAP {
-        let stale_qns: std::collections::HashSet<&str> = stale_rows
+        // Dirty = stale OR never state'd. `list_stale` only returns rows
+        // already present in `embedding_state`; elements that the indexer
+        // added to `code_elements` but never flagged (e.g. be's 274k
+        // functions after a storage-migration partial embed) have NO state
+        // row and are invisible to a stale-only scan. Build the full fresh
+        // QN set and treat "absent" as dirty, so a partially-embedded
+        // project converges instead of skipping its tail forever.
+        let all_state = state::list_all(graph.db())?;
+        let fresh_qns: std::collections::HashSet<&str> = all_state
             .iter()
+            .filter(|r| r.state == "fresh")
             .map(|r| r.qualified_name.as_str())
             .collect();
+        let fresh_count = fresh_qns.len();
         tracing::info!(
-            "incremental dirty collect: bulk scan (stale_rows={} > cap={})",
+            "incremental dirty collect: bulk scan (stale_rows={} fresh_state={} > cap={})",
             stale_rows.len(),
+            fresh_count,
             INCREMENTAL_POINT_LOOKUP_CAP
         );
         let total = graph.count_elements().unwrap_or(0);
@@ -426,8 +451,8 @@ fn collect_incremental_dirty_work(
             }
             offset += page.len();
             for el in page {
-                if !stale_qns.contains(el.qualified_name.as_str()) {
-                    continue;
+                if fresh_qns.contains(el.qualified_name.as_str()) {
+                    continue; // already embedded, still matching
                 }
                 if !element_passes_type_filter(&el, opts) {
                     continue;
@@ -644,16 +669,15 @@ pub fn run(
     // forever. Escalate to a Full walk — with zero vectors that is also exactly
     // the right amount of work.
     let fresh_state_rows = preflight.as_ref().map(|p| p.fresh).unwrap_or(0);
+    let vectors_existing = preflight.as_ref().map(|p| p.vectors_existing).unwrap_or(0) as usize;
     if matches!(opts.mode, BuildMode::Incremental)
-        && vector_state_inconsistent(
-            preflight.as_ref().map(|p| p.vectors_existing).unwrap_or(0) as usize,
-            fresh_state_rows,
-        )
+        && should_escalate_incremental_to_full(vectors_existing, fresh_state_rows)
     {
         tracing::warn!(
-            "embedding_state reports {} fresh rows but 0 vectors exist; \
-             escalating Incremental -> Full to break the resume deadlock",
-            fresh_state_rows
+            "embedding_state has {} fresh rows and {} vectors; \
+             escalating Incremental -> Full so the first embed does real work",
+            fresh_state_rows,
+            vectors_existing,
         );
         opts.mode = BuildMode::Full;
     }
@@ -881,13 +905,15 @@ pub fn build_index_parallel(
         .ok()
         .map(|p| p.fresh)
         .unwrap_or(0);
+    let vectors_existing = count_vectors(db).unwrap_or(0);
     if matches!(opts.mode, BuildMode::Incremental)
-        && vector_state_inconsistent(count_vectors(db).unwrap_or(0), fresh_state_rows)
+        && should_escalate_incremental_to_full(vectors_existing, fresh_state_rows)
     {
         tracing::warn!(
-            "embedding_state reports {} fresh rows but 0 vectors exist; \
-             escalating Incremental -> Full to break the resume deadlock",
-            fresh_state_rows
+            "embedding_state has {} fresh rows and {} vectors; \
+             escalating Incremental -> Full so the first embed does real work",
+            fresh_state_rows,
+            vectors_existing,
         );
         opts.mode = BuildMode::Full;
     }
@@ -2114,6 +2140,20 @@ mod tests {
         assert!(!vector_state_inconsistent(23_645, 23_645)); // healthy
         assert!(!vector_state_inconsistent(0, 0)); // never embedded
         assert!(!vector_state_inconsistent(100, 0)); // vectors, nothing fresh
+    }
+
+    #[test]
+    fn should_escalate_incremental_to_full_on_cold_first_run() {
+        // A freshly-indexed project has 0 vectors AND 0 state rows (nothing
+        // ever embedded). A plain Incremental's `list_stale` is empty, so it
+        // would report "nothing to embed" — a silent no-op on the very first
+        // `leankg embed`. It must escalate to a Full walk.
+        assert!(should_escalate_incremental_to_full(0, 0), "cold first run");
+        // State-lies recovery (vectors gone, state fresh) must also escalate.
+        assert!(should_escalate_incremental_to_full(0, 628_259));
+        // Healthy / partially-embedded graphs must NOT escalate.
+        assert!(!should_escalate_incremental_to_full(23_645, 23_645));
+        assert!(!should_escalate_incremental_to_full(100, 0));
     }
 
     #[test]

--- a/tests/pg_pool_reconnect_e2e.rs
+++ b/tests/pg_pool_reconnect_e2e.rs
@@ -1,0 +1,51 @@
+//! PG pool reconnect e2e: sequential queries on the same `PostgresBackend`
+//! must all succeed — regression for the stale-connection `Error::Closed`
+//! bug where `ClientPool` returned closed idle connections blindly.
+//!
+//! Before the fix: the second sequential query failed with
+//! `Error::Closed` / `connection closed` after the pool's idle clients went
+//! stale (long-running mcp-http + host.docker.internal route flapping).
+//! After the fix: `count_elements` returns the real row count (804k on be).
+//!
+//! Requires a live PG reachable via LEANKG_PG_URL (e.g. run inside a Docker
+//! container on the leankg network). Ignored by default.
+#![cfg(feature = "embeddings")]
+
+use leankg::db::backend::init_db;
+use leankg::embeddings::state::{list_all, list_stale};
+use leankg::graph::GraphEngine;
+
+#[test]
+#[ignore = "needs live PG via LEANKG_PG_URL"]
+fn two_sequential_queries_both_succeed() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = init_db(tmp.path().join("x.db").as_path()).unwrap();
+    let ge = GraphEngine::new(db.clone());
+    let a = ge
+        .count_elements()
+        .unwrap_or_else(|e| panic!("count a: {e}"));
+    let b = ge
+        .count_elements()
+        .unwrap_or_else(|e| panic!("count b: {e}"));
+    eprintln!("count a={a} b={b}");
+    // The exact queries the embed preflight runs — these hit `embedding_state`
+    // and previously surfaced `connection closed` on the second call.
+    let stale = list_stale(db.as_ref()).unwrap_or_else(|e| panic!("list_stale failed: {e}"));
+    eprintln!("stale = {}", stale.len());
+    let all = list_all(db.as_ref()).unwrap_or_else(|e| panic!("list_all failed: {e}"));
+    eprintln!("all = {}", all.len());
+}
+
+#[test]
+#[ignore = "needs live PG via LEANKG_PG_URL"]
+fn count_then_list_stale_succeeds() {
+    let tmp = tempfile::tempdir().unwrap();
+    let db = init_db(tmp.path().join("x.db").as_path()).unwrap();
+    let ge = GraphEngine::new(db.clone());
+    let total = ge
+        .count_elements()
+        .unwrap_or_else(|e| panic!("count_elements: {e}"));
+    eprintln!("count_elements = {total}");
+    let stale = list_stale(db.as_ref()).unwrap_or_else(|e| panic!("list_stale failed: {e}"));
+    eprintln!("stale rows = {}", stale.len());
+}


### PR DESCRIPTION
## What

Enables triggering cold embed **without stopping the leankg-mcp server**. Three bugs blocked it on PG:

### 1. Dockerfile built without embeddings (image mislabeled)
The `:embeddings` tag was built without `--features=embeddings` — no `embed` subcommand existed, so every embed attempt was a silent no-op. Now opt-in via `--build-arg LEANKG_FEATURES=embeddings`. Also switched apt to the HTTPS `deb.debian.org` mirror (plain-HTTP mirrors are unreachable from sandboxed build networks).

### 2. PG pool returned stale/closed connections (`Error::Closed`)
After idle or a host.docker.internal route flap, `ClientPool::checkout` handed out dead clients and every query failed with opaque `Error: Closed`. `checkout`/`release` now drop closed clients and reconnect. Verified by `tests/pg_pool_reconnect_e2e.rs` against live PG (count_elements returns the real 804k, was `connection closed`).

### 3. Incremental embed skipped never-state'd elements
`collect_incremental_dirty_work` only found rows already in `embedding_state`. Elements indexed into `code_elements` but never flagged (be had 274k functions after a partial embed) were invisible → embed reported "nothing to embed" and never converged. The bulk scan now treats **absent-as-dirty**; `should_escalate_incremental_to_full` escalates cold first runs (0 vectors + 0 state rows).

## Tests

- `scripts/test-live-embed-no-stop.sh`: 9 PASS — image exposes embed, server stays healthy before/after, vectors land without stop/recreate.
- `cargo test --release --features=embeddings --lib -- should_escalate_incremental`: pass.
- Live-verified: 138k vectors embedded into PG while leankg-mcp stayed up (never stopped).

## Perf note

Embed inference is hardware-bound at **60-80 v/s** on this Mac (benchmarked bge-q int8 vs minilm across workers/intra/batch; see `docs/analysis/embed-inference-throughput-2026-08-06.md`). The 200-500 v/s target needs MPS/GPU or a different host — documented for later.