### PR TITLE
feat(db): route Postgres writes through priority write bus

### DIFF
--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -26,11 +26,40 @@ pub trait DbBackend: Send + Sync {
         params: BTreeMap<String, serde_json::Value>,
     ) -> Result<NamedRows, Box<dyn std::error::Error>>;
 
+    /// Submit a write through the priority write bus (Slice 4 seam).
+    ///
+    /// Default impl runs inline (same as `run_script`). The PG backend
+    /// overrides to route via [`crate::db::write_bus::WriteBus`] when the
+    /// backend carries one, so tool writes jump embed writes without
+    /// callers having to know which backend they hold. Callers use this
+    /// for tool writes (add_knowledge, add_annotation, ...); reads and
+    /// embed bulk writes keep using `run_script` / `import_relations`.
+    fn submit_write(
+        &self,
+        query: &str,
+        params: BTreeMap<String, serde_json::Value>,
+        _priority: crate::db::write_bus::Priority,
+    ) -> Result<NamedRows, Box<dyn std::error::Error>> {
+        self.run_script(query, params)
+    }
+
     /// Bulk-load named rows into a relation.
     fn import_relations(
         &self,
         data: BTreeMap<String, NamedRows>,
     ) -> Result<(), Box<dyn std::error::Error>>;
+
+    /// Priority variant of `import_relations` for embed bulk writes
+    /// (Slice 5). Default impl runs inline; PG backend overrides to route
+    /// through the bus as `Priority::EmbedWrite` so tool writes can jump
+    /// embed batches.
+    fn submit_import(
+        &self,
+        data: BTreeMap<String, NamedRows>,
+        _priority: crate::db::write_bus::Priority,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.import_relations(data)
+    }
 
     /// Safe-to-log connection URL (password masked).
     fn redacted_url(&self) -> String;
@@ -70,6 +99,11 @@ pub struct PostgresBackend {
     /// `init_db_readonly` semantics on PG. Writes through such a backend
     /// fail at the Postgres layer with a clean error, never silently.
     pub read_only: bool,
+    /// Optional priority write bus (Slice 3). When `Some`, write-classified
+    /// scripts are submitted to the bus (so tool writes jump embed writes).
+    /// When `None` — the current default — writes run inline as before.
+    /// Opt-in to avoid touching every test backend constructor today.
+    pub write_bus: Option<Arc<dyn crate::db::write_bus::WriteBus>>,
 }
 
 /// RAII checked-out connection: returns its client to the pool on drop.
@@ -278,6 +312,7 @@ impl PostgresBackend {
             pool: Arc::new(ClientPool::new(pool_size)),
             ro_pool: Arc::new(ClientPool::new(pool_size)),
             read_only: false,
+            write_bus: None,
         })
     }
 
@@ -768,11 +803,67 @@ impl DbBackend for PostgresBackend {
         PostgresBackend::run_script(self, query, params)
     }
 
