### PR TITLE
feat(setup): add server-side 'leankg setup' pipeline (clone -> index -> embed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,39 @@ leankg mcp-http --port 9699  # HTTP / Docker
 
 Docker MCP: pass **container** paths as `project=` (e.g. `/workspace`), never the host Mac path.
 
+### Server-side setup pipeline (clone -> index -> embed)
+
+`leankg setup` with no flags keeps the legacy client-side behavior (register
+MCP + hooks). Pass pipeline flags to instead clone a list of repos and index
+each one server-side:
+
+```bash
+# Status: print the resolved repo list without running anything
+LEANKG_REPOS="github.com/org/repo-a,github.com/org/repo-b" leankg setup --status
+
+# Clone + index + embed each repo under LEANKG_CLONE_ROOT (default: cwd)
+LEANKG_REPOS="github.com/org/repo-a,github.com/org/repo-b" \
+  LEANKG_GIT_REF=main \
+  LEANKG_CLONE_ROOT=/srv/repos \
+  leankg setup --clone --index --embed
+```
+
+Repo sources:
+
+- `LEANKG_REPOS` — comma-separated `host/namespace` paths to clone.
+- `LEANKG_PROJECT_DIRS` — comma-separated dirs already mounted on disk
+  (skips clone; falls back to indexing what exists when no git token is set).
+
+Env knobs: `LEANKG_GIT_HOST` (default `github.com`), `LEANKG_GIT_REF`
+(default `main`), `LEANKG_CLONE_ROOT` / `CLONE_ROOT`, `LEANKG_ENV` (default
+`local`), git token via `GITLAB_TOKEN` / `GIT_TOKEN` / `GITHUB_TOKEN`.
+Each cloned repo gets a minimal `.leankg/leankg.yaml`, then `leankg index`
+and `leankg embed --wait` run inside it. A `setup.done` marker prevents
+re-runs.
+
+Set `LEANKG_SETUP=1` on `leankg mcp-http` to run the same pipeline once after
+the server binds (spawned as a background task; the server stays healthy).
+
 ### Web UI
 
 UI talks REST (`:8080`), not MCP (`:9699`). Start the API, then the Vite app in `ui-v2/`:

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -654,8 +654,23 @@ pub enum CLICommand {
         /// Name of the repository
         name: String,
     },
-    /// Global setup: configure MCP for all registered repos at once, install Claude hooks and register plugin
-    Setup {},
+    /// Global setup: clone repos -> index -> embed (server-side pipeline),
+    /// or legacy client-side setup (register MCP + Claude hooks) when no
+    /// pipeline flags are given.
+    Setup {
+        /// Clone the repo list (LEANKG_REPOS) into LEANKG_CLONE_ROOT before indexing.
+        #[arg(long)]
+        clone: bool,
+        /// Run the full index per repo dir.
+        #[arg(long)]
+        index: bool,
+        /// Run the embedding build (embed --wait) per repo dir.
+        #[arg(long)]
+        embed: bool,
+        /// Print resolved repo list + registry state without running.
+        #[arg(long)]
+        status: bool,
+    },
     /// Run a shell command with optional RTK-style compression
     Run {
         /// Command to run (e.g., "git status", "cargo test")

--- a/src/main.rs
+++ b/src/main.rs
@@ -39,6 +39,7 @@ mod report;
 mod retrieval;
 mod runtime;
 mod session;
+mod setup;
 mod sources;
 mod watcher;
 mod web;
@@ -322,6 +323,43 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 println!("[READ-ONLY] write tools will be rejected");
             }
             println!();
+
+            // LEANKG_SETUP=1: after the server binds, run the setup pipeline
+            // (clone -> index -> embed) once per boot. Spawned as a background
+            // task so the server stays healthy; the pipeline re-invokes the
+            // `leankg` binary, so this process isn't blocked.
+            let spawn_setup = std::env::var("LEANKG_SETUP")
+                .map(|v| v != "0" && v != "false")
+                .unwrap_or(false);
+            if spawn_setup {
+                let setup_port = port;
+                if crate::setup::setup_done() {
+                    println!("LEANKG_SETUP=1 but setup already done (marker exists), skipping.");
+                } else {
+                    println!("LEANKG_SETUP=1 — scheduling setup after MCP binds...");
+                    tokio::spawn(async move {
+                        // Poll /health until the server is up, then run setup.
+                        for _ in 0..60 {
+                            if reqwest::blocking::Client::new()
+                                .get(format!("http://127.0.0.1:{setup_port}/health"))
+                                .timeout(std::time::Duration::from_secs(2))
+                                .send()
+                                .map(|r| r.status().is_success())
+                                .unwrap_or(false)
+                            {
+                                break;
+                            }
+                            tokio::time::sleep(std::time::Duration::from_secs(2)).await;
+                        }
+                        println!("LEANKG_SETUP: MCP up — running setup pipeline...");
+                        if let Err(e) = crate::setup::run_setup(true, true, true, false) {
+                            eprintln!("LEANKG_SETUP: pipeline failed: {e}");
+                        } else {
+                            println!("LEANKG_SETUP: pipeline complete.");
+                        }
+                    });
+                }
+            }
 
             if let Err(e) = mcp_server.serve_http(port, auth_token, reuse).await {
                 eprintln!("MCP HTTP server error: {}", e);
@@ -1089,9 +1127,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli::CLICommand::StatusRepo { name } => {
             status_repo(&name)?;
         }
-        cli::CLICommand::Setup {} => {
-            setup_global()?;
-            install_claude_hooks()?;
+        cli::CLICommand::Setup {
+            clone,
+            index,
+            embed,
+            status,
+        } => {
+            if clone || index || embed || status {
+                crate::setup::run_setup(clone, index, embed, status)?;
+            } else {
+                // Legacy client-side behavior: register MCP servers + hooks.
+                setup_global()?;
+                install_claude_hooks()?;
+            }
         }
         cli::CLICommand::Run { command, compress } => {
             run_shell_command(&command, compress)?;

--- a/src/setup/mod.rs
+++ b/src/setup/mod.rs
@@ -1,0 +1,592 @@
+//! Server-side setup pipeline: clone repos -> index -> embed.
+//!
+//! Pure Rust, no shell script dependency. The repo list comes from
+//! `LEANKG_PROJECT_DIRS` (comma-separated, already-mounted dirs -> skip
+//! clone) or `LEANKG_REPOS` (comma-separated `host/namespace` paths to
+//! clone). Clone/pull goes through the `git` CLI as a subprocess (git is a
+//! system binary); indexing reuses the `leankg index` CLI and embedding
+//! reuses the `leankg embed --wait` path.
+//!
+//! Trigger: `leankg setup --clone --index --embed` from the CLI, or
+//! `LEANKG_SETUP=1` on `leankg mcp-http` (runs once after the server binds).
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Git host for clone URLs (override via LEANKG_GIT_HOST).
+pub fn git_host() -> String {
+    std::env::var("LEANKG_GIT_HOST")
+        .ok()
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "github.com".to_string())
+}
+
+/// The default clone root. Override via LEANKG_CLONE_ROOT or CLONE_ROOT;
+/// otherwise the current working directory.
+pub fn clone_root() -> PathBuf {
+    std::env::var("LEANKG_CLONE_ROOT")
+        .ok()
+        .or_else(|| std::env::var("CLONE_ROOT").ok())
+        .filter(|v| !v.trim().is_empty())
+        .map(PathBuf::from)
+        .unwrap_or_else(|| std::env::current_dir().unwrap_or_else(|_| PathBuf::from("/app")))
+}
+
+/// The git ref to clone/pull. Override via LEANKG_GIT_REF or GIT_REF.
+pub fn git_ref() -> String {
+    std::env::var("LEANKG_GIT_REF")
+        .ok()
+        .or_else(|| std::env::var("GIT_REF").ok())
+        .filter(|v| !v.trim().is_empty())
+        .unwrap_or_else(|| "main".to_string())
+}
+
+/// Resolve the git access token from env.
+fn git_token() -> Option<String> {
+    if let Ok(t) = std::env::var("GITLAB_TOKEN") {
+        if !t.trim().is_empty() {
+            return Some(t);
+        }
+    }
+    if let Ok(t) = std::env::var("GIT_TOKEN") {
+        if !t.trim().is_empty() {
+            return Some(t);
+        }
+    }
+    std::env::var("GITHUB_TOKEN")
+        .ok()
+        .filter(|t| !t.trim().is_empty())
+}
+
+/// A resolved repo: display name, clone URL, and local clone destination.
+#[derive(Debug, Clone)]
+pub struct RepoSpec {
+    pub name: String,
+    pub url: String,
+    pub dest: PathBuf,
+}
+
+/// Resolve the repo list.
+///
+/// If `LEANKG_PROJECT_DIRS` is set (comma-separated dirs), those are returned
+/// as-is (skip clone). Otherwise `LEANKG_REPOS` (comma-separated
+/// `host/namespace` paths, e.g. `github.com/org/repo`) drives the clone list,
+/// with each repo cloned to `<clone_root>/<namespace>`.
+pub fn resolve_repos() -> Result<Vec<RepoSpec>, Box<dyn std::error::Error>> {
+    if let Ok(dirs) = std::env::var("LEANKG_PROJECT_DIRS") {
+        let root = clone_root();
+        let specs: Vec<RepoSpec> = dirs
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|d| {
+                let dest = PathBuf::from(d);
+                let name = dest
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_else(|| d.to_string());
+                RepoSpec {
+                    name,
+                    url: String::new(), // mounted dirs are not cloned
+                    dest,
+                }
+            })
+            .collect();
+        if !specs.is_empty() {
+            return Ok(specs);
+        }
+    }
+
+    let host = git_host();
+    let root = clone_root();
+    let mut specs = Vec::new();
+    if let Ok(repos) = std::env::var("LEANKG_REPOS") {
+        for entry in repos.split(',').map(str::trim).filter(|s| !s.is_empty()) {
+            let ns: String = if entry.contains('/') {
+                let (o, rest) = entry.split_once('/').expect("split_once");
+                let h = if o.contains('.') { o } else { host.as_str() };
+                format!("{}/{}", h, rest)
+            } else {
+                let owner =
+                    std::env::var("LEANKG_GIT_OWNER").unwrap_or_else(|_| "user".to_string());
+                format!("{}/{}", host, owner) + "/" + entry
+            };
+            specs.push(RepoSpec::new(entry, &format!("https://{}", ns), &root, &ns));
+        }
+    }
+    Ok(specs)
+}
+
+impl RepoSpec {
+    fn new(name: &str, url: &str, root: &Path, subpath: &str) -> Self {
+        Self {
+            name: name.to_string(),
+            url: url.to_string(),
+            dest: root.join(subpath),
+        }
+    }
+}
+
+/// Clone or pull every repo into [`clone_root`]. Returns the list of dirs.
+pub fn clone_repos(specs: &[RepoSpec]) -> Result<Vec<PathBuf>, Box<dyn std::error::Error>> {
+    let token = git_token().ok_or("no git token: set GITLAB_TOKEN, GIT_TOKEN, or GITHUB_TOKEN")?;
+    let ref_name = git_ref();
+    let mut dirs = Vec::with_capacity(specs.len());
+
+    for spec in specs {
+        // LEANKG_PROJECT_DIRS mode: dirs already exist on disk, nothing to clone.
+        if spec.dest.exists() && spec.dest.join(".git").exists() {
+            fetch_and_checkout(&spec.dest, &ref_name)?;
+            dirs.push(spec.dest.clone());
+            continue;
+        }
+
+        let url = spec
+            .url
+            .replace("https://", &format!("https://oauth2:{}@", token));
+        println!(
+            "Cloning {} -> {} (ref={ref_name})",
+            spec.url,
+            spec.dest.display()
+        );
+        let parent = spec
+            .dest
+            .parent()
+            .ok_or_else(|| format!("invalid dest: {}", spec.dest.display()))?;
+        std::fs::create_dir_all(parent)?;
+
+        let status = Command::new("git")
+            .args(["clone", "--depth", "1", "--branch", &ref_name, &url])
+            .arg(&spec.dest)
+            .status();
+        if let Ok(s) = status {
+            if s.success() {
+                dirs.push(spec.dest.clone());
+                continue;
+            }
+        }
+        // Fall back to default-branch clone when the ref doesn't exist.
+        let status = Command::new("git")
+            .args(["clone", "--depth", "1", &url])
+            .arg(&spec.dest)
+            .status()?;
+        if !status.success() {
+            return Err(format!("git clone failed for {}", spec.url).into());
+        }
+        dirs.push(spec.dest.clone());
+    }
+    Ok(dirs)
+}
+
+/// Fetch + checkout the given ref (shallow) into an existing clone.
+fn fetch_and_checkout(dir: &Path, ref_name: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let fetch = Command::new("git")
+        .current_dir(dir)
+        .args(["fetch", "--depth", "1", "origin", ref_name])
+        .status()?;
+    if fetch.success() {
+        let _ = Command::new("git")
+            .current_dir(dir)
+            .args(["checkout", "-q", "FETCH_HEAD"])
+            .status();
+    }
+    Ok(())
+}
+
+/// Write a minimal `.leankg/leankg.yaml` project config for a repo dir.
+pub fn write_project_config(dir: &Path) -> Result<PathBuf, Box<dyn std::error::Error>> {
+    let name = dir
+        .file_name()
+        .map(|n| n.to_string_lossy().to_string())
+        .unwrap_or_else(|| "repo".to_string());
+    let leankg_dir = dir.join(".leankg");
+    std::fs::create_dir_all(&leankg_dir)?;
+    let config_path = leankg_dir.join("leankg.yaml");
+    if config_path.exists() {
+        return Ok(config_path);
+    }
+    let yaml = format!(
+        r#"project:
+  name: "{name}"
+  root: .
+  project_path: "{path}"
+  languages:
+    - go
+    - typescript
+    - python
+    - java
+    - kotlin
+    - rust
+mcp:
+  enabled: true
+  auto_index_on_start: true
+  auto_index_threshold_minutes: 60
+  auto_index_on_db_write: false
+  require_git_for_auto_index: false
+indexer:
+  exclude:
+    - "**/node_modules/**"
+    - "**/vendor/**"
+  include:
+    - "*.go"
+    - "*.ts"
+    - "*.tsx"
+    - "*.js"
+    - "*.py"
+    - "*.java"
+    - "*.kt"
+    - "*.rs"
+"#,
+        name = name,
+        path = dir.display(),
+    );
+    std::fs::write(&config_path, yaml)?;
+    Ok(config_path)
+}
+
+/// Re-invoke the `leankg` binary for a subcommand inside a repo dir.
+///
+/// Reuses the exact CLI path for `index` and `embed` without duplicating the
+/// orchestration that lives in `main.rs`. Returns the exit status.
+fn run_leankg_sub(dir: &Path, args: &[&str]) -> Result<(), Box<dyn std::error::Error>> {
+    let status = Command::new("leankg")
+        .current_dir(dir)
+        .args(args)
+        .status()
+        .map_err(|e| format!("failed to spawn `leankg {}`: {e}", args.join(" ")))?;
+    if !status.success() {
+        return Err(format!(
+            "`leankg {}` exited {:?} in {}",
+            args.join(" "),
+            status.code(),
+            dir.display()
+        )
+        .into());
+    }
+    Ok(())
+}
+
+/// Full index (delete-then-insert via the CLI) for a repo dir. Returns the
+/// number of elements indexed, or None when the count isn't surfaced.
+pub fn index_one(
+    dir: &Path,
+    env: &str,
+    verbose: bool,
+) -> Result<Option<usize>, Box<dyn std::error::Error>> {
+    let mut args = vec!["index", "."];
+    if verbose {
+        args.push("--verbose");
+    }
+    if !env.is_empty() {
+        args.push("--env");
+        args.push(env);
+    }
+    run_leankg_sub(dir, &args)?;
+    Ok(None)
+}
+
+/// Run `leankg embed --wait --project <dir>` for a repo dir. Blocking; shares
+/// the `.leankg` project config written above.
+pub fn embed_one(dir: &Path) -> Result<(), Box<dyn std::error::Error>> {
+    run_leankg_sub(dir, &["embed", "--wait", "--project", "."])
+}
+
+/// Full setup pipeline for a list of dirs.
+pub fn run_setup(
+    do_clone: bool,
+    do_index: bool,
+    do_embed: bool,
+    status_only: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let specs = resolve_repos()?;
+
+    if status_only || !(do_clone || do_index || do_embed) {
+        println!("=== leankg setup --status ===");
+        for spec in &specs {
+            let state = if spec.dest.exists() {
+                "exists"
+            } else {
+                "missing"
+            };
+            println!(
+                "  {} | {} | {} ({state})",
+                spec.name,
+                spec.url,
+                spec.dest.display()
+            );
+        }
+        return Ok(());
+    }
+
+    let dirs: Vec<PathBuf> = if do_clone {
+        match clone_repos(&specs) {
+            Ok(d) => d,
+            Err(e) if std::env::var("LEANKG_PROJECT_DIRS").is_ok() => {
+                // No git token but dirs are mounted — fall back to indexing
+                // whatever already exists on disk (skip clone).
+                println!("WARN: clone skipped ({e}); using mounted dirs only.");
+                specs.iter().map(|s| s.dest.clone()).collect()
+            }
+            Err(e) => return Err(e),
+        }
+    } else {
+        specs.iter().map(|s| s.dest.clone()).collect()
+    };
+
+    let env = std::env::var("LEANKG_ENV").unwrap_or_else(|_| "local".to_string());
+    let mut registry = crate::registry::Registry::load()?;
+    let mut processed = 0usize;
+
+    for dir in &dirs {
+        if !dir.exists() {
+            println!("WARN: {} does not exist, skipping", dir.display());
+            continue;
+        }
+        processed += 1;
+        let name = dir
+            .file_name()
+            .map(|n| n.to_string_lossy().to_string())
+            .unwrap_or_else(|| "repo".to_string());
+
+        let config_path = write_project_config(dir)?;
+        println!("=== {name}: config {} ===", config_path.display());
+
+        if do_index {
+            println!("=== {name}: index ===");
+            match index_one(dir, &env, true) {
+                Ok(_) => {
+                    let _ = registry.register(name.clone(), dir.display().to_string());
+                }
+                Err(e) => {
+                    println!("WARN: index failed for {name}: {e}");
+                }
+            }
+        }
+
+        if do_embed {
+            println!("=== {name}: embed ===");
+            if let Err(e) = embed_one(dir) {
+                println!("WARN: embed failed for {name}: {e}");
+            }
+        }
+    }
+
+    if processed == 0 && (do_index || do_embed || do_clone) {
+        return Err(format!(
+            "no project dirs found (clone_root={}, LEANKG_PROJECT_DIRS={:?}, LEANKG_REPOS={:?}); \
+             set LEANKG_PROJECT_DIRS to mounted dirs or LEANKG_REPOS to a repo list",
+            clone_root().display(),
+            std::env::var("LEANKG_PROJECT_DIRS").unwrap_or_default(),
+            std::env::var("LEANKG_REPOS").unwrap_or_default()
+        )
+        .into());
+    }
+
+    // Record the run marker so the post-bind trigger only runs once.
+    // Soft-fail: an unwritable clone root must not abort a successful index/embed.
+    let marker = clone_root().join(".leankg").join("setup.done");
+    if let Some(parent) = marker.parent() {
+        match std::fs::create_dir_all(parent)
+            .and_then(|_| std::fs::write(&marker, env::now_rfc3339()))
+        {
+            Ok(()) => println!("Setup marker written: {}", marker.display()),
+            Err(e) => println!(
+                "WARN: could not write setup marker {}: {e}",
+                marker.display()
+            ),
+        }
+    }
+    Ok(())
+}
+
+/// Whether the setup pipeline has already completed for this clone root.
+pub fn setup_done() -> bool {
+    clone_root().join(".leankg").join("setup.done").exists()
+}
+
+mod env {
+    /// RFC3339-ish timestamp (seconds since epoch is fine for a marker).
+    pub fn now_rfc3339() -> String {
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_secs().to_string())
+            .unwrap_or_else(|_| "0".to_string())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialize env-var-mutating tests — `set_var`/`remove_var` are
+    /// process-global and tests run in parallel.
+    fn env_lock() -> &'static Mutex<()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(()))
+    }
+
+    /// Run `f` with the given (var, value) pairs set, restoring the previous
+    /// values after. Sets ALL vars under ONE lock acquisition — `Mutex` is not
+    /// re-entrant, so nested `with_envs` calls deadlock on the same thread.
+    fn with_envs(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
+        let _guard = env_lock().lock().unwrap_or_else(|e| e.into_inner());
+        let mut prev = Vec::with_capacity(vars.len());
+        for (var, value) in vars {
+            prev.push((*var, std::env::var(var).ok()));
+            match value {
+                Some(v) => std::env::set_var(var, v),
+                None => std::env::remove_var(var),
+            }
+        }
+        f();
+        for (var, old) in prev {
+            match old {
+                Some(p) => std::env::set_var(var, p),
+                None => std::env::remove_var(var),
+            }
+        }
+    }
+
+    /// LEANKG_PROJECT_DIRS drives resolve_repos (skip-clone mode).
+    #[test]
+    fn resolve_repos_uses_project_dirs() {
+        with_envs(
+            &[
+                ("LEANKG_PROJECT_DIRS", Some("/a/go-repo,/b/ts-repo")),
+                ("LEANKG_CLONE_ROOT", Some("/")),
+            ],
+            || {
+                let specs = resolve_repos().expect("resolve");
+                assert_eq!(specs.len(), 2);
+                assert_eq!(specs[0].name, "go-repo");
+                assert_eq!(specs[0].dest, PathBuf::from("/a/go-repo"));
+                assert_eq!(specs[1].name, "ts-repo");
+            },
+        );
+    }
+
+    /// LEANKG_REPOS drives clone-mode resolve with host + namespace split.
+    #[test]
+    fn resolve_repos_uses_repo_list() {
+        with_envs(
+            &[
+                ("LEANKG_PROJECT_DIRS", Some("")),
+                (
+                    "LEANKG_REPOS",
+                    Some("github.com/freepeak/leankg,github.com/org/other"),
+                ),
+                ("LEANKG_CLONE_ROOT", Some("/tmp/lkg-clone")),
+                ("LEANKG_GIT_HOST", Some("github.com")),
+            ],
+            || {
+                let specs = resolve_repos().expect("resolve");
+                assert_eq!(specs.len(), 2);
+                assert_eq!(specs[0].name, "github.com/freepeak/leankg");
+                assert_eq!(specs[0].url, "https://github.com/freepeak/leankg");
+                assert_eq!(
+                    specs[0].dest,
+                    PathBuf::from("/tmp/lkg-clone/github.com/freepeak/leankg")
+                );
+            },
+        );
+    }
+
+    /// Empty LEANKG_PROJECT_DIRS + no LEANKG_REPOS falls back to an empty list
+    /// (no baked internal table in the opensource fork).
+    #[test]
+    fn resolve_repos_empty_without_env() {
+        with_envs(
+            &[
+                ("LEANKG_PROJECT_DIRS", None),
+                ("LEANKG_REPOS", None),
+                ("LEANKG_CLONE_ROOT", Some("/tmp/lkg-clone-empty")),
+            ],
+            || {
+                let specs = resolve_repos().expect("resolve");
+                assert!(specs.is_empty());
+            },
+        );
+    }
+
+    /// git_ref / clone_root / git_host env overrides.
+    #[test]
+    fn env_helpers_honor_overrides() {
+        with_envs(
+            &[
+                ("LEANKG_GIT_REF", Some("master")),
+                ("LEANKG_CLONE_ROOT", Some("/srv/repos")),
+                ("LEANKG_GIT_HOST", Some("gitlab.example.com")),
+            ],
+            || {
+                assert_eq!(git_ref(), "master");
+                assert_eq!(clone_root(), PathBuf::from("/srv/repos"));
+                assert_eq!(git_host(), "gitlab.example.com");
+            },
+        );
+    }
+
+    /// Defaults when no overrides.
+    #[test]
+    fn env_helpers_defaults() {
+        with_envs(
+            &[
+                ("LEANKG_GIT_REF", None),
+                ("GIT_REF", None),
+                ("LEANKG_CLONE_ROOT", None),
+                ("CLONE_ROOT", None),
+                ("LEANKG_GIT_HOST", None),
+            ],
+            || {
+                let cwd = std::env::current_dir().expect("cwd");
+                assert_eq!(git_ref(), "main");
+                assert_eq!(clone_root(), cwd);
+                assert_eq!(git_host(), "github.com");
+            },
+        );
+    }
+
+    /// write_project_config creates a .leankg/leankg.yaml with the repo name.
+    #[test]
+    fn write_project_config_creates_yaml() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("be-food-order");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let cfg = write_project_config(&dir).expect("write config");
+        assert!(cfg.exists());
+        let content = std::fs::read_to_string(&cfg).expect("read");
+        assert!(content.contains("be-food-order"), "name missing: {content}");
+        assert!(content.contains("languages"), "no languages block");
+        assert!(content.contains("auto_index_on_start"), "no mcp block");
+    }
+
+    /// write_project_config is idempotent (doesn't overwrite existing).
+    #[test]
+    fn write_project_config_is_idempotent() {
+        let tmp = tempfile::tempdir().expect("tempdir");
+        let dir = tmp.path().join("repo-x");
+        std::fs::create_dir_all(&dir).expect("mkdir");
+        let first = write_project_config(&dir).expect("write");
+        std::fs::write(&first, "sentinel").expect("overwrite");
+        let second = write_project_config(&dir).expect("write again");
+        assert_eq!(first, second);
+        assert_eq!(std::fs::read_to_string(&second).expect("read"), "sentinel");
+    }
+
+    /// setup_done respects the marker.
+    #[test]
+    fn setup_done_reflects_marker() {
+        with_envs(
+            &[("LEANKG_CLONE_ROOT", Some("/tmp/leankg-unit-marker"))],
+            || {
+                let root = clone_root();
+                let _ = std::fs::remove_dir_all(&root);
+                assert!(!setup_done());
+                std::fs::create_dir_all(root.join(".leankg")).expect("mkdir");
+                std::fs::write(root.join(".leankg").join("setup.done"), "1").expect("write marker");
+                assert!(setup_done());
+                let _ = std::fs::remove_dir_all(root);
+            },
+        );
+    }
+}


### PR DESCRIPTION
## What

Ports the `leankg setup` server-side pipeline from the internal `be-knowledge-graph` fork to opensource LeanKG. Adds a `[clone -> index -> embed]` flow that ingests remote repos without a shell script.

## Features

- **`leankg setup [--clone --index --embed --status]`** — with no flags it keeps the legacy client-side behavior (register MCP + hooks).
- **Repo sources (env-driven, no baked internal table):**
  - `LEANKG_REPOS` — comma-separated `host/namespace` paths to clone.
  - `LEANKG_PROJECT_DIRS` — comma-separated dirs already mounted on disk (skips clone; falls back to indexing what exists when no git token is set).
- **Pipeline per repo:** writes a minimal `.leankg/leankg.yaml`, runs `leankg index`, then `leankg embed --wait`. Sets a `setup.done` marker so re-runs are skipped.
- **`LEANKG_SETUP=1`** on `leankg mcp-http` runs the pipeline once after the server binds (spawned as a background task; the server stays healthy).

## Env knobs

`LEANKG_GIT_HOST` (default `github.com`), `LEANKG_GIT_REF` (default `main`), `LEANKG_CLONE_ROOT` / `CLONE_ROOT`, `LEANKG_ENV` (default `local`); git token from `GITLAB_TOKEN` / `GIT_TOKEN` / `GITHUB_TOKEN`.

## Verification

- Release build passes.
- 8 new unit tests in `src/setup/mod.rs` pass (`--bin leankg -- setup::`).
- CLI smoke-tested: `leankg setup --status` resolves project dirs and repos correctly.
- Pre-commit hook (fmt + clippy `-D warnings`) passes.