### PR TITLE
fix(pg): parameterized embedding writes + cozo→SQL hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@
 
 ```bash
 # macOS / Linux
-curl -fsSL https://raw.githubusercontent.com/FreePeak/LeanKG/main/scripts/install.sh | bash -s -- <target>
+curl -fsSL https://raw.githubusercontent.com/FreePeak/LeanKG/main/scripts/install.sh | bash -s -- <opencode|cursor|claude|gemini|kilo|antigravity|docker|update|version>
 ```
 
 | Target                            | What you get                                                              |
@@ -213,7 +213,7 @@ graph LR
 
 ### Company ROI vs grep and Graphify
 
-For engineering managers choosing a team-wide stack: [LeanKG vs Graphify — Company ROI Brief](docs/reports/leankg-vs-graphify-company-roi-2026-07-21.md) (token/tool-call floors, multi-repo Docker TCO, mega-graph safety, ops/traceability). The primary adoption lever is always-on graph-first install (`curl …/install.sh | bash -s -- cursor` or `claude`) so agents query the graph before grep.
+For engineering managers choosing a team-wide stack: [LeanKG vs Graphify — Company ROI Brief](docs/reports/leankg-vs-graphify-company-roi-2026-07-21.md) (token/tool-call floors, multi-repo Docker TCO, mega-graph safety, ops/traceability). The primary adoption lever is always-on graph-first install (`curl …/install.sh | bash -s -- claude` or `cursor`) so agents query the graph before grep. Note: the PreToolUse "use LeanKG before grep" hook is wired for `claude` and `cursor` targets only — `opencode`/`gemini`/`kilo`/`antigravity` install the MCP server but rely on agent-side instruction following rather than a hard block.
 
 ---
 

--- a/scripts/docker-up.sh
+++ b/scripts/docker-up.sh
@@ -38,6 +38,19 @@ if [[ ! -d "$HOST_DIR" ]]; then
   exit 1
 fi
 
+# PG pre-flight: catch missing/closed Postgres early so the user doesn't get an
+# opaque "connection refused" from inside the container on first index.
+PG_URL="${LEANKG_PG_URL:-postgresql://postgres:postgres@localhost:5433/leankg}"
+PG_HOST=$(echo "$PG_URL" | sed -E 's#.*@([^:/]+).*#\1#')
+PG_PORT=$(echo "$PG_URL" | sed -E 's#.*@[^:/]+:([0-9]+).*#\1#')
+if command -v nc >/dev/null 2>&1; then
+  if ! nc -z -G 2 "$PG_HOST" "$PG_PORT" 2>/dev/null && ! nc -z -w 2 "$PG_HOST" "$PG_PORT" 2>/dev/null; then
+    echo "ERROR: PostgreSQL unreachable at $PG_HOST:$PG_PORT (from LEANKG_PG_URL)." >&2
+    echo "  Start Postgres (or override LEANKG_PG_URL) before running again." >&2
+    exit 1
+  fi
+fi
+
 echo "=== LeanKG Docker setup ==="
 echo "  image:     $IMAGE"
 echo "  host dir:  $HOST_DIR → /workspace"
@@ -55,7 +68,7 @@ VOLUMES=(
   -v leankg-models:/root/.cache/leankg
 )
 ENV_COMMON=(
-  -e LEANKG_PG_URL="${LEANKG_PG_URL:-postgresql://postgres:postgres@localhost:5433/leankg}"
+  -e LEANKG_PG_URL="${PG_URL}"
   -e LEANKG_MCP_PROJECT=/workspace
   -e LEANKG_AUTO_INDEX=1
   -e LEANKG_EMBED_ON_BOOT=0

--- a/scripts/install-leankg-mcp-launchd.sh
+++ b/scripts/install-leankg-mcp-launchd.sh
@@ -7,7 +7,7 @@ set -e
 LABEL="com.leankg.mcp-http"
 PLIST_DIR="$HOME/Library/LaunchAgents"
 PLIST_PATH="$PLIST_DIR/$LABEL.plist"
-LEANKG_DIR="/Users/linh.doan/work/harvey/freepeak/leankg"
+LEANKG_DIR="${LEANKG_DIR:-$HOME/work/freepeak/leankg}"
 
 echo "=== LeanKG MCP HTTP LaunchAgent Setup ==="
 echo ""
@@ -29,7 +29,7 @@ if [ ! -f "$BINARY_PATH" ]; then
 fi
 
 # Create the launchd plist
-cat > "$PLIST_PATH" << 'EOF'
+cat > "$PLIST_PATH" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -39,14 +39,14 @@ cat > "$PLIST_PATH" << 'EOF'
 
     <key>ProgramArguments</key>
     <array>
-        <string>/Users/linh.doan/work/harvey/freepeak/leankg/target/release/leankg</string>
+        <string>${BINARY_PATH}</string>
         <string>mcp-http</string>
         <string>--watch</string>
         <string>--reuse</string>
     </array>
 
     <key>WorkingDirectory</key>
-    <string>/Users/linh.doan/work/harvey/freepeak/leankg</string>
+    <string>${LEANKG_DIR}</string>
 
     <key>RunAtLoad</key>
     <true/>

--- a/src/db/pg/schema.sql
+++ b/src/db/pg/schema.sql
@@ -296,6 +296,11 @@ CREATE TABLE IF NOT EXISTS api_keys (
 );
 
 CREATE INDEX IF NOT EXISTS api_keys_id_index ON api_keys (id);
+-- The translator's `pk_for_table("api_keys") = key_hash` drives `:put
+-- api_keys` → `ON CONFLICT ("key_hash")`. That needs a UNIQUE index on
+-- key_hash or every api_keys write fails ("no unique or exclusion
+-- constraint matching the ON CONFLICT specification").
+CREATE UNIQUE INDEX IF NOT EXISTS api_keys_key_hash_uniq ON api_keys (key_hash);
 
 -- ---------------------------------------------------------------------------
 -- embedding_state — KEYED in cozo (qualified_name => usearch_key), single row

--- a/src/db/pg/translate.rs
+++ b/src/db/pg/translate.rs
@@ -1861,6 +1861,17 @@ fn render_clause<'a>(
         return Ok((format!("{lhs_sql} {op} {placeholder}"), used, clause));
     }
 
+    // Boolean literal `true` / `false` — bind as a bool param. A bare
+    // `false` must not fall through to scalar_expr, which would emit
+    // `"is_deleted" = false` and Postgres would read `false` as a column
+    // name (E42703).
+    if rhs == "true" || rhs == "false" {
+        let placeholder = format!("${}", *next_idx);
+        *next_idx += 1;
+        let used = vec![json_to_pg(serde_json::Value::Bool(rhs == "true"))];
+        return Ok((format!("{lhs_sql} {op} {placeholder}"), used, clause));
+    }
+
     // Computed RHS expression (e.g. `span = line_end - line_start`,
     // `(line_end - line_start + 1) >= 50`).
     let rhs_sql = scalar_expr(rhs);
@@ -2332,7 +2343,45 @@ fn put_from_literal(
             ));
         }
     }
-    build_insert(&infer_table(cols, pk), cols, pk, &rows, is_keyed)
+    let table = infer_table(cols, pk);
+    // Resolve the effective PK from the known table catalog when the caller
+    // omitted the `=>` marker (Cozo allows `:put t {cols}` on a keyed table
+    // — the PK is implied by the table). Without this, a re-`put` of an
+    // existing row hits `embedding_state_pkey` (duplicate key).
+    let (pk, keyed) = resolve_effective_pk(&table, pk, is_keyed);
+    build_insert(&table, cols, pk.as_deref(), &rows, keyed)
+}
+
+/// Known primary-key columns per table (schema.sql). Used to turn a
+/// `:put t {cols}` (no `=>`) on a keyed table into an `INSERT ... ON
+/// CONFLICT (pk) DO UPDATE` instead of a plain INSERT.
+fn pk_for_table(table: &str) -> Option<&'static str> {
+    match table {
+        "embedding_state" => Some("qualified_name"),
+        "embedding_vectors" => Some("qualified_name"),
+        "index_inventory" => Some("key"),
+        "index_hashes" => Some("path"),
+        "migrations" => Some("id"),
+        "api_keys" => Some("key_hash"),
+        _ => None,
+    }
+}
+
+/// Effective (pk, is_keyed) for a `:put`. The explicit `=>` marker wins;
+/// otherwise fall back to the table's known PK so keyed tables still
+/// upsert. Unknown tables stay non-keyed (plain INSERT).
+fn resolve_effective_pk(
+    table: &str,
+    explicit_pk: Option<&str>,
+    is_keyed: bool,
+) -> (Option<String>, bool) {
+    match explicit_pk {
+        Some(pk) => (Some(pk.to_string()), is_keyed),
+        None => match pk_for_table(table) {
+            Some(pk) => (Some(pk.to_string()), true),
+            None => (None, is_keyed),
+        },
+    }
 }
 
 /// Find the table name for a `:put` target by matching its columns to known
@@ -2361,6 +2410,12 @@ fn infer_table(cols: &[String], pk: Option<&str>) -> String {
     // Fallback: guess by column signature.
     if cols == ["path", "hash"] || cols == ["hash"] || cols == ["path"] {
         "index_hashes".into()
+    } else if cols.contains(&"usearch_key".to_string()) {
+        // embedding_state — 5-col shape `[qualified_name, usearch_key,
+        // content_hash, state, embedded_at]`. Must precede the generic
+        // element_type/qualified_name checks below (qualified_name alone
+        // would otherwise mis-resolve to code_elements).
+        "embedding_state".into()
     } else if cols.contains(&"element_type".to_string()) {
         "code_elements".into()
     } else if cols.contains(&"rel_type".to_string()) {
@@ -2739,7 +2794,8 @@ fn put_from_batch(
         }
     }
     let _ = name;
-    build_insert(&table, cols, pk, &rows, is_keyed)
+    let (pk, keyed) = resolve_effective_pk(&table, pk, is_keyed);
+    build_insert(&table, cols, pk.as_deref(), &rows, keyed)
 }
 
 fn rm_script(
@@ -2750,10 +2806,13 @@ fn rm_script(
     // Shape B: literal rm — `?[col] <- [{values}] :rm rel {col}` (key-only).
     let idx = body.find(":rm").ok_or("no :rm in body".to_string())?;
     // The target may carry the table name (`:rm relationships {cols}`) or
-    // not (`:rm {cols}`). Strip any `name {` prefix so only the column
-    // list remains.
+    // not (`:rm {cols}`). Keep the explicit table name (the prefix before
+    // `{`) so ambiguous key columns (e.g. `qualified_name` on both
+    // embedding_state and embedding_vectors) resolve to the caller's table,
+    // not a best-guess from the key column alone.
     let target = body[idx + 3..].trim();
     let brace_open = target.find('{').unwrap_or(0);
+    let explicit_table = target[..brace_open].trim();
     let target_cols = &target[brace_open..];
     let inner = target_cols
         .trim_start_matches('{')
@@ -2797,9 +2856,15 @@ fn rm_script(
         let list_text = after_arrow.trim();
         let arr = parse_nested_lists(list_text)?;
         let key_col = cols.first().cloned().unwrap_or_default();
-        let table = match infer_table_by_key(&key_col) {
-            Some(t) => t.to_string(),
-            None => infer_table(&cols, None),
+        // Explicit table name wins over key-column inference — `qualified_name`
+        // is the PK of both embedding_state and embedding_vectors.
+        let table = if !explicit_table.is_empty() {
+            explicit_table.to_string()
+        } else {
+            match infer_table_by_key(&key_col) {
+                Some(t) => t.to_string(),
+                None => infer_table(&cols, None),
+            }
         };
         let pk = key_col;
         // Flatten the outer array: each row is a single column.
@@ -2960,11 +3025,29 @@ fn hnsw_ddl(rest: &str) -> Result<Translation, String> {
     }
     if let Some(_after) = trimmed.strip_prefix("create") {
         if trimmed.contains("embedding_vectors") {
+            // Respect the caller's `m` / `ef_construction` (from
+            // LEANKG_HNSW_M / LEANKG_HNSW_EF_CONST, see
+            // build_hnsw_create_stmt) instead of silently hardcoding.
+            let mut m = 16usize;
+            let mut ef = 200usize;
+            for line in trimmed.lines() {
+                let l = line.trim().trim_end_matches(',');
+                if let Some(v) = l.strip_prefix("m:") {
+                    if let Ok(p) = v.trim().parse::<usize>() {
+                        m = p;
+                    }
+                } else if let Some(v) = l.strip_prefix("ef_construction:") {
+                    if let Ok(p) = v.trim().parse::<usize>() {
+                        ef = p;
+                    }
+                }
+            }
             return Ok(Translation::write(
-                "CREATE INDEX IF NOT EXISTS embedding_vectors_vec_hnsw_idx \
-                 ON embedding_vectors USING hnsw (vec vector_cosine_ops) \
-                 WITH (m = 16, ef_construction = 200)"
-                    .to_string(),
+                format!(
+                    "CREATE INDEX IF NOT EXISTS embedding_vectors_vec_hnsw_idx \
+                     ON embedding_vectors USING hnsw (vec vector_cosine_ops) \
+                     WITH (m = {m}, ef_construction = {ef})"
+                ),
                 Vec::new(),
             ));
         }
@@ -3871,6 +3954,24 @@ fn rm_literal_key_only_with_table_prefix() {
 }
 
 #[test]
+fn rm_embedding_state_with_table_prefix() {
+    // delete_state_rows targets `embedding_state`, whose PK `qualified_name`
+    // is shared with embedding_vectors. The explicit table prefix must win
+    // over key-column inference, else this deletes from the wrong table.
+    let t = translate(
+        r#"?[qualified_name] <- [["a"], ["b"]] :rm embedding_state {qualified_name}"#,
+        std::collections::BTreeMap::new(),
+    )
+    .unwrap();
+    assert!(
+        t.sql
+            .contains("DELETE FROM embedding_state WHERE \"qualified_name\" = ANY($1::text[])"),
+        "got: {}",
+        t.sql
+    );
+}
+
+#[test]
 fn put_embedding_vectors_maps_vector_to_vec() {
     // B1 — put_pairs_to_db_script shape: cozo `vector` col → PG `vec`.
     let t = translate(
@@ -3924,4 +4025,75 @@ fn str_contains_param_wrapped_in_lowercase_binds() {
     .unwrap();
     assert!(t.sql.contains("lower($1)"), "got: {}", t.sql);
     assert_eq!(t.params.len(), 1);
+}
+
+#[test]
+fn boolean_literal_filter_binds_param() {
+    // `is_deleted = false` must bind `false` as a bool param, not emit a
+    // bare `false` token (Postgres would read it as a column name → E42703).
+    let t = translate(
+        "?[tool_name, timestamp] := *context_metrics[tool_name, timestamp, project_path, input_tokens, output_tokens, output_elements, execution_time_ms, baseline_tokens, baseline_lines_scanned, tokens_saved, savings_percent, correct_elements, total_expected, f1_score, query_pattern, query_file, query_depth, success, is_deleted], is_deleted = false",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    assert!(
+        t.sql.contains("\"is_deleted\" = $1"),
+        "bool literal must bind as param, got: {}",
+        t.sql
+    );
+    assert_eq!(t.params.len(), 1, "one bool param");
+}
+
+#[test]
+fn hnsw_create_respects_m_and_ef_from_stmt() {
+    // ::hnsw create with explicit m / ef_construction values must be
+    // honored, not silently replaced with hardcoded defaults.
+    let t = translate(
+        "::hnsw create embedding_vectors:vec_idx {\n    dim: 384,\n    dtype: F32,\n    fields: [vector],\n    distance: Cosine,\n    ef_construction: 40,\n    m: 32,\n    extend_candidates: false,\n    keep_pruned_connections: false\n}",
+        BTreeMap::new(),
+    )
+    .unwrap();
+    assert!(
+        t.sql.contains("m = 32"),
+        "m=32 must be honored, got: {}",
+        t.sql
+    );
+    assert!(
+        t.sql.contains("ef_construction = 40"),
+        "ef_construction=40 must be honored, got: {}",
+        t.sql
+    );
+}
+
+#[test]
+fn put_embedding_state_literal_rows() {
+    // Exact shape from embeddings::state::mark_stale_for_qualified_names:
+    // `?[cols] <- [[literal rows]]\n:put embedding_state {cols}`
+    let t = translate(
+        "?[qualified_name, usearch_key, content_hash, state, embedded_at] <- [[\"test/qn\", 0, \"\", \"stale\", \"2026-08-06T03:00:00Z\"]]\n:put embedding_state {qualified_name, usearch_key, content_hash, state, embedded_at}",
+        std::collections::BTreeMap::new(),
+    );
+    match t {
+        Ok(t) => {
+            assert!(t.sql.contains("embedding_state"), "got: {}", t.sql);
+            // Keyed table, no `=>` marker → must upsert, not plain INSERT.
+            assert!(
+                t.sql.contains("ON CONFLICT (\"qualified_name\")"),
+                "expected upsert, got: {}",
+                t.sql
+            );
+        }
+        Err(e) => panic!("translate failed: {}", e),
+    }
+}
+
+#[test]
+fn put_embedding_state_reput_existing_row_upserts() {
+    // The regression this guards: a second `:put` of the same qualified_name
+    // on a keyed table must not hit embedding_state_pkey (duplicate key).
+    let q = "?[qualified_name, usearch_key, content_hash, state, embedded_at] <- [[\"same/qn\", 0, \"\", \"stale\", \"2026-08-06T03:00:00Z\"]]\n:put embedding_state {qualified_name, usearch_key, content_hash, state, embedded_at}";
+    let t1 = translate(q, std::collections::BTreeMap::new()).unwrap();
+    let t2 = translate(q, std::collections::BTreeMap::new()).unwrap();
+    assert!(t1.sql.contains("ON CONFLICT"));
+    assert_eq!(t1.sql, t2.sql);
 }

--- a/src/db/pg/translate.rs
+++ b/src/db/pg/translate.rs
@@ -2854,7 +2854,6 @@ fn rm_script(
     // `DELETE FROM table WHERE col = ANY('{...}')`.
     if let Some((_, after_arrow)) = source.split_once("<-") {
         let list_text = after_arrow.trim();
-        let arr = parse_nested_lists(list_text)?;
         let key_col = cols.first().cloned().unwrap_or_default();
         // Explicit table name wins over key-column inference — `qualified_name`
         // is the PK of both embedding_state and embedding_vectors.
@@ -2867,16 +2866,38 @@ fn rm_script(
             }
         };
         let pk = key_col;
-        // Flatten the outer array: each row is a single column.
-        let strs: Vec<String> = arr
-            .into_iter()
-            .filter_map(|row| {
-                row.into_iter().next().map(|v| match v {
-                    serde_json::Value::String(s) => s,
-                    other => other.to_string(),
+        let strs: Vec<String> = if let Some(name) = list_text.strip_prefix('$') {
+            // `?[col] <- $qns :rm table {col}` — caller passes a Vec<String>
+            // under `$qns`. Parameterized: avoids the literal-escaping bug
+            // (a QN containing `"` or `\` breaks the inline `[[...]]` literal
+            // and can merge rows → E21000 / wrong deletes).
+            let v = params.get(name).cloned().unwrap_or(serde_json::Value::Null);
+            match v {
+                serde_json::Value::Array(outer) => outer
+                    .into_iter()
+                    .filter_map(|r| match r {
+                        serde_json::Value::Array(row) => row.first().map(|f| match f {
+                            serde_json::Value::String(s) => s.clone(),
+                            other => other.to_string(),
+                        }),
+                        serde_json::Value::String(s) => Some(s),
+                        _ => None,
+                    })
+                    .collect(),
+                _ => Vec::new(),
+            }
+        } else {
+            let arr = parse_nested_lists(list_text)?;
+            // Flatten the outer array: each row is a single column.
+            arr.into_iter()
+                .filter_map(|row| {
+                    row.into_iter().next().map(|v| match v {
+                        serde_json::Value::String(s) => s,
+                        other => other.to_string(),
+                    })
                 })
-            })
-            .collect();
+                .collect()
+        };
         let sql = format!(
             "DELETE FROM {table} WHERE {pk} = ANY($1::text[])",
             table = table,
@@ -4085,6 +4106,54 @@ fn put_embedding_state_literal_rows() {
         }
         Err(e) => panic!("translate failed: {}", e),
     }
+}
+
+#[test]
+fn rm_embedding_state_param_batch() {
+    // `?[qn] <- $qns :rm embedding_state {qualified_name}` — parameterized
+    // delete for QNs that may contain quotes/backslashes.
+    let mut p = BTreeMap::new();
+    p.insert(
+        "qns".into(),
+        serde_json::json!([["qn/a"], ["qn\"with\"quote"], ["qn\\backslash"]]),
+    );
+    let t = translate(
+        r#"?[qualified_name] <- $qns :rm embedding_state {qualified_name}"#,
+        p,
+    )
+    .unwrap();
+    assert!(
+        t.sql
+            .contains("DELETE FROM embedding_state WHERE \"qualified_name\" = ANY($1::text[])"),
+        "got: {}",
+        t.sql
+    );
+}
+
+#[test]
+fn put_embedding_state_large_batch_preserves_row_count() {
+    // The indexer marks up to UPSERT_CHUNK (500) qualified_names per `:put`.
+    // A translator bug that drops or duplicates a row in a large VALUES list
+    // would surface as PG E21000 (duplicate PK) or a wrong row count. Build
+    // 500 distinct QNs and assert the SQL keeps all 500.
+    let rows: Vec<String> = (0..500)
+        .map(|i| format!("[\"qn_{i}\", 0, \"\", \"stale\", \"0\"]"))
+        .collect();
+    let values = rows.join(", ");
+    let query = format!(
+        "?[qualified_name, usearch_key, content_hash, state, embedded_at] <- [{values}]\n:put embedding_state {{qualified_name, usearch_key, content_hash, state, embedded_at}}"
+    );
+    let t = translate(&query, BTreeMap::new()).unwrap();
+    // 500 rows × 5 cols = 2500 params. If the translator dropped or merged
+    // a row, this count would be off and a re-write would E21000.
+    assert_eq!(
+        t.params.len(),
+        2500,
+        "500-row :put must yield 2500 params, got: {}",
+        t.params.len()
+    );
+    let row_count = t.params.len() / 5;
+    assert_eq!(row_count, 500, "500 rows expected, got {}", row_count);
 }
 
 #[test]

--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -416,6 +416,7 @@ fn collect_incremental_dirty_work(
         let total = graph.count_elements().unwrap_or(0);
         let mut offset = 0usize;
         let page_size = 5_000usize;
+        let mut seen_qns: std::collections::HashSet<String> = std::collections::HashSet::new();
         loop {
             if crate::embeddings::control::is_cancel_requested() {
                 return Err("embed cancelled".into());
@@ -430,6 +431,14 @@ fn collect_incremental_dirty_work(
                     continue;
                 }
                 if !element_passes_type_filter(&el, opts) {
+                    continue;
+                }
+                // code_elements can carry the same QN many times (e.g. 171
+                // copies of a minified `vis-network.min.js::constructor`).
+                // The live-HNSW `:put embedding_vectors` emits ONE statement
+                // per batch; duplicate QNs in one VALUES list fail with PG
+                // E21000. Mirror the Full-path dedupe (build.rs:507).
+                if !seen_qns.insert(el.qualified_name.clone()) {
                     continue;
                 }
                 if let Some(item) = work_item_from_element(&el) {
@@ -1484,16 +1493,15 @@ fn remove_vectors(
 fn count_vectors(
     db: &dyn crate::db::backend::DbBackend,
 ) -> Result<usize, Box<dyn std::error::Error>> {
-    // ponytail: the attribute syntax `*embedding_vectors{qualified_name}` is
-    // not yet handled by the translator (Phase 5 inventory risk 8). On
-    // Postgres the call will surface a translate error; on Cozo the
-    // CozoBackend still executes the script unchanged. Replace with the
-    // LIMIT 1 EXISTS check once the translator learns attribute syntax.
-    let result = db.run_script(
-        "?[qualified_name] := *embedding_vectors{qualified_name}",
-        Default::default(),
-    )?;
-    Ok(result.rows.len())
+    // Aggregate COUNT instead of pulling every QN row (628k+ on workspace-be)
+    // into memory just to count. Attribute syntax `*embedding_vectors{qn}`
+    // is handled by the translator, but COUNT is far cheaper here.
+    let result = db.run_script("?[count(qn)] := *embedding_vectors[qn]", Default::default())?;
+    Ok(result
+        .rows
+        .first()
+        .and_then(|r| r.first().and_then(|v| v.get_int()))
+        .unwrap_or(0) as usize)
 }
 
 /// Configuration for the in-process background embed used by mcp-http

--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -1477,15 +1477,16 @@ fn remove_vectors(
     }
     let chunk_size = effective_upsert_chunk();
     for chunk in qns.chunks(chunk_size) {
-        let literals: Vec<String> = chunk
+        // Parameterized `:rm` — avoids the inline-literal escaping bug for
+        // QNs with `"`/`\`/control chars (see delete_state_rows).
+        let rows: Vec<serde_json::Value> = chunk
             .iter()
-            .map(|qn| format!("[{}]", serde_json::Value::String(qn.clone())))
+            .map(|qn| serde_json::Value::Array(vec![serde_json::Value::String(qn.clone())]))
             .collect();
-        let values_clause = literals.join(", ");
-        let query = format!(
-            r#"?[qualified_name] <- [{values_clause}] :rm embedding_vectors {{qualified_name}}"#
-        );
-        db.run_script(&query, Default::default())?;
+        let mut params = std::collections::BTreeMap::new();
+        params.insert("qns".to_string(), serde_json::Value::Array(rows));
+        let query = r#"?[qualified_name] <- $qns :rm embedding_vectors {qualified_name}"#;
+        db.run_script(query, params)?;
     }
     Ok(())
 }

--- a/src/embeddings/state.rs
+++ b/src/embeddings/state.rs
@@ -220,10 +220,16 @@ pub fn mark_stale_for_qualified_names(
     if qualified_names.is_empty() {
         return Ok(());
     }
+    // Dedupe: a single `:put` with two rows for the same PK fails with
+    // E21000 ("ON CONFLICT DO UPDATE command cannot affect row a second
+    // time"). The indexer can hand us the same qualified_name twice (e.g.
+    // host-path + workspace-path copies of the same file).
     let now = now_iso();
+    let mut seen = std::collections::HashSet::with_capacity(qualified_names.len());
     for chunk in qualified_names.chunks(UPSERT_CHUNK) {
         let rows: Vec<String> = chunk
             .iter()
+            .filter(|qn| seen.insert(qn.to_string()))
             .map(|qn| {
                 // usearch_key column is now legacy (CozoDB HNSW keys on
                 // qualified_name directly). Stored as 0 for schema-compat.
@@ -539,5 +545,48 @@ mod tests {
         )
         .unwrap();
         assert!(has_any(db.as_ref()).unwrap());
+    }
+
+    #[test]
+    fn mark_stale_dedupes_duplicate_qualified_names() {
+        // Regression: duplicate qualified_names in one call must not emit a
+        // `:put` with two rows for the same PK (E21000 on PG).
+        use crate::db::backend::PostgresBackend;
+        let Ok(db) = PostgresBackend::from_env() else {
+            eprintln!("skipping: LEANKG_PG_URL not set");
+            return;
+        };
+        let boxed: Box<dyn crate::db::backend::DbBackend> = Box::new(db);
+        let dupes: Vec<String> = vec![
+            "/dup/qn".to_string(),
+            "/dup/qn".to_string(),
+            "/dup/qn".to_string(),
+            "/other/qn".to_string(),
+        ];
+        // Should not error (no E21000) even though /dup/qn appears 3x.
+        mark_stale_for_qualified_names(boxed.as_ref(), &dupes).expect("dedupe must prevent E21000");
+        // Clean up the rows we inserted.
+        let clean = r#"?[qualified_name] <- [["/dup/qn"], ["/other/qn"]]
+:rm embedding_state {qualified_name}"#;
+        let _ = boxed.run_script(clean, std::collections::BTreeMap::new());
+    }
+
+    #[test]
+    fn mark_stale_many_identical_qns_no_e21000() {
+        // Reproduces the indexer on a real codebase: vis-network.min.js
+        // yields 171 identical qualified_names. A single `:put` with all of
+        // them must not E21000 (dedupe collapses to one row).
+        use crate::db::backend::PostgresBackend;
+        let Ok(db) = PostgresBackend::from_env() else {
+            eprintln!("skipping: LEANKG_PG_URL not set");
+            return;
+        };
+        let boxed: Box<dyn crate::db::backend::DbBackend> = Box::new(db);
+        let dupes: Vec<String> = (0..171).map(|_| "/vis/constructor".to_string()).collect();
+        mark_stale_for_qualified_names(boxed.as_ref(), &dupes)
+            .expect("171 identical qns must not E21000");
+        let clean = r#"?[qualified_name] <- [["/vis/constructor"]]
+:rm embedding_state {qualified_name}"#;
+        let _ = boxed.run_script(clean, std::collections::BTreeMap::new());
     }
 }

--- a/src/embeddings/state.rs
+++ b/src/embeddings/state.rs
@@ -220,37 +220,51 @@ pub fn mark_stale_for_qualified_names(
     if qualified_names.is_empty() {
         return Ok(());
     }
-    // Dedupe: a single `:put` with two rows for the same PK fails with
+    // Dedupe: a single import with two rows for the same PK fails with
     // E21000 ("ON CONFLICT DO UPDATE command cannot affect row a second
     // time"). The indexer can hand us the same qualified_name twice (e.g.
     // host-path + workspace-path copies of the same file).
     let now = now_iso();
     let mut seen = std::collections::HashSet::with_capacity(qualified_names.len());
     for chunk in qualified_names.chunks(UPSERT_CHUNK) {
-        let rows: Vec<String> = chunk
+        // Parameterized import (DataValue) instead of string-interpolating
+        // qualified_names into a Datalog literal. A QN can contain a
+        // double-quote / backslash / control char (e.g. the minified JS
+        // `vis-network.min.js` extractor or a markdown heading with
+        // `"..."`); a string literal `["qn", ...]` with an unescaped quote
+        // breaks the literal parser, which mis-parses rows and can merge two
+        // distinct QNs into one duplicate PK → E21000. import_relations skips
+        // script parsing entirely (same safe path as upsert_fresh).
+        use crate::db::backend::DataValue;
+        let rows: Vec<Vec<DataValue>> = chunk
             .iter()
             .filter(|qn| seen.insert(qn.to_string()))
             .map(|qn| {
-                // usearch_key column is now legacy (CozoDB HNSW keys on
-                // qualified_name directly). Stored as 0 for schema-compat.
-                let key_i64: i64 = 0;
-                format!(
-                    "[{}, {}, {}, {}, {}]",
-                    serde_json::Value::String(qn.clone()),
-                    serde_json::Value::Number(key_i64.into()),
-                    serde_json::Value::String("".to_string()),
-                    serde_json::Value::String("stale".to_string()),
-                    serde_json::Value::String(now.clone()),
-                )
+                vec![
+                    DataValue::Str(qn.as_str().into()),
+                    DataValue::from(0i64),
+                    DataValue::Str("".into()),
+                    DataValue::Str("stale".into()),
+                    DataValue::Str(now.as_str().into()),
+                ]
             })
             .collect();
-        let values_clause = rows.join(", ");
-
-        let query = format!(
-            r#"?[qualified_name, usearch_key, content_hash, state, embedded_at] <- [{values_clause}]
-               :put embedding_state {{qualified_name, usearch_key, content_hash, state, embedded_at}}"#
+        if rows.is_empty() {
+            continue;
+        }
+        let named_rows = crate::db::backend::NamedRows::new(
+            vec![
+                "qualified_name".to_string(),
+                "usearch_key".to_string(),
+                "content_hash".to_string(),
+                "state".to_string(),
+                "embedded_at".to_string(),
+            ],
+            rows,
         );
-        db.run_script(&query, Default::default())?;
+        let mut map = std::collections::BTreeMap::new();
+        map.insert("embedding_state".to_string(), named_rows);
+        db.import_relations(map)?;
     }
     Ok(())
 }
@@ -375,15 +389,25 @@ pub fn delete_state_rows(
         return Ok(());
     }
     for chunk in rows.chunks(UPSERT_CHUNK) {
-        let literals: Vec<String> = chunk
+        // Parameterized `:rm` (`?[qn] <- $qns :rm embedding_state {qualified_name}`)
+        // — a QN with `"`/`\`/control chars breaks the inline `[[...]]`
+        // literal (mis-parses → E21000 or wrong deletes), same as the
+        // stale-mark path.
+        let qns: Vec<serde_json::Value> = chunk
             .iter()
-            .map(|r| format!("[{}]", serde_json::Value::String(r.qualified_name.clone())))
+            .map(|r| serde_json::Value::String(r.qualified_name.clone()))
             .collect();
-        let values_clause = literals.join(", ");
-        let query = format!(
-            r#"?[qualified_name] <- [{values_clause}] :rm embedding_state {{qualified_name}}"#
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "qns".to_string(),
+            serde_json::Value::Array(
+                qns.into_iter()
+                    .map(|q| serde_json::Value::Array(vec![q]))
+                    .collect(),
+            ),
         );
-        db.run_script(&query, Default::default())?;
+        let query = r#"?[qualified_name] <- $qns :rm embedding_state {qualified_name}"#;
+        db.run_script(query, params)?;
     }
     Ok(())
 }
@@ -565,6 +589,21 @@ mod tests {
         ];
         // Should not error (no E21000) even though /dup/qn appears 3x.
         mark_stale_for_qualified_names(boxed.as_ref(), &dupes).expect("dedupe must prevent E21000");
+        // Real indexer shape: UPSERT_CHUNK=500 long-path QNs, all distinct.
+        let big: Vec<String> = (0..500)
+            .map(|i| format!("/Users/linh.doan/work/harvey/freepeak/leankg/tests/load_test_1m_nodes.rs::load_test_fn_{i}"))
+            .collect();
+        mark_stale_for_qualified_names(boxed.as_ref(), &big).expect("500 distinct must not E21000");
+        // Clean up.
+        let clean_qns: Vec<String> = (0..500)
+            .map(|i| format!("/Users/linh.doan/work/harvey/freepeak/leankg/tests/load_test_1m_nodes.rs::load_test_fn_{i}"))
+            .collect();
+        let literals: Vec<String> = clean_qns.iter().map(|q| format!("[\"{}\"]", q)).collect();
+        let clean = format!(
+            "?[qualified_name] <- [{}] :rm embedding_state {{qualified_name}}",
+            literals.join(", ")
+        );
+        let _ = boxed.run_script(&clean, std::collections::BTreeMap::new());
         // Clean up the rows we inserted.
         let clean = r#"?[qualified_name] <- [["/dup/qn"], ["/other/qn"]]
 :rm embedding_state {qualified_name}"#;

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1009,7 +1009,7 @@ pub fn index_files_parallel_with_typed_resolve(
                         skipped
                     );
                 }
-                Err(e) => tracing::warn!("embedding_state stale-mark failed: {}", e),
+                Err(e) => tracing::warn!("embedding_state stale-mark failed: {:?}", e),
             }
         }
     }


### PR DESCRIPTION
## Problem

Two issues on the Postgres (pgvector) backend:

1. **E21000 on embed/index writes** — `embedding_state` / `embedding_vectors` were written via string-interpolated Cozo literals. QNs extracted from minified JS / markdown headings contain double-quotes and backslashes (228k rows on this repo). An unescaped quote in `["qn", 0, "", "stale", "ts"]` breaks the literal parser → rows merge → one `ON CONFLICT` statement gets a duplicate PK → **PG E21000**.
2. **Cozo→SQL translator gaps** for the write shapes those paths use (`:put` without `=>` PK marker on keyed tables, `:rm` on ambiguous `qualified_name`, boolean literal filters, oversized `:rm` batches).

## Fix

- `state.rs mark_stale_for_qualified_names`: string-interpolated `:put` → parameterized `import_relations` (DataValue rows). QN dedupe kept.
- `state.rs delete_state_rows` + `build.rs remove_vectors`: `:rm` literal list → bound `$qns` array.
- `translate.rs rm_script` Shape B: `$param` batch source → `DELETE ... WHERE qn = ANY($1::text[])`.
- `translate.rs`: `:put` keyed-table upsert inference, `:rm` explicit-table priority, boolean-literal filter binding, `::hnsw` m/ef honoring, `count_vectors` COUNT aggregate.
- `schema.sql`: unique index on `api_keys.key_hash` (matches `pk_for_table`).
- Tests for the `$qns :rm`, 500-row `:put`, boolean-literal, and `::hnsw` shapes.

## Verified

- `leankg index` + `embed --wait` on this repo: no E21000, 7682 vectors, orphans reaped.
- 1081 lib tests pass; 3 pre-existing FakeBackend failures (unchanged).
- `mcp_embed` one-call index+embed MCP tool added earlier on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)