+    fn submit_write(
+        &self,
+        query: &str,
+        params: BTreeMap<String, serde_json::Value>,
+        priority: crate::db::write_bus::Priority,
+    ) -> Result<NamedRows, Box<dyn std::error::Error>> {
+        // Route through the priority bus when attached. The bus worker
+        // already runs in a tokio task; `block_in_place` on the sync
+        // `postgres::Client` inside the closure is safe.
+        match &self.write_bus {
+            Some(bus) => {
+                let query = query.to_string();
+                let me = self.clone();
+                let params_clone = params.clone();
+                bus.submit(crate::db::write_bus::WriteJob {
+                    priority,
+                    kind: "tool_write",
+                    run: Box::new(move || {
+                        me.run_script(&query, params_clone)
+                            .map(|_| ())
+                            .map_err(|e| e.to_string())
+                    }),
+                })
+                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+                // Writes are fire-and-forget on the bus; the caller cannot
+                // observe per-row results. Reads still go through run_script.
+                Ok(NamedRows::new(Vec::new(), Vec::new()))
+            }
+            None => self.run_script(query, params),
+        }
+    }
+
     fn import_relations(
         &self,
         data: BTreeMap<String, NamedRows>,
     ) -> Result<(), Box<dyn std::error::Error>> {
         PostgresBackend::import_relations(self, data)
+    }
+
+    fn submit_import(
+        &self,
+        data: BTreeMap<String, NamedRows>,
+        priority: crate::db::write_bus::Priority,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        match &self.write_bus {
+            Some(bus) => {
+                let me = self.clone();
+                let kind = match priority {
+                    crate::db::write_bus::Priority::EmbedWrite => "embed_import",
+                    crate::db::write_bus::Priority::ToolWrite => "tool_import",
+                };
+                bus.submit(crate::db::write_bus::WriteJob {
+                    priority,
+                    kind,
+                    run: Box::new(move || me.import_relations(data).map_err(|e| e.to_string())),
+                })
+                .map_err(|e| -> Box<dyn std::error::Error> { e.into() })?;
+                Ok(())
+            }
+            None => self.import_relations(data),
+        }
     }
 
     fn redacted_url(&self) -> String {
@@ -1164,6 +1255,7 @@ mod tests {
             pool: std::sync::Arc::new(ClientPool::new(1)),
             ro_pool: std::sync::Arc::new(ClientPool::new(1)),
             read_only: false,
+            write_bus: None,
         };
         let err = pg
             .run_script("?[a] := *x[a]", Default::default())
@@ -1329,5 +1421,105 @@ mod tests {
         assert_eq!(s.get_str(), Some("hi"));
         let b = DataValue::Bool(true);
         assert_eq!(b.get_bool(), Some(true));
+    }
+
+    // ------------------------------------------------------------------
+    // Slice 3 — write_bus=None keeps the current direct path (no
+    // regression). With Some(bus), writes route through the bus (Slice 4
+    // wires callers). This test exercises the seam on the bus side: the
+    // closure submitted from a write site runs on the worker.
+    // ------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn write_bus_some_routes_writes_through_worker() {
+        use crate::db::backend::DbBackend;
+        use crate::db::fake::FakeBackend;
+        use crate::db::write_bus::{InProcessWriteBus, Priority, WriteBus, WriteJob};
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        use std::sync::Arc;
+
+        let backend: Arc<dyn DbBackend> = Arc::new(FakeBackend::new());
+        let bus = Arc::new(InProcessWriteBus::default());
+        let executed = Arc::new(AtomicUsize::new(0));
+
+        // The closure body mirrors what Slice 4 will execute from the MCP
+        // tool handlers: translate() + checkout + execute() on the shared
+        // backend. For this RED test, the FakeBackend's run_script on a
+        // `:put` query is what counts.
+        let backend_for_job = backend.clone();
+        let executed_for_job = executed.clone();
+        bus.submit(WriteJob {
+            priority: Priority::ToolWrite,
+            kind: "tool_write",
+            run: Box::new(move || {
+                let q = "?[a] <- [[$a]] :put business_logic { element_qualified: $a }";
+                let mut params = std::collections::BTreeMap::new();
+                params.insert(
+                    "a".to_string(),
+                    serde_json::Value::String("src/lib.rs::foo".to_string()),
+                );
+                backend_for_job
+                    .run_script(q, params)
+                    .map_err(|e| e.to_string())?;
+                executed_for_job.fetch_add(1, Ordering::SeqCst);
+                Ok(())
+            }),
+        })
+        .unwrap();
+
+        // Poll until the worker drains.
+        let mut tries = 0;
+        while executed.load(Ordering::SeqCst) == 0 && tries < 200 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tries += 1;
+        }
+        assert_eq!(
+            executed.load(Ordering::SeqCst),
+            1,
+            "bus-routed write must execute the closure once"
+        );
+        bus.shutdown();
+    }
+
+    // ------------------------------------------------------------------
+    // Slice 4 — trait `submit_write` on PostgresBackend routes via the
+    // bus when one is attached, and falls back to inline `run_script`
+    // when not. We exercise the override path with a dead URL: the bus
+    // path is fire-and-forget so the call returns Ok even though the
+    // inner closure would fail at connect time. The smoke test confirms
+    // the bus is consulted (the override does not short-circuit to
+    // inline run_script, which would surface a connection error).
+    // ------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn submit_write_with_bus_does_not_connect_inline() {
+        use crate::db::backend::DbBackend;
+        use crate::db::write_bus::{InProcessWriteBus, Priority};
+        use std::sync::Arc;
+
+        let mut pg = PostgresBackend {
+            pg_url: "postgres://invalid-host-not-real:1/leankg".into(),
+            pool: std::sync::Arc::new(ClientPool::new(1)),
+            ro_pool: std::sync::Arc::new(ClientPool::new(1)),
+            read_only: false,
+            write_bus: None,
+        };
+        // Same backend with a write bus attached.
+        let bus = Arc::new(InProcessWriteBus::default());
+        pg.write_bus = Some(bus.clone());
+        // Bus path is fire-and-forget → returns Ok without ever touching
+        // the network. Inline run_script on the same backend would fail
+        // with a connection error. This confirms the override routed via
+        // the bus.
+        let q = "?[a] <- [[$a]] :put business_logic { element_qualified: $a }";
+        let mut params = std::collections::BTreeMap::new();
+        params.insert("a".to_string(), serde_json::Value::String("x".into()));
+        let res = pg.submit_write(q, params, Priority::ToolWrite);
+        assert!(
+            res.is_ok(),
+            "submit_write with bus must not error on dead URL (bus is async), got {:?}",
+            res.err()
+        );
+        bus.shutdown();
     }
 }

--- a/src/db/pg/schema.sql
+++ b/src/db/pg/schema.sql
@@ -219,6 +219,13 @@ CREATE INDEX IF NOT EXISTS knowledge_entries_type_index ON knowledge_entries (kn
 CREATE INDEX IF NOT EXISTS knowledge_entries_element_index ON knowledge_entries (element_qualified);
 CREATE INDEX IF NOT EXISTS knowledge_entries_env_index ON knowledge_entries (environment);
 CREATE INDEX IF NOT EXISTS knowledge_entries_author_index ON knowledge_entries (author);
+-- Slice 7 audit (2026-08-06): the only `knowledge_entries` exact-match
+-- path is `id = $id` (update_knowledge / delete_knowledge at db/mod.rs:894
+-- and :rm at 921). Without this index every update/delete is a sequential
+-- scan. The cozo comment notes `id` is "unique per writer" — promote that
+-- intent to a real constraint; it also makes ON CONFLICT (id) DO UPDATE
+-- viable if a future writer ever double-puts.
+CREATE UNIQUE INDEX IF NOT EXISTS knowledge_entries_id_uniq ON knowledge_entries (id);
 
 -- ---------------------------------------------------------------------------
 -- feature_workflow_links — no PK in cozo (composite tuple key), none here.

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -198,6 +198,7 @@ mod tests {
             pool: std::sync::Arc::new(crate::db::backend::ClientPool::new(1)),
             ro_pool: std::sync::Arc::new(crate::db::backend::ClientPool::new(1)),
             read_only: false,
+            write_bus: None,
         }
     }
 

--- a/src/db/write_bus.rs
+++ b/src/db/write_bus.rs
@@ -359,4 +359,124 @@ mod tests {
         assert!(res.is_ok(), "fresh bus must accept a job");
         bus.shutdown();
     }
+
+    // ------------------------------------------------------------------
+    // Slice 1 — closure runs the backend write on the bus worker.
+    // The integration under test: a caller submits a WriteJob whose
+    // closure executes a write against a shared backend (FakeBackend in
+    // tests, PostgresBackend in prod). After submit returns, the worker
+    // must execute the closure exactly once. We assert via a recorder
+    // shared between the closure and the test, mirroring the contract
+    // the MCP tool handlers will rely on once they call submit().
+    // ------------------------------------------------------------------
+
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Arc;
+
+    #[derive(Default)]
+    struct Recorder(Arc<AtomicUsize>);
+
+    impl Recorder {
+        fn bump(&self) {
+            self.0.fetch_add(1, AtomicOrdering::SeqCst);
+        }
+        fn count(&self) -> usize {
+            self.0.load(AtomicOrdering::SeqCst)
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn closure_runs_against_shared_backend() {
+        let bus = InProcessWriteBus::default();
+        let recorder = Recorder::default();
+        let recorder_for_job = Recorder(recorder.0.clone());
+
+        // The "backend write" here is just a counter bump; the real backend
+        // call (run_script on PostgresBackend / FakeBackend) is what callers
+        // put inside the closure. We're testing that the bus executes the
+        // closure on its worker thread exactly once.
+        bus.submit(WriteJob {
+            priority: Priority::ToolWrite,
+            kind: "tool_write",
+            run: Box::new(move || {
+                recorder_for_job.bump();
+                Ok(())
+            }),
+        })
+        .unwrap();
+
+        // Poll until the worker has run the job (avoid fixed sleeps).
+        let mut tries = 0;
+        while recorder.count() == 0 && tries < 100 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tries += 1;
+        }
+        assert_eq!(
+            recorder.count(),
+            1,
+            "closure must run exactly once after submit() returns, got {} after {} polls",
+            recorder.count(),
+            tries
+        );
+        bus.shutdown();
+    }
+
+    // ------------------------------------------------------------------
+    // Slice 2 — priority ordering across queued jobs (the contract MCP
+    // tool writers rely on: an in-flight embed batch cannot starve a
+    // tool write that arrives after). When all jobs are queued ahead of
+    // execution, the highest-priority job runs first.
+    // ------------------------------------------------------------------
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn tool_write_runs_before_buffered_embed_writes() {
+        // The bus worker is single-threaded and serial. Submit several
+        // embed jobs (Priority::EmbedWrite) followed by a tool job
+        // (Priority::ToolWrite). Because all submissions happen before
+        // any closure runs, the worker should pick the tool job first
+        // per the priority heap.
+        let bus = InProcessWriteBus::default();
+        let order: Arc<std::sync::Mutex<Vec<&'static str>>> =
+            Arc::new(std::sync::Mutex::new(Vec::new()));
+
+        for _ in 0..3 {
+            let order = order.clone();
+            bus.submit(WriteJob {
+                priority: Priority::EmbedWrite,
+                kind: "embed",
+                run: Box::new(move || {
+                    order.lock().unwrap().push("embed");
+                    Ok(())
+                }),
+            })
+            .unwrap();
+        }
+        let order_tool = order.clone();
+        bus.submit(WriteJob {
+            priority: Priority::ToolWrite,
+            kind: "tool",
+            run: Box::new(move || {
+                order_tool.lock().unwrap().push("tool");
+                Ok(())
+            }),
+        })
+        .unwrap();
+
+        // Poll until the worker drains.
+        let mut tries = 0;
+        while order.lock().unwrap().len() < 4 && tries < 200 {
+            tokio::time::sleep(std::time::Duration::from_millis(5)).await;
+            tries += 1;
+        }
+        let got = order.lock().unwrap().clone();
+        assert_eq!(got.len(), 4, "all jobs must run, got {got:?}");
+        // The tool write is the only ToolWrite; it must be dequeued first
+        // by the heap even though it was submitted last (FIFO-within-tier
+        // is overridden by priority across tiers).
+        assert_eq!(
+            got[0], "tool",
+            "tool write must run before any buffered embed write, got {got:?}"
+        );
+        bus.shutdown();
+    }
 }


### PR DESCRIPTION
## Summary

Plumb Postgres writes through the existing priority write bus so tool writes jump embed writes without callers having to know which backend they hold.

## Changes

- `DbBackend` trait gains two opt-in methods with inline defaults:
  - `submit_write(query, params, priority)` — for tool writes
  - `submit_import(data, priority)` — for embed bulk imports
- `PostgresBackend` overrides both. When `write_bus: Some(...)`, the closure runs on the bus worker with the requested priority; otherwise it falls back to inline `run_script` / `import_relations` (no behavior change).
- New `write_bus: Option<Arc<dyn WriteBus>>` field on `PostgresBackend`. All existing constructors (`from_env`, schema-test fixtures, run_script-test fixtures) leave it `None`.
- New tests pin the contract:
  - `closure_runs_against_shared_backend` — submitted closures execute on the worker exactly once.
  - `tool_write_runs_before_buffered_embed_writes` — priority ordering across queued jobs.
  - `write_bus_some_routes_writes_through_worker` — bus-routed closure calls the shared backend.
  - `submit_write_with_bus_does_not_connect_inline` — PG override is fire-and-forget; never touches the network on the caller's thread.
- Schema audit: added `UNIQUE INDEX knowledge_entries_id_uniq` (was missing; every `update_knowledge` / `delete_knowledge` was a sequential scan). No speculative indexes — env filters and compound indexes are post-fetch in Rust.

## Not in this PR

- No MCP handler call-site changes. The four tool handlers (`add_knowledge`, `add_annotation`, `add_ontology_concept`, `add_ontology_workflow`) still go through `db::*` shims → inline `run_script`. Flip one at a time so failures stay isolated.
- No embed `import_relations` rewrites. `embeddings/build.rs` still calls `db.import_relations(...)` directly; can opt into `submit_import(..., EmbedWrite)` next.
- Idempotent writes (`ON CONFLICT DO UPDATE` on every relation, eliminating duplicate rows on re-run) — handled in a separate session.

## Test results

- 20/20 tests in touched modules pass (`db::write_bus`, `db::backend`).
- 5 pre-existing failures in `embeddings::build::tests` and `graph::inventory::tests` are container-gated (live PG required); confirmed identical on `main`.

## Verification

```
cargo build --release --lib --features=embeddings   # clean
cargo test --release --lib --features=embeddings -- db::write_bus db::backend
# 20 passed; 0 failed
```