### PR TITLE
feat(split): sync query-only MCP + worker split

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,16 @@ categories = ["command-line-utilities", "data-structures"]
 [lib]
 crate-type = ["rlib"]
 
+# Query-only MCP (RO) — thin wrapper over leankg mcp-http/mcp-stdio
+[[bin]]
+name = "leankg-mcp"
+path = "src/bin/leankg_mcp.rs"
+
+# Pipeline worker (index / embed / watch / status)
+[[bin]]
+name = "leankg-worker"
+path = "src/bin/leankg_worker.rs"
+
 [features]
 default = ["lang-extras"]
 # Enable vector retrieval + cross-encoder rerank + adaptive KG traversal.

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # LeanKG Makefile
 
-.PHONY: help build test lint run clean mcp-stdio mcp-http mcp-http-auth mcp-http-watch kill docker-build docker-push docker-run docker-reload docker-reload-tag docker-sync-binary docker-pull
+.PHONY: help build test lint run clean mcp-stdio mcp-http mcp-http-auth mcp-http-watch leankg-mcp leankg-worker kill docker-build docker-push docker-run docker-reload docker-reload-tag docker-sync-binary docker-pull
 
 DOCKER_IMAGE ?= freepeak/leankg
 DOCKER_TAG ?= $(shell sed -n 's/^version = "\(.*\)"/\1/p' Cargo.toml | head -1)
@@ -11,12 +11,16 @@ help:
 	@echo "LeanKG Makefile"
 	@echo ""
 	@echo "Targets:"
-	@echo "  build           Build release binary"
+	@echo "  build           Build release binaries (leankg, leankg-mcp, leankg-worker)"
 	@echo "  test            Run tests"
 	@echo "  lint            Run linter"
-	@echo "  run             Run dev (stdio mode)"
+	@echo "  run             Run compat leankg (stdio mode)"
 	@echo "  clean           Clean build artifacts"
 	@echo "  kill            Kill all leankg MCP processes"
+	@echo ""
+	@echo "Split binaries:"
+	@echo "  leankg-mcp      Query-only MCP HTTP (:9699, read-only)"
+	@echo "  leankg-worker   Pipeline: WORKER_CMD=index|embed|watch|status (default: status)"
 	@echo ""
 	@echo "Docker targets:"
 	@echo "  docker-reload    Pull latest Hub image + recreate container (no build)"
@@ -24,20 +28,20 @@ help:
 	@echo "  docker-sync-binary  Build Linux binary + bind-mount onto Hub runtime"
 	@echo "  docker-build    Build freepeak/leankg image (Dockerfile.rocksdb)"
 	@echo "  docker-push     Push freepeak/leankg:VERSION and :latest"
-	@echo "  docker-run      Run with HOST_DIR mounted at /workspace (default: \$$PWD)"
+	@echo "  docker-run      Run with HOST_DIR mounted at /app (default: \$$PWD)"
 	@echo ""
-	@echo "MCP Server targets (HTTP mode):"
-	@echo "  mcp-http        Start MCP HTTP server on port 9699"
+	@echo "MCP Server targets (HTTP mode; prefer leankg-mcp for RO query-only):"
+	@echo "  mcp-http        Start query-only MCP HTTP on port 9699"
 	@echo "  mcp-http-auth   Start MCP HTTP server with auth"
-	@echo "  mcp-http-watch  Start MCP HTTP server with file watcher"
+	@echo "  mcp-http-watch  Start MCP HTTP with file watcher (compat; discouraged for RO)"
 	@echo ""
 	@echo "MCP Server targets (Stdio mode):"
-	@echo "  mcp-stdio       Start MCP stdio server"
-	@echo "  mcp-stdio-watch Start MCP stdio server with file watcher"
+	@echo "  mcp-stdio       Start query-only MCP stdio server"
+	@echo "  mcp-stdio-watch Start MCP stdio with file watcher (compat; discouraged for RO)"
 
-# Build release binary
+# Build release binaries (leankg + leankg-mcp + leankg-worker)
 build:
-	cargo build --release
+	cargo build --release --bins
 
 # Run tests
 test:
@@ -47,47 +51,62 @@ test:
 lint:
 	cargo clippy --all-targets --all-features -- -D warnings
 
-# Run LeanKG (stdio mode for local dev)
+# Run LeanKG compat binary (stdio mode for local dev)
 run:
-	cargo run --release
+	cargo run --release --bin leankg
 
 # Clean build artifacts
 clean:
 	cargo clean
 
-# Kill all leankg processes (HTTP and stdio)
+# Kill all leankg MCP processes (HTTP and stdio)
 kill:
 	pkill -9 -f "leankg.*mcp" 2>/dev/null || true
+	pkill -9 -f "leankg-mcp" 2>/dev/null || true
 	@echo "All leankg MCP processes killed"
 
-# === MCP Stdio Mode ===
+# === Split binaries ===
+
+# Query-only MCP HTTP (read-only; no auto-index / bulk embed)
+leankg-mcp:
+	cargo run --release --bin leankg-mcp -- mcp-http --port 9699
+
+# Pipeline worker. Examples:
+#   make leankg-worker WORKER_CMD="index $(PWD)"
+#   make leankg-worker WORKER_CMD="embed --wait --project $(PWD)"
+#   make leankg-worker WORKER_CMD=status
+WORKER_CMD ?= status
+leankg-worker:
+	cargo run --release --bin leankg-worker -- $(WORKER_CMD)
+
+# === MCP Stdio Mode (query-only via leankg-mcp) ===
 
 mcp-stdio:
-	cargo run --release -- mcp-stdio
+	cargo run --release --bin leankg-mcp -- mcp-stdio
 
 mcp-stdio-watch:
-	cargo run --release -- mcp-stdio --watch
+	cargo run --release --bin leankg -- mcp-stdio --watch
 
-# === MCP HTTP Mode ===
+# === MCP HTTP Mode (query-only via leankg-mcp) ===
 
 mcp-http:
-	cargo run --release -- mcp-http
+	cargo run --release --bin leankg-mcp -- mcp-http
 
 mcp-http-auth:
-	cargo run --release -- mcp-http --auth "$(shell uuidgen 2>/dev/null || echo 'secret-token')"
+	cargo run --release --bin leankg-mcp -- mcp-http --auth "$(shell uuidgen 2>/dev/null || echo 'secret-token')"
 
 mcp-http-watch:
-	cargo run --release -- mcp-http --watch
+	cargo run --release --bin leankg -- mcp-http --watch
 
 # Start on custom port
 mcp-http-port:
 	@read -p "Enter port: " port; \
-	cargo run --release -- mcp-http --port $$port
+	cargo run --release --bin leankg-mcp -- mcp-http --port $$port
 
 # === Development ===
 
 dev:
-	RUST_LOG=debug cargo run --release -- mcp-stdio --watch
+	RUST_LOG=debug cargo run --release --bin leankg-mcp -- mcp-stdio
 
 # === Docker ===
 
@@ -102,11 +121,11 @@ docker-push: docker-build
 	docker push $(DOCKER_IMAGE):latest
 
 # One-line equivalent:
-#   docker run -d --name leankg -p 9699:9699 -v "$$PWD:/workspace" -v leankg-rocksdb:/data/leankg-rocksdb freepeak/leankg:latest
+#   docker run -d --name leankg -p 9699:9699 -v "$$PWD:/app" -v leankg-rocksdb:/data/leankg-rocksdb freepeak/leankg:latest
 docker-run:
 	docker rm -f leankg 2>/dev/null || true
 	docker run -d --name leankg -p 9699:9699 \
-		-v "$(HOST_DIR):/workspace" \
+		-v "$(HOST_DIR):/app" \
 		-v leankg-rocksdb:/data/leankg-rocksdb \
 		$(DOCKER_IMAGE):latest
 	@echo "LeanKG MCP listening on http://localhost:9699 (project: $(HOST_DIR))"
@@ -129,7 +148,7 @@ docker-pull:
 # === Installation ===
 
 install: build
-	sudo cp target/release/leankg /usr/local/bin/
+	sudo cp target/release/leankg target/release/leankg-mcp target/release/leankg-worker /usr/local/bin/
 
 # === macOS LaunchAgent (auto-start on login) ===
 

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -2,6 +2,31 @@
 
 Complete reference for all LeanKG CLI commands.
 
+## Binaries (MCP / worker split)
+
+Same crate, three entrypoints:
+
+| Binary | Surface | Notes |
+|--------|---------|-------|
+| `leankg-mcp` | `mcp-http`, `mcp-stdio` only | **Read-only by default** (`--read-only` forced). Rejects `index` / `embed` / `watch` at parse time. No auto-index or bulk embed. |
+| `leankg-worker` | `index`, `embed`, `watch`, `status` | Pipeline process. Rejects `mcp-http` / `mcp-stdio`. Owns writes + advisory lock. |
+| `leankg` | Full CLI (compat) | Thin facade; prefer split bins in production. |
+
+```bash
+# Query-only MCP (stays up during indexing)
+leankg-mcp mcp-http --port 9699 --project .
+
+# Pipeline (separate process / cron)
+leankg-worker index .
+leankg-worker embed --wait --project .
+leankg-worker watch --path .
+leankg-worker status
+```
+
+Embed provider (worker bulk + MCP query-time): `LEANKG_EMBED_PROVIDER=local|openai`,
+`LEANKG_EMBED_API_BASE_URL`, `LEANKG_EMBED_API_KEY`, `LEANKG_EMBED_API_MODEL`,
+`LEANKG_EMBED_API_DIM` (must be 384). See [deploy-server-with-cold-embed.md](deploy-server-with-cold-embed.md).
+
 ## CLI Commands
 
 | Command | Description |
@@ -65,33 +90,39 @@ leankg init
 # Optional: prefab LSP servers + typed_resolve=go,ts (FR-LSP-B / REL-039)
 leankg init --with-lsp
 
-# 2. Index your codebase
-leankg index ./src
+# 2. Index your codebase (worker or compat)
+leankg-worker index ./src
+# or: leankg index ./src
 
-# 3. Start the MCP server (for AI tools)
-leankg serve
+# 3. Start query-only MCP (for AI tools)
+leankg-mcp mcp-http --port 9699
+# or compat: leankg mcp-http --read-only / leankg serve
 
 # 4. Compute impact radius for a file
 leankg impact src/main.rs --depth 3
 
 # 5. Check index status
-leankg status
+leankg-worker status
+# or: leankg status
 ```
 
 ## Auto-Indexing
 
+Prefer a dedicated worker so MCP can stay query-only:
+
 ```bash
-# Start file watcher -- indexes changes automatically in background
-leankg watch
+# File watcher on the worker (not on leankg-mcp)
+leankg-worker watch
 
 # Incremental indexing -- only re-index changed files (git-based)
-leankg index --incremental
+leankg-worker index --incremental
+# or: leankg index --incremental
 
 # Filter by language
-leankg index --lang go,ts,py,rs,java,kotlin
+leankg-worker index --lang go,ts,py,rs,java,kotlin
 
 # Exclude patterns
-leankg index --exclude vendor,node_modules,dist
+leankg-worker index --exclude vendor,node_modules,dist
 ```
 
 ## Multi-Project Setup (Docker Compose)

--- a/docs/deploy-server-with-cold-embed.md
+++ b/docs/deploy-server-with-cold-embed.md
@@ -1,45 +1,56 @@
 # LeanKG Server Deployment with Cold Embedding
 
-Production deployment of the LeanKG MCP HTTP server with cold (offline) embed
-pipeline. Postgres + pgvector is the single storage engine; offline INT8
-embed runs in a one-shot worker before the long-lived MCP server starts.
+Production deployment of LeanKG as **two processes** against shared Postgres +
+pgvector: a long-lived **query-only MCP** (`leankg-mcp`) and a pipeline
+**worker** (`leankg-worker`) that owns index / cold embed. MCP stays up and
+answers RO queries while the worker indexes or embeds (MVCC; readers are not
+blocked by the index advisory lock).
+
+The compat `leankg` binary still works as a thin facade; prefer the split
+binaries in production.
 
 ## Architecture
 
 ```
-┌──────────────────────────────┐
-│   leankg-embed (one-shot)    │  cold INT8 embed, exits 0 when done
-│   ─ leankg index /workspace  │
-│   ─ leankg embed --wait      │
-└──────────────┬───────────────┘
-               │ writes
+┌──────────────────────────────────┐
+│   leankg-worker (one-shot/cron)  │  index + cold embed (local ONNX or API)
+│   ─ leankg-worker index /app     │
+│   ─ leankg-worker embed --wait   │
+└──────────────┬───────────────────┘
+               │ writes (RW + advisory lock)
                ▼
-┌──────────────────────────────┐    ┌─────────────────────────┐
-│   leankg-mcp (HTTP :9699)    │◀──▶│  leankg-db (pgvector)   │
-│   long-lived, serves MCP     │    │  pgdata volume           │
-└──────────────────────────────┘    └─────────────────────────┘
+┌──────────────────────────────────┐    ┌─────────────────────────┐
+│   leankg-mcp (HTTP :9699)        │◀──▶│  leankg-db (pgvector)   │
+│   query-only, --read-only        │    │  pgdata volume           │
+│   no auto-index / no bulk embed  │    │                          │
+└──────────────────────────────────┘    └─────────────────────────┘
 ```
 
-Two containers, one shared DB volume. The embed worker runs once per index
-cycle (cold start or `--force-reindex`); the MCP server runs continuously.
+| Binary | Role | PG access | Owns |
+|--------|------|-----------|------|
+| `leankg-mcp` | HTTP/stdio MCP, **read-only** | RO pool | Query tools; query-time embed of the search string (+ optional rerank) |
+| `leankg-worker` | Pipeline | RW + `index_advisory_lock` | `index`, `watch`, `embed`, bulk COPY into `embedding_vectors` |
 
-## 1. Build the embed-enabled binary + worker image
+Two containers (or host processes), one shared DB. The worker runs once per
+index cycle (cold start, cron, or git hook); the MCP server runs continuously
+and does **not** stop when the worker runs.
+
+## 1. Build the embed-enabled image
 
 The Hub image `freepeak/leankg:latest` is built without `--features=embeddings`
-(slim). Cold embed requires the embeddings feature. Build the binary
-locally with the feature on, then assemble the slim worker image that
-ships it:
+(slim). Cold local ONNX embed requires the embeddings feature. Build it locally:
 
 ```bash
-cargo build --release --features=embeddings
-mkdir -p .docker-build && cp target/release/leankg .docker-build/leankg
-docker build -f Dockerfile.embed-worker -t freepeak/leankg:embed-worker .
+docker build -f Dockerfile.embed -t freepeak/leankg:embeddings .
 ```
 
-> **Build network note:** the cargo build must reach `deb.debian.org` to
-> fetch `clang`, `libclang-dev`, `libssl-dev` for fastembed. If your build
-> environment blocks these mirrors (e.g. air-gapped, sandboxed), pre-stage
-> the apt cache on the host or use an internal Debian mirror.
+> **Build network note:** Docker build must reach `deb.debian.org` to fetch
+> `clang`, `libclang-dev`, `libssl-dev`. If your build environment blocks
+> these mirrors (e.g. air-gapped, sandboxed), pre-stage the apt cache on
+> the host or use an internal Debian mirror.
+
+For API-only embedding (`LEANKG_EMBED_PROVIDER=openai`), the slim image can
+work without ONNX if query-time and bulk embed both use the HTTP provider.
 
 ## 2. Compose stack
 
@@ -62,31 +73,40 @@ services:
       - ./pg-conf/postgresql.conf:/etc/postgresql/postgresql.conf:ro
     command: ["postgres", "-c", "config_file=/etc/postgresql/postgresql.conf"]
 
-  leankg-embed:
-    # One-shot: runs `leankg index ... && leankg embed --wait`, then exits.
+  leankg-worker:
+    # One-shot: runs index + embed, then exits.
     # Re-run via cron / on git push to refresh the index + re-embed.
+    # MCP stays up the whole time — do not stop leankg-mcp.
     image: freepeak/leankg:embeddings
-    profiles: ["embed"]        # opt-in: `docker compose --profile embed run --rm leankg-embed`
+    profiles: ["embed"]        # opt-in: `docker compose --profile embed run --rm leankg-worker`
     restart: "no"
     depends_on:
       postgres:
         condition: service_healthy
     environment:
       LEANKG_PG_URL: postgresql://postgres:${LEANKG_DB_PASSWORD}@postgres:5432/leankg
+      # Embed provider: local (default, needs embeddings feature) or openai
+      LEANKG_EMBED_PROVIDER: local
+      # LEANKG_EMBED_PROVIDER: openai
+      # LEANKG_EMBED_API_BASE_URL: https://api.openai.com/v1
+      # LEANKG_EMBED_API_KEY: ${LEANKG_EMBED_API_KEY}
+      # LEANKG_EMBED_API_MODEL: text-embedding-3-small
+      # LEANKG_EMBED_API_DIM: "384"   # must equal VEC_DIM
       LEANKG_EMBED_FAST: "1"
       LEANKG_EMBED_MODEL: bge-q
       LEANKG_EMBED_MAX_SEQ: "128"
       LEANKG_EMBED_MAX_MB: "0"     # unlimited on the worker (separate container)
       LEANKG_INSERT_BATCH_SIZE: "20000"
-      MCP_HTTP_PORT: "9699"
     volumes:
-      - ${LEANKG_PROJECT_DIR}:/workspace
+      - ${LEANKG_PROJECT_DIR}:/app
       - ${LEANKG_MODELS_CACHE_DIR}:/root/.cache/leankg
+    # entrypoint examples (override per run):
+    #   leankg-worker index /app
+    #   leankg-worker embed --wait --project /app
 
   leankg-mcp:
-    # Long-lived HTTP MCP server. Embed runs in-process and ARMS on idle.
-    # For deterministic "embed complete before serving", run the embed
-    # worker first (above), then start this service.
+    # Long-lived query-only MCP. No auto-index, no bulk/background embed.
+    # Corpus refresh is owned entirely by leankg-worker.
     image: freepeak/leankg:embeddings
     container_name: leankg-mcp
     restart: unless-stopped
@@ -98,27 +118,24 @@ services:
     mem_limit: 12g
     environment:
       LEANKG_PG_URL: postgresql://postgres:${LEANKG_DB_PASSWORD}@postgres:5432/leankg
-      LEANKG_MCP_PROJECT: /workspace
-      LEANKG_AUTO_INDEX: "0"      # index is owned by leankg-embed worker
-      LEANKG_EMBED_BACKGROUND: "1"
-      LEANKG_EMBED_AUTO_ARM: "1"
+      LEANKG_MCP_PROJECT: /app
+      LEANKG_AUTO_INDEX: "0"           # index owned by leankg-worker
+      LEANKG_EMBED_BACKGROUND: "0"     # bulk embed owned by leankg-worker
+      LEANKG_EMBED_AUTO_ARM: "0"
+      # Query-time embed of the search string (same provider as worker recommended)
+      LEANKG_EMBED_PROVIDER: local
       LEANKG_EMBED_FAST: "1"
       LEANKG_EMBED_MODEL: bge-q
       LEANKG_EMBED_MAX_SEQ: "128"
       LEANKG_EMBED_MAX_BLOB_CHARS: "500"
       LEANKG_EMBED_MAX_MB: "512"
-      LEANKG_EMBED_BACKGROUND_WORKERS: "2"
-      LEANKG_EMBED_BACKGROUND_BATCH: "128"
-      LEANKG_EMBED_IDLE_AFTER_SECS: "30"
-      LEANKG_EMBED_PARTIAL_BATCHES: "4"
-      LEANKG_EMBED_PARTIAL_PAUSE_MS: "500"
       LEANKG_ONTOLOGY_SYNC_ON_BOOT: timeout
       LEANKG_ONTOLOGY_SYNC_TIMEOUT_SECS: "45"
       LEANKG_MCP_TOOL_TIMEOUT_SECS: "300"
-      LEANKG_INSERT_BATCH_SIZE: "20000"
       LEANKG_SERVE_HTTP: "0"
+    command: ["leankg-mcp", "mcp-http", "--port", "9699", "--project", "/app"]
     volumes:
-      - ${LEANKG_PROJECT_DIR}:/workspace
+      - ${LEANKG_PROJECT_DIR}:/app
       - ${LEANKG_MODELS_CACHE_DIR}:/root/.cache/leankg
 
 volumes:
@@ -147,126 +164,140 @@ LEANKG_PROJECT_DIR=/srv/code/be
 LEANKG_MODELS_CACHE_DIR=/srv/leankg/models
 ```
 
+### Embed provider env (worker + MCP query-time)
+
+| Variable | Meaning |
+|----------|---------|
+| `LEANKG_EMBED_PROVIDER` | `local` (default) or `openai` |
+| `LEANKG_EMBED_API_BASE_URL` | OpenAI-compatible base URL (required for `openai`) |
+| `LEANKG_EMBED_API_KEY` | API key (required for `openai`) |
+| `LEANKG_EMBED_API_MODEL` | Model id |
+| `LEANKG_EMBED_API_DIM` | Must equal vector dim **384** or init fails |
+
 ## 3. First bootstrap
 
 ```bash
 # 1. Bring up the DB.
 docker compose up -d postgres
 
-# 2. Cold embed + index. Runs once; exits 0 when both are done.
-docker compose --profile embed run --rm leankg-embed \
-  leankg migrate
-docker compose --profile embed run --rm leankg-embed \
-  leankg index /workspace
-docker compose --profile embed run --rm leankg-embed \
-  leankg embed --init --project /workspace    # downloads models
-docker compose --profile embed run --rm leankg-embed \
-  leankg embed --wait --project /workspace \
+# 2. Cold index + embed via the worker (MCP not required yet).
+docker compose --profile embed run --rm --entrypoint leankg leankg-worker \
+  migrate
+docker compose --profile embed run --rm leankg-worker \
+  leankg-worker index /app
+docker compose --profile embed run --rm leankg-worker \
+  leankg-worker embed --init --project /app    # downloads models (local provider)
+docker compose --profile embed run --rm leankg-worker \
+  leankg-worker embed --wait --project /app \
   --workers 8 --batch-size 128 \
   --types function,method
 
-# 3. Start the long-lived MCP server.
+# 3. Start the long-lived query-only MCP server.
 docker compose up -d leankg-mcp
 curl -fsS http://localhost:9699/health
 ```
 
+Host / local-dev equivalent (no Docker):
+
+```bash
+# Terminal A — query-only MCP (stays up)
+leankg-mcp mcp-http --port 9699 --project /path/to/repo
+
+# Terminal B — pipeline when needed (MCP keeps answering)
+leankg-worker index /path/to/repo
+leankg-worker embed --wait --project /path/to/repo
+```
+
 ## 4. Refresh cycle (cron / git hook)
 
-Cold embed is idempotent but slow (10-60 min on a mega-graph). On the
-production server, run it on a schedule, not on every request:
+Cold embed is idempotent but slow (10-60 min on a mega-graph). Run the
+**worker** on a schedule; leave `leankg-mcp` running:
 
 ```bash
 # /etc/cron.d/leankg-reindex
 # 02:00 daily: full re-index + cold embed. Uses LEANKG_FORCE_REINDEX=1
 # to wipe and rebuild. Set to 0 (or omit) for incremental.
+# Do NOT stop leankg-mcp — RO queries continue during the job.
 0 2 * * *  cd /srv/leankg && \
   LEANKG_FORCE_REINDEX=1 \
-  docker compose --profile embed run --rm leankg-embed \
-    bash -c "leankg index /workspace && leankg embed --wait --project /workspace"
+  docker compose --profile embed run --rm leankg-worker \
+    bash -c "leankg-worker index /app && leankg-worker embed --wait --project /app"
 ```
 
-For git-push triggered refresh, hook the same command in the deploy pipeline.
+For git-push triggered refresh, hook the same worker command in the deploy
+pipeline.
 
-## 4b. Live embed (no server stop)
+## 4b. Live embed (MCP stays up)
 
-On Postgres the RocksDB single-writer constraint is gone. Embedding and
-indexing can run **while the MCP server stays up** — the server and a
-throwaway embed container write the same `embedding_vectors` / tables via
-`LEANKG_PG_URL`, and the index advisory lock is scoped to the `leankg index`
-job (never blocks serving).
-
-The only prerequisite: the image must be built with the embeddings feature
-(`--build-arg LEANKG_FEATURES=embeddings`). Without it, `leankg embed` and
-`embed_control` don't exist in the binary — the compose env
-(`LEANKG_EMBED_BACKGROUND=1`/`AUTO_ARM=1`) silently no-ops.
+On Postgres, embedding and indexing run **while MCP stays up**. The worker
+holds the index advisory lock only for the index job; MCP’s RO pool continues
+to serve `mcp_status` / `search_code` / semantic tools (readers may see slight
+MVCC lag until the worker commits).
 
 ```bash
-# Build the embed-capable image (HTTPS apt mirror — sandbox-safe).
+# Build the embed-capable image if using local ONNX.
 docker build --build-arg LEANKG_FEATURES=embeddings -t freepeak/leankg:embeddings .
 
-# Trigger a cold embed against the live server's PG — server never stops.
-# Models auto-download into the shared model volume on first run.
+# Trigger a cold embed against the live DB — do not restart leankg-mcp.
 docker run --rm --network host \
   -e LEANKG_PG_URL="postgresql://postgres:postgres@localhost:5432/leankg" \
+  -e LEANKG_EMBED_PROVIDER=local \
   -e LEANKG_EMBED_FAST=1 -e LEANKG_EMBED_MODEL=bge-q \
   -e LEANKG_EMBED_MAX_MB=2048 -e LEANKG_EMBED_MAX_BLOB_CHARS=500 \
   -e OMP_NUM_THREADS=1 \
   -v leankg-models:/root/.cache/leankg \
-  --entrypoint leankg freepeak/leankg:embeddings \
-  embed --wait --project /workspace --workers 2 --batch-size 64
-
-# Or trigger in-process on the server itself (no extra container):
-# set LEANKG_EMBED_BACKGROUND=1 + LEANKG_EMBED_AUTO_ARM=1 and the server
-# auto-arms on idle, or call the embed_control MCP tool action=on.
+  --entrypoint leankg-worker freepeak/leankg:embeddings \
+  embed --wait --project /app --workers 2 --batch-size 64
 ```
 
 Verify: `/health` stays `ok` throughout, and
 `SELECT count(*) FROM embedding_vectors` grows.
+
+> **Do not** re-enable `LEANKG_EMBED_BACKGROUND` / `LEANKG_EMBED_AUTO_ARM` on
+> `leankg-mcp` for production refresh — that couples serving to bulk embed.
+> Use `leankg-worker` instead. Compat `leankg mcp-http` without `--read-only`
+> still exists for legacy single-process setups.
 
 ## 5. Why this split works
 
 The old `LEANKG_DOCKER_SETUP=1` entrypoint mode blocks `mcp-http` start on
 embed completion. That ties uptime to embed duration (bad for SLOs).
 
-Splitting into two containers:
+Splitting into two binaries / containers:
 
-| Concern | Worker | Server |
+| Concern | `leankg-worker` | `leankg-mcp` |
 |---|---|---|
-| Index | ✔ | — |
-| Cold embed | ✔ | — |
-| Serve MCP | — | ✔ |
-| Lifecycle | one-shot | long-lived |
+| Index | ✔ | — (RO; no auto-index) |
+| Cold / bulk embed | ✔ | — (query-time embed of search string only) |
+| Serve MCP | — | ✔ (read-only tools) |
+| Lifecycle | one-shot / cron / watch | long-lived |
 | Memory | unlimited | capped (12g) |
 | Restart on edit | yes | no |
 
-The MCP server still embeds in-process for incremental updates
-(`LEANKG_EMBED_BACKGROUND=1` + `LEANKG_EMBED_AUTO_ARM=1`) — it picks up
-newly-indexed elements on idle. Cold embed is the periodic full refresh,
-not the runtime data path.
+MCP never auto-indexes, never file-watch reindexes, and never arms background
+corpus embed. The worker owns those pipelines.
 
 ## 6. Operations
 
-- **Logs:** `docker compose logs -f leankg-mcp` (server) / `... leankg-embed` (worker).
-- **Restart server without losing embeddings:** `docker compose restart leankg-mcp`. Embeds persist in pg.
-- **Schema migrate (rare):** `docker compose --profile embed run --rm leankg-embed leankg migrate`.
-- **Doctor (stale fd / mmap):** `docker compose exec leankg-mcp leankg doctor`.
+- **Logs:** `docker compose logs -f leankg-mcp` (server) / `... leankg-worker` (pipeline).
+- **Restart MCP without losing embeddings:** `docker compose restart leankg-mcp`. Embeds persist in pg.
+- **Schema migrate (rare):** `docker compose --profile embed run --rm --entrypoint leankg leankg-worker migrate` (compat `leankg`; not on `leankg-worker` CLI).
+- **Doctor:** `docker compose exec leankg-mcp leankg doctor`.
 - **Backups:** snapshot `leankg-pgdata` volume. Models cache in `LEANKG_MODELS_CACHE_DIR` is re-downloadable.
+- **Local restart script:** repo `scripts/restart-leankg-mcp.sh` starts MCP with auto-index/embed off; run `leankg-worker` separately for refresh.
 
 ## 7. Multi-project
 
-For multi-repo deployments, mount each project + run worker per project
-sequentially, or run workers in parallel against the same DB (Postgres
-advisory lock prevents concurrent index; embed is multi-writer — the
-server and a throwaway embed container can write `embedding_vectors`
-concurrently against the same Postgres, so no `docker compose stop` is
-needed to refresh embeddings).
+For multi-repo deployments, mount each project + run the worker per project
+sequentially (or parallel workers against the same DB — advisory lock
+serializes concurrent index; embed is multi-writer). Leave MCP running.
 
 ```bash
-docker compose --profile embed run --rm leankg-embed \
-  bash -c 'for p in /workspace /workspace-be; do
-             leankg index "$p"
-             leankg embed --wait --project "$p"
+docker compose --profile embed run --rm leankg-worker \
+  bash -c 'for p in /app /app-be; do
+             leankg-worker index "$p"
+             leankg-worker embed --wait --project "$p"
            done'
 ```
 
-MCP server mounts both projects and serves per-request via `project=` arg.
+MCP mounts both projects and serves per-request via `project=` arg.

--- a/docs/mcp-tools.md
+++ b/docs/mcp-tools.md
@@ -2,6 +2,18 @@
 
 LeanKG exposes a comprehensive set of MCP tools for AI tools to query the knowledge graph.
 
+## Query-only MCP vs pipeline worker
+
+Production runs **two binaries** from the same crate (see [deploy-server-with-cold-embed.md](deploy-server-with-cold-embed.md)):
+
+| Binary | Role |
+|--------|------|
+| `leankg-mcp` | HTTP/stdio MCP, **read-only by default**. Serves query tools only. No auto-index, no file-watch reindex, no bulk/background corpus embed. Mutators are rejected / omitted from `tools/list`. |
+| `leankg-worker` | Owns `index` / `watch` / `embed` (and related pipeline). Writes into shared Postgres + pgvector while MCP stays up. |
+| `leankg` | Compat facade over the same library (all subcommands). Prefer the split bins in production. |
+
+For corpus refresh, invoke the worker separately — do not rely on MCP auto-index or `LEANKG_EMBED_BACKGROUND` on the serving process.
+
 Live registry size is **~81** tools with embeddings (`tools/list`; ~79 without). Prefer-order and redundancy status:
 
 | Prefer-order | Tools |
@@ -117,7 +129,9 @@ Use `get_architecture` to inspect how many calls fall into each bucket once Phas
 
 ## Auto-Initialization
 
-When the MCP server starts without an existing LeanKG project, it automatically initializes and indexes the current directory. This provides a "plug and play" experience for AI tools.
+**Compat / non-RO `leankg mcp-*`:** When the MCP server starts without an existing LeanKG project, it may automatically initialize and index the current directory.
+
+**`leankg-mcp` (query-only / read-only):** Does **not** auto-init or auto-index. Initialize and index with `leankg-worker` (or compat `leankg init` / `leankg index`) before pointing clients at MCP.
 
 ## Procedural ontology (auto-update)
 
@@ -133,8 +147,8 @@ Procedural workflows live in `ontology/workflows.yaml` (plus `concepts.yaml`). F
 
 1. YAML watch during `mcp-http` / `mcp-stdio` / `leankg serve` (debounce `LEANKG_ONTOLOGY_WATCH_DEBOUNCE_MS`, default 1500ms, min 1000)
 2. Docker/boot when `.leankg/ontology_synced` is older than `concepts.yaml` **or** `workflows.yaml` (`LEANKG_ONTOLOGY_SYNC_ON_BOOT`)
-3. After successful index (CLI / MCP / auto-index / UI)
-4. Explicit `ontology_control(action=sync)`
+3. After successful index (`leankg-worker` / compat CLI / non-RO MCP / UI)
+4. Explicit `ontology_control(action=sync)` (write tool — blocked on RO `leankg-mcp`)
 
 **Sync semantics:** YAML is source of truth. Each sync **clears** the `ontology://` layer then batch-inserts, so renames/removals do not leave duplicate workflow steps. Live correction path (wrong steps → edit YAML → watcher → next `kg_trace_workflow`): [`docs/reports/ontology-proc-auto-smoke-2026-07-21.md`](reports/ontology-proc-auto-smoke-2026-07-21.md).
 
@@ -148,14 +162,17 @@ These tools ship only when LeanKG is built with `--features embeddings`. They ad
 |------|-------------|
 | `semantic_search` | Natural-language → functions. HNSW vector retrieve → cross-encoder rerank → **ontology-guided top-down traversal**: high-level seeds (class / doc / workflow / concept) walk *down* to the function nodes that implement the intent, re-ranked by a composite embedding of `"{upper_name}\n{function_blob}"`. Returns a merged, deduplicated function list. Each result carries `source: "direct"` (HNSW + cross-encoder) or `source: "traversed"` (composite-scored), plus `via_upper` / `via_edge` / `hop` for traversed hits. |
 | `kg_semantic_context` | Vector retrieve → rerank → traverse. Best for natural-language questions where keyword search misses (e.g., 'where do we validate access rights'). Returns ranked seed nodes, 1-2 hop additive `traversed[]` neighborhood, **and a `functions[]` array** of composite-scored functions discovered by the same ontology-guided top-down traversal as `semantic_search`. |
-| `embed_control` | US-EMBED-05: arm/disarm in-process day-2 embed when boot FG is off. Actions: `on` (idle-gated Incremental resume, default `mode=partial`), `off` (cooperative cancel), `status` (`mode`, `vectors_existing`, `skipped_fresh`, `armed`/`waiting_idle`/`running`/`paused_yield`). Does not wipe existing RocksDB vectors. |
+| `embed_control` | US-EMBED-05: arm/disarm in-process day-2 embed when boot FG is off (compat / non-RO MCP only). Rejected on query-only `leankg-mcp`. Prefer `leankg-worker embed` for corpus refresh. Actions: `on` / `off` / `status`. |
 
-Setup (one-time):
+Setup (one-time) — run on the **worker**, not inside query-only MCP:
 
 ```bash
-cargo run --release --features embeddings -- embed --init        # pre-download models (~700MB)
-cargo run --release --features embeddings -- embed               # build the embedding index
+cargo run --release --features embeddings --bin leankg-worker -- embed --init   # pre-download models (~700MB)
+cargo run --release --features embeddings --bin leankg-worker -- embed --wait  # build the embedding index
+# or: leankg-worker embed --init / leankg-worker embed --wait
 ```
+
+Provider: `LEANKG_EMBED_PROVIDER=local|openai` plus `LEANKG_EMBED_API_*` when using the HTTP provider (dim must be 384).
 
 Then call from any MCP client:
 
@@ -179,11 +196,20 @@ Behavior notes:
 
 ## Auto-Indexing
 
-When the MCP server starts with an existing LeanKG project, it checks if the index is stale (by comparing git HEAD commit time vs database file modification time). If stale, it automatically runs incremental indexing to ensure AI tools have up-to-date context.
+**Compat / non-RO MCP:** On start with an existing project, the server may check freshness (git HEAD vs DB) and run incremental indexing when `LEANKG_AUTO_INDEX` is enabled.
+
+**`leankg-mcp` (query-only):** Never auto-indexes. Keep `LEANKG_AUTO_INDEX=0` on the MCP process and refresh with:
+
+```bash
+leankg-worker index /path/to/project
+leankg-worker embed --wait --project /path/to/project   # when vectors need refresh
+```
+
+Write tools (`mcp_index`, `mcp_embed`, `embed_control`, ontology mutators, …) are rejected in read-only mode with `"server is in read-only mode"`.
 
 ## Fallback
 
-If the MCP server reports "LeanKG not initialized", manually run `leankg init` in your project directory, then restart the AI tool.
+If the MCP server reports "LeanKG not initialized", run `leankg init` / `leankg-worker index` in your project directory, then restart the AI tool (or reconnect MCP).
 
 ## Path Normalization
 

--- a/src/bin/leankg_mcp.rs
+++ b/src/bin/leankg_mcp.rs
@@ -1,0 +1,14 @@
+//! `leankg-mcp` — query-only MCP server (read-only by default).
+//!
+//! Thin wrapper: parses the MCP-only CLI surface, then re-execs the compat
+//! `leankg` binary with `--read-only` forced so all handlers stay in main.rs.
+
+use clap::Parser;
+use leankg::cli::mcp::McpArgs;
+use leankg::cli::reexec::reexec_leankg;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = McpArgs::parse();
+    let argv = args.command.to_leankg_argv();
+    reexec_leankg(&argv)
+}

--- a/src/bin/leankg_worker.rs
+++ b/src/bin/leankg_worker.rs
@@ -1,0 +1,14 @@
+//! `leankg-worker` — pipeline process (index / embed / watch / status).
+//!
+//! Thin wrapper: parses the worker-only CLI surface, then re-execs the compat
+//! `leankg` binary so indexer/embed handlers stay in main.rs.
+
+use clap::Parser;
+use leankg::cli::reexec::reexec_leankg;
+use leankg::cli::worker::WorkerArgs;
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let args = WorkerArgs::parse();
+    let argv = args.command.to_leankg_argv();
+    reexec_leankg(&argv)
+}

--- a/src/cli/mcp.rs
+++ b/src/cli/mcp.rs
@@ -1,0 +1,128 @@
+//! Query-only MCP CLI surface for the `leankg-mcp` binary.
+//!
+//! Accepts only `mcp-http` / `mcp-stdio` and defaults to read-only.
+
+use clap::{Parser, Subcommand};
+
+use crate::cli::CLICommand;
+
+/// Top-level args for `leankg-mcp`.
+#[derive(Parser, Debug)]
+#[command(name = "leankg-mcp")]
+#[command(version)]
+#[command(about = "LeanKG MCP server (query-only, read-only)")]
+pub struct McpArgs {
+    #[command(subcommand)]
+    pub command: McpCommand,
+}
+
+/// MCP transport subcommands. Pipeline commands (`index`, `embed`, …) are
+/// intentionally absent — use `leankg-worker`.
+#[derive(Subcommand, Debug)]
+pub enum McpCommand {
+    /// Start MCP server with stdio transport
+    McpStdio {
+        /// Enable auto-indexing with file watcher (discouraged on query-only MCP)
+        #[arg(long)]
+        watch: bool,
+        /// Open the database in read-only mode (reject all write tools).
+        /// Defaults to true for `leankg-mcp`.
+        #[arg(long, default_value_t = true)]
+        read_only: bool,
+    },
+    /// Start MCP server with HTTP transport
+    McpHttp {
+        /// Port to listen on (default: 9699)
+        #[arg(long)]
+        port: Option<u16>,
+        /// Bearer token for authentication (optional)
+        #[arg(long)]
+        auth: Option<String>,
+        /// Enable auto-indexing with file watcher (discouraged on query-only MCP)
+        #[arg(long)]
+        watch: bool,
+        /// Reuse existing server if already running
+        #[arg(long)]
+        reuse: bool,
+        /// Project root directory (default: auto-detect from cwd)
+        #[arg(long)]
+        project: Option<String>,
+        /// Open the database in read-only mode (reject all write tools).
+        /// Defaults to true for `leankg-mcp`.
+        #[arg(long, default_value_t = true)]
+        read_only: bool,
+    },
+}
+
+impl McpCommand {
+    /// Map to the shared `CLICommand` used by the compat `leankg` facade.
+    /// Always forces `read_only = true` (product contract for this binary).
+    pub fn into_cli_command(self) -> CLICommand {
+        match self {
+            McpCommand::McpStdio {
+                watch,
+                read_only: _,
+            } => CLICommand::McpStdio {
+                watch,
+                read_only: true,
+            },
+            McpCommand::McpHttp {
+                port,
+                auth,
+                watch,
+                reuse,
+                project,
+                read_only: _,
+            } => CLICommand::McpHttp {
+                port,
+                auth,
+                watch,
+                reuse,
+                project,
+                read_only: true,
+            },
+        }
+    }
+
+    /// Argv tail for re-executing the compat `leankg` binary.
+    pub fn to_leankg_argv(&self) -> Vec<String> {
+        match self {
+            McpCommand::McpStdio { watch, .. } => {
+                let mut v = vec!["mcp-stdio".to_string(), "--read-only".to_string()];
+                if *watch {
+                    v.push("--watch".to_string());
+                }
+                v
+            }
+            McpCommand::McpHttp {
+                port,
+                auth,
+                watch,
+                reuse,
+                project,
+                ..
+            } => {
+                let mut v = vec!["mcp-http".to_string(), "--read-only".to_string()];
+                if let Some(p) = port {
+                    v.push("--port".to_string());
+                    v.push(p.to_string());
+                }
+                if let Some(a) = auth {
+                    v.push("--auth".to_string());
+                    v.push(a.clone());
+                }
+                if *watch {
+                    v.push("--watch".to_string());
+                }
+                if *reuse {
+                    v.push("--reuse".to_string());
+                }
+                if let Some(p) = project {
+                    v.push("--project".to_string());
+                    v.push(p.clone());
+                }
+                v
+            }
+        }
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,6 +1,9 @@
 use clap::{Subcommand, ValueEnum};
 
+pub mod mcp;
+pub mod reexec;
 pub mod shell_runner;
+pub mod worker;
 
 /// Output format for `leankg tags` (currently only `ctags`).
 #[derive(ValueEnum, Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/cli/reexec.rs
+++ b/src/cli/reexec.rs
@@ -1,0 +1,55 @@
+//! Shared helper: re-exec the compat `leankg` binary with a mapped argv.
+//!
+//! Keeps `leankg-mcp` / `leankg-worker` as thin wrappers so all pipeline /
+//! MCP handler logic stays in `src/main.rs` (compat facade).
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// Resolve the sibling `leankg` binary next to the current executable.
+pub fn resolve_leankg_bin() -> Result<PathBuf, String> {
+    let current = std::env::current_exe().map_err(|e| format!("current_exe: {e}"))?;
+    let dir = current
+        .parent()
+        .ok_or_else(|| "current_exe has no parent directory".to_string())?;
+    let candidate = dir.join("leankg");
+    if candidate.is_file() {
+        return Ok(candidate);
+    }
+    // Windows / cargo naming fallbacks
+    let candidate_exe = dir.join("leankg.exe");
+    if candidate_exe.is_file() {
+        return Ok(candidate_exe);
+    }
+    Err(format!(
+        "compat binary not found at {} (build `leankg` alongside this binary)",
+        candidate.display()
+    ))
+}
+
+/// Replace this process with `leankg <argv…>` (Unix `exec`), or spawn+wait
+/// and exit with the child's status when `exec` is unavailable.
+pub fn reexec_leankg(argv: &[String]) -> Result<(), Box<dyn std::error::Error>> {
+    let bin = resolve_leankg_bin()?;
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = Command::new(&bin).args(argv).exec();
+        Err(format!("failed to exec {}: {err}", bin.display()).into())
+    }
+    #[cfg(not(unix))]
+    {
+        use std::process::Stdio;
+        let status = Command::new(&bin)
+            .args(argv)
+            .stdin(Stdio::inherit())
+            .stdout(Stdio::inherit())
+            .stderr(Stdio::inherit())
+            .status()?;
+        if status.success() {
+            Ok(())
+        } else {
+            Err(format!("leankg exited with {status}").into())
+        }
+    }
+}

--- a/src/cli/worker.rs
+++ b/src/cli/worker.rs
@@ -1,0 +1,358 @@
+//! Pipeline CLI surface for the `leankg-worker` binary.
+//!
+//! Owns index / embed / watch / status. MCP transports are intentionally absent.
+
+use clap::{Parser, Subcommand};
+
+use crate::cli::CLICommand;
+
+/// Top-level args for `leankg-worker`.
+#[derive(Parser, Debug)]
+#[command(name = "leankg-worker")]
+#[command(version)]
+#[command(about = "LeanKG pipeline worker (index / embed / watch)")]
+pub struct WorkerArgs {
+    #[command(subcommand)]
+    pub command: WorkerCommand,
+}
+
+/// Worker pipeline subcommands. MCP server commands are rejected at parse time.
+#[derive(Subcommand, Debug)]
+pub enum WorkerCommand {
+    /// Index the codebase
+    Index {
+        /// Path to index
+        path: Option<String>,
+        #[arg(long, short)]
+        incremental: bool,
+        /// Filter by language (e.g., go,ts,py)
+        #[arg(long, short)]
+        lang: Option<String>,
+        /// Exclude patterns (comma-separated)
+        #[arg(long)]
+        exclude: Option<String>,
+        /// Verbose output
+        #[arg(long, short)]
+        verbose: bool,
+        /// Target environment (local, staging, production)
+        #[arg(long, default_value = "local")]
+        env: String,
+        /// Service name for this index
+        #[arg(long)]
+        service_name: Option<String>,
+        /// Version tag for this index (semver or git sha)
+        #[arg(long)]
+        version: Option<String>,
+        /// Source URI for remote indexing
+        #[arg(long)]
+        source: Option<String>,
+        /// Git branch/tag/commit to check out (used with --source git+...)
+        #[arg(long)]
+        ref_name: Option<String>,
+        /// Auth credential for remote sources
+        #[arg(long)]
+        auth: Option<String>,
+        /// Run live A/B benchmark before and after indexing
+        #[arg(long)]
+        benchmark: bool,
+    },
+    /// Build or refresh the embedding index
+    Embed {
+        /// Download the embedding + reranker models to the cache and exit
+        #[arg(long)]
+        init: bool,
+        /// Ignore embedding_state freshness and re-embed every node
+        #[arg(long)]
+        full: bool,
+        /// Override the embedding batch size (default 32)
+        #[arg(long, default_value = "32")]
+        batch_size: usize,
+        /// Project root (defaults to current working directory)
+        #[arg(long, default_value = ".")]
+        project: String,
+        /// Wait for the embed to complete in the foreground
+        #[arg(long)]
+        wait: bool,
+        /// Print progress for an in-flight background embed and exit
+        #[arg(long)]
+        status: bool,
+        /// Cancel an in-flight background embed and exit
+        #[arg(long)]
+        cancel: bool,
+        /// Internal: set by the parent when re-spawning as a background worker
+        #[arg(long, hide = true)]
+        background: bool,
+        /// Number of parallel ONNX inference workers (default 2)
+        #[arg(long, default_value = "2")]
+        workers: usize,
+        /// Comma-separated list of element types to embed
+        #[arg(long, default_value = "")]
+        types: String,
+        /// Run live A/B benchmark measuring semantic search quality
+        #[arg(long)]
+        benchmark: bool,
+    },
+    /// Start file watcher for incremental re-indexing
+    Watch {
+        /// Path to watch (default: project root)
+        #[arg(long)]
+        path: Option<String>,
+        /// Remote source URI (git+https:// or gs://)
+        #[arg(long)]
+        source: Option<String>,
+        /// Ref name for git sources (default: main)
+        #[arg(long)]
+        ref_name: Option<String>,
+        /// Poll interval in seconds (default: 60). Only used with --source
+        #[arg(long, default_value = "60")]
+        interval: u64,
+        /// Auth credential for the remote source
+        #[arg(long)]
+        auth: Option<String>,
+        /// Also run embed after each detected change
+        #[arg(long)]
+        embed: bool,
+    },
+    /// Show index status
+    Status,
+}
+
+impl WorkerCommand {
+    /// Map to the shared `CLICommand` used by the compat `leankg` facade.
+    ///
+    /// `Embed` requires the `embeddings` feature on the compat binary; without
+    /// it this returns an error string instead of a command.
+    pub fn try_into_cli_command(self) -> Result<CLICommand, String> {
+        match self {
+            WorkerCommand::Index {
+                path,
+                incremental,
+                lang,
+                exclude,
+                verbose,
+                env,
+                service_name,
+                version,
+                source,
+                ref_name,
+                auth,
+                benchmark,
+            } => Ok(CLICommand::Index {
+                path,
+                incremental,
+                lang,
+                exclude,
+                verbose,
+                env,
+                service_name,
+                version,
+                source,
+                ref_name,
+                auth,
+                benchmark,
+            }),
+            WorkerCommand::Watch {
+                path,
+                source,
+                ref_name,
+                interval,
+                auth,
+                embed,
+            } => Ok(CLICommand::Watch {
+                path,
+                source,
+                ref_name,
+                interval,
+                auth,
+                embed,
+            }),
+            WorkerCommand::Status => Ok(CLICommand::Status),
+            WorkerCommand::Embed {
+                init,
+                full,
+                batch_size,
+                project,
+                wait,
+                status,
+                cancel,
+                background,
+                workers,
+                types,
+                benchmark,
+            } => {
+                #[cfg(feature = "embeddings")]
+                {
+                    Ok(CLICommand::Embed {
+                        init,
+                        full,
+                        batch_size,
+                        project,
+                        wait,
+                        status,
+                        cancel,
+                        background,
+                        workers,
+                        types,
+                        benchmark,
+                    })
+                }
+                #[cfg(not(feature = "embeddings"))]
+                {
+                    let _ = (
+                        init, full, batch_size, project, wait, status, cancel, background, workers,
+                        types, benchmark,
+                    );
+                    Err(
+                        "embed requires building with `--features embeddings` (compat leankg / leankg-worker)"
+                            .to_string(),
+                    )
+                }
+            }
+        }
+    }
+
+    /// Argv tail for re-executing the compat `leankg` binary.
+    pub fn to_leankg_argv(&self) -> Vec<String> {
+        match self {
+            WorkerCommand::Index {
+                path,
+                incremental,
+                lang,
+                exclude,
+                verbose,
+                env,
+                service_name,
+                version,
+                source,
+                ref_name,
+                auth,
+                benchmark,
+            } => {
+                let mut v = vec!["index".to_string()];
+                if let Some(p) = path {
+                    v.push(p.clone());
+                }
+                if *incremental {
+                    v.push("--incremental".to_string());
+                }
+                if let Some(l) = lang {
+                    v.push("--lang".to_string());
+                    v.push(l.clone());
+                }
+                if let Some(e) = exclude {
+                    v.push("--exclude".to_string());
+                    v.push(e.clone());
+                }
+                if *verbose {
+                    v.push("--verbose".to_string());
+                }
+                v.push("--env".to_string());
+                v.push(env.clone());
+                if let Some(s) = service_name {
+                    v.push("--service-name".to_string());
+                    v.push(s.clone());
+                }
+                if let Some(ver) = version {
+                    v.push("--version".to_string());
+                    v.push(ver.clone());
+                }
+                if let Some(s) = source {
+                    v.push("--source".to_string());
+                    v.push(s.clone());
+                }
+                if let Some(r) = ref_name {
+                    v.push("--ref-name".to_string());
+                    v.push(r.clone());
+                }
+                if let Some(a) = auth {
+                    v.push("--auth".to_string());
+                    v.push(a.clone());
+                }
+                if *benchmark {
+                    v.push("--benchmark".to_string());
+                }
+                v
+            }
+            WorkerCommand::Embed {
+                init,
+                full,
+                batch_size,
+                project,
+                wait,
+                status,
+                cancel,
+                background,
+                workers,
+                types,
+                benchmark,
+            } => {
+                let mut v = vec!["embed".to_string()];
+                if *init {
+                    v.push("--init".to_string());
+                }
+                if *full {
+                    v.push("--full".to_string());
+                }
+                v.push("--batch-size".to_string());
+                v.push(batch_size.to_string());
+                v.push("--project".to_string());
+                v.push(project.clone());
+                if *wait {
+                    v.push("--wait".to_string());
+                }
+                if *status {
+                    v.push("--status".to_string());
+                }
+                if *cancel {
+                    v.push("--cancel".to_string());
+                }
+                if *background {
+                    v.push("--background".to_string());
+                }
+                v.push("--workers".to_string());
+                v.push(workers.to_string());
+                if !types.is_empty() {
+                    v.push("--types".to_string());
+                    v.push(types.clone());
+                }
+                if *benchmark {
+                    v.push("--benchmark".to_string());
+                }
+                v
+            }
+            WorkerCommand::Watch {
+                path,
+                source,
+                ref_name,
+                interval,
+                auth,
+                embed,
+            } => {
+                let mut v = vec!["watch".to_string()];
+                if let Some(p) = path {
+                    v.push("--path".to_string());
+                    v.push(p.clone());
+                }
+                if let Some(s) = source {
+                    v.push("--source".to_string());
+                    v.push(s.clone());
+                }
+                if let Some(r) = ref_name {
+                    v.push("--ref-name".to_string());
+                    v.push(r.clone());
+                }
+                v.push("--interval".to_string());
+                v.push(interval.to_string());
+                if let Some(a) = auth {
+                    v.push("--auth".to_string());
+                    v.push(a.clone());
+                }
+                if *embed {
+                    v.push("--embed".to_string());
+                }
+                v
+            }
+            WorkerCommand::Status => vec!["status".to_string()],
+        }
+    }
+}

--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -55,10 +55,22 @@ use crate::embeddings::build_index;
 // FR-EMBED-FAST: per-worker enum wrapping either the fastembed Embedder
 // (legacy path, hardcoded intra_threads = available_parallelism()) or
 // the DirectEmbedder (ort + tokenizers with controlled intra_threads).
+// OpenAI-compatible / injected providers use `Remote`.
 // The pipeline calls `.embed(&texts)` uniformly through the enum.
 enum EmbedderBackend {
     Direct(DirectEmbedder),
     Fast(Embedder),
+    Remote(std::sync::Arc<dyn crate::embeddings::provider::EmbedProvider>),
+}
+
+impl EmbedderBackend {
+    fn embed(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, String> {
+        match self {
+            EmbedderBackend::Direct(e) => e.embed(texts).map_err(|e| e.to_string()),
+            EmbedderBackend::Fast(e) => e.embed(texts).map_err(|e| e.to_string()),
+            EmbedderBackend::Remote(p) => p.embed_batch(texts).map_err(|e| e.to_string()),
+        }
+    }
 }
 
 /// CozoDB pest parser has stack-depth limits on inline `<~ [...]` literals
@@ -1192,45 +1204,63 @@ pub fn build_index_parallel(
         let work_items = work_items.clone();
         let embedded_count = embedded_count.clone();
         let handle = std::thread::spawn(move || -> Result<(), String> {
-            // Try DirectEmbedder first (no fastembed intra_threads overhead).
-            // Fall back to Embedder if the model cache is missing.
-            // `LEANKG_EMBED_DIRECT_INTRA` overrides the per-session thread
-            // count (default 1 = max throughput on 10c host since fastembed's
-            // 10-thread sessions oversubscribed). Set higher on hosts with
-            // many cores per session.
-            let direct_intra = std::env::var("LEANKG_EMBED_DIRECT_INTRA")
-                .ok()
-                .and_then(|v| v.parse::<usize>().ok())
-                .filter(|n| (1..=128).contains(n))
-                .unwrap_or(1);
-            let backend = if use_direct_embedder {
-                match DirectEmbedder::with_intra_threads(direct_intra) {
-                    Ok(e) => {
-                        tracing::info!(
-                            "worker {}: using DirectEmbedder (intra_threads={})",
-                            w_id,
-                            e.intra_threads()
+            use crate::embeddings::provider::{
+                create_provider_from_env, provider_kind_from_env, ProviderKind,
+            };
+            // Prefer OpenAI-compatible (or other factory) provider when
+            // LEANKG_EMBED_PROVIDER requests it; otherwise keep local ONNX.
+            let backend = match provider_kind_from_env().map_err(|e| e.to_string())? {
+                ProviderKind::OpenAi => {
+                    let p = create_provider_from_env().map_err(|e| e.to_string())?;
+                    tracing::info!(
+                        "worker {}: using remote embed provider ({})",
+                        w_id,
+                        p.name()
+                    );
+                    EmbedderBackend::Remote(p)
+                }
+                ProviderKind::Local => {
+                    // Try DirectEmbedder first (no fastembed intra_threads overhead).
+                    // Fall back to Embedder if the model cache is missing.
+                    // `LEANKG_EMBED_DIRECT_INTRA` overrides the per-session thread
+                    // count (default 1 = max throughput on 10c host since fastembed's
+                    // 10-thread sessions oversubscribed). Set higher on hosts with
+                    // many cores per session.
+                    let direct_intra = std::env::var("LEANKG_EMBED_DIRECT_INTRA")
+                        .ok()
+                        .and_then(|v| v.parse::<usize>().ok())
+                        .filter(|n| (1..=128).contains(n))
+                        .unwrap_or(1);
+                    if use_direct_embedder {
+                        match DirectEmbedder::with_intra_threads(direct_intra) {
+                            Ok(e) => {
+                                tracing::info!(
+                                    "worker {}: using DirectEmbedder (intra_threads={})",
+                                    w_id,
+                                    e.intra_threads()
+                                );
+                                EmbedderBackend::Direct(e)
+                            }
+                            Err(e) => {
+                                // Do not silently fall back — FastEmbedder has historically
+                                // hit ORT "512 by 800" on long code blobs. Surface the
+                                // DirectEmbedder error so ops can `embed --init` / fix cache.
+                                return Err(format!(
+                                    "worker {w_id}: DirectEmbedder init failed ({e}); \
+                                     refusing FastEmbedder fallback (ORT seq_len risk). \
+                                     Run `leankg embed --init` or set LEANKG_EMBED_DIRECT=0 \
+                                     only if you accept that risk."
+                                ));
+                            }
+                        }
+                    } else {
+                        tracing::warn!(
+                            "worker {}: LEANKG_EMBED_DIRECT=0 — using FastEmbedder",
+                            w_id
                         );
-                        EmbedderBackend::Direct(e)
-                    }
-                    Err(e) => {
-                        // Do not silently fall back — FastEmbedder has historically
-                        // hit ORT "512 by 800" on long code blobs. Surface the
-                        // DirectEmbedder error so ops can `embed --init` / fix cache.
-                        return Err(format!(
-                            "worker {w_id}: DirectEmbedder init failed ({e}); \
-                             refusing FastEmbedder fallback (ORT seq_len risk). \
-                             Run `leankg embed --init` or set LEANKG_EMBED_DIRECT=0 \
-                             only if you accept that risk."
-                        ));
+                        EmbedderBackend::Fast(Embedder::new().map_err(|e| e.to_string())?)
                     }
                 }
-            } else {
-                tracing::warn!(
-                    "worker {}: LEANKG_EMBED_DIRECT=0 — using FastEmbedder",
-                    w_id
-                );
-                EmbedderBackend::Fast(Embedder::new().map_err(|e| e.to_string())?)
             };
             // Round-robin shards: this worker takes every Nth shard.
             let shards: Vec<&[WorkItem]> = work_items.chunks(batch_size * n_workers).collect();
@@ -1238,10 +1268,7 @@ pub fn build_index_parallel(
                 for chunk in shard.chunks(batch_size) {
                     wait_for_embed_rss_headroom(max_rss_mb);
                     let texts: Vec<String> = chunk.iter().map(|w| w.blob.clone()).collect();
-                    let vectors = match &backend {
-                        EmbedderBackend::Direct(e) => e.embed(&texts).map_err(|e| e.to_string())?,
-                        EmbedderBackend::Fast(e) => e.embed(&texts).map_err(|e| e.to_string())?,
-                    };
+                    let vectors = backend.embed(&texts)?;
                     for (item, vec) in chunk.iter().zip(vectors.iter()) {
                         let qn = item.qualified_name.clone();
                         let hash = item.current_hash.clone();
@@ -1967,6 +1994,19 @@ pub const EMBEDDING_DIM_CONST: usize = EMBEDDING_DIM;
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn bulk_embed_remote_backend_uses_injected_provider() {
+        use crate::embeddings::provider::{FakeEmbedProvider, VEC_DIM};
+        use std::sync::Arc;
+
+        let backend = EmbedderBackend::Remote(Arc::new(FakeEmbedProvider::new(VEC_DIM)));
+        let texts = vec!["a".into(), "b".into()];
+        let vecs = backend.embed(&texts).expect("remote embed");
+        assert_eq!(vecs.len(), 2);
+        assert_eq!(vecs[0].len(), VEC_DIM);
+        assert_ne!(vecs[0][0], vecs[1][0]);
+    }
 
     #[test]
     fn default_options_batch_size_32() {

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -1,6 +1,9 @@
 //! Embedding-based retrieval for LeanKG.
 //!
-//! Behind the `embeddings` cargo feature. Provides:
+//! The [`provider`] module (trait + OpenAI-compatible HTTP + factory) is
+//! always available so MCP can embed via API without the ONNX stack.
+//!
+//! Behind the `embeddings` cargo feature:
 //! - Text-blob construction for code, ontology, and doc nodes
 //! - fastembed-backed embedding inference (BGE-small-en-v1.5) and reranking
 //!   (bge-reranker-v2-m3)
@@ -12,15 +15,22 @@
 //!
 //! See `EMBEDDINGS.md` in this directory for the module architecture.
 
-#![cfg(feature = "embeddings")]
+pub mod provider;
 
+#[cfg(feature = "embeddings")]
 pub mod build;
+#[cfg(feature = "embeddings")]
 pub mod control;
+#[cfg(feature = "embeddings")]
 pub mod models;
+#[cfg(feature = "embeddings")]
 pub mod runtime;
+#[cfg(feature = "embeddings")]
 pub mod state;
+#[cfg(feature = "embeddings")]
 pub mod text_blob;
 
+#[cfg(feature = "embeddings")]
 #[allow(unused_imports)]
 pub use build::{
     build_index_parallel, embed_max_rss_mb, parse_type_filter, plan_embed_memory,
@@ -28,28 +38,41 @@ pub use build::{
     BackgroundEmbedConfig, BackgroundEmbedHandle, BuildMode, BuildOptions, BuildReport,
     EmbedMemoryPlan,
 };
+#[cfg(feature = "embeddings")]
 #[allow(unused_imports)]
 pub use control::{
     arm_embed, disarm_embed, embed_job_status, embed_resume_preflight, is_armed,
     request_cancel_in_process_embed, resolve_partial_embed_budget_mb,
     should_use_incremental_hnsw_puts, EmbedResumePreflight, PartialEmbedPolicy,
 };
+#[cfg(feature = "embeddings")]
 #[allow(unused_imports)]
 pub use models::{
     cache_dir, init_models, DirectEmbedder, EmbedModelKind, Embedder, InitReport, RerankScore,
     Reranker, RerankerStatus, DEFAULT_EMBEDDING_MODEL, DEFAULT_RERANKER_MODEL, EMBEDDING_DIM,
     MAX_SEQ_LEN,
 };
+#[cfg(feature = "embeddings")]
 #[allow(unused_imports)]
 pub use runtime::{
     embed_fast_enabled, ensure_quantized_onnx, quantized_onnx_available, resolve_embed_runtime,
     EmbedRuntimePlan,
 };
+#[cfg(feature = "embeddings")]
 #[allow(unused_imports)]
 pub use state::{
     count_by_state, create_hnsw_index, delete_state_rows, drop_hnsw_index,
     ensure_embedding_state_table, has_any, list_all, list_orphans, list_stale,
     mark_stale_for_qualified_names, upsert_fresh, EmbeddingStateRow, FreshRow, StateCounts,
 };
+#[cfg(feature = "embeddings")]
 #[allow(unused_imports)]
 pub use text_blob::{build_blob, classify, BlobKind, PERF_TYPE_PRESET};
+
+pub use provider::{
+    create_provider_from_env, embed_query, provider_kind_from_env, validate_provider, EmbedError,
+    EmbedProvider, FakeEmbedProvider, OpenAiCompatibleProvider, ProviderKind, VEC_DIM,
+};
+
+#[cfg(feature = "embeddings")]
+pub use provider::LocalOnnxProvider;

--- a/src/embeddings/provider.rs
+++ b/src/embeddings/provider.rs
@@ -1,0 +1,542 @@
+//! Pluggable embedding providers (local ONNX + OpenAI-compatible HTTP).
+//!
+//! Available without the `embeddings` cargo feature so MCP can call an API
+//! embedder without linking ONNX / fastembed.
+
+use std::sync::Arc;
+use thiserror::Error;
+
+/// Must match `VEC_DIM` / `EMBEDDING_DIM` (pgvector column width).
+pub const VEC_DIM: usize = 384;
+
+#[derive(Debug, Error)]
+pub enum EmbedError {
+    #[error("embedding provider '{name}' reports dimensions={got}, expected {expected}")]
+    DimensionMismatch {
+        name: String,
+        got: usize,
+        expected: usize,
+    },
+    #[error("embedding response dimension mismatch: got {got}, expected {expected}")]
+    ResponseDimensionMismatch { got: usize, expected: usize },
+    #[error("embedding provider config: {0}")]
+    Config(String),
+    #[error("embedding HTTP error: {0}")]
+    Http(String),
+    #[error("embedding provider error: {0}")]
+    Other(String),
+}
+
+/// Abstraction over local ONNX and remote OpenAI-compatible embed APIs.
+pub trait EmbedProvider: Send + Sync {
+    fn name(&self) -> &str;
+    fn dimensions(&self) -> usize;
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedError>;
+}
+
+/// Reject providers whose advertised dimension ≠ `expected_dim` (normally [`VEC_DIM`]).
+pub fn validate_provider(
+    provider: &dyn EmbedProvider,
+    expected_dim: usize,
+) -> Result<(), EmbedError> {
+    let got = provider.dimensions();
+    if got != expected_dim {
+        return Err(EmbedError::DimensionMismatch {
+            name: provider.name().to_string(),
+            got,
+            expected: expected_dim,
+        });
+    }
+    Ok(())
+}
+
+/// Deterministic in-memory provider for tests and injection seams.
+#[derive(Debug, Clone)]
+pub struct FakeEmbedProvider {
+    name: String,
+    dim: usize,
+}
+
+impl FakeEmbedProvider {
+    pub fn new(dim: usize) -> Self {
+        Self {
+            name: "fake".to_string(),
+            dim,
+        }
+    }
+
+    pub fn with_name(name: impl Into<String>, dim: usize) -> Self {
+        Self {
+            name: name.into(),
+            dim,
+        }
+    }
+}
+
+impl EmbedProvider for FakeEmbedProvider {
+    fn name(&self) -> &str {
+        &self.name
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dim
+    }
+
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        Ok(texts
+            .iter()
+            .enumerate()
+            .map(|(i, _)| {
+                let mut v = vec![0.0_f32; self.dim];
+                if self.dim > 0 {
+                    v[0] = (i as f32 + 1.0) / (self.dim as f32);
+                }
+                v
+            })
+            .collect())
+    }
+}
+
+/// OpenAI-compatible `/v1/embeddings` HTTP client (blocking).
+#[derive(Debug, Clone)]
+pub struct OpenAiCompatibleProvider {
+    base_url: String,
+    api_key: String,
+    model: String,
+    dimensions: usize,
+    http: reqwest::blocking::Client,
+}
+
+impl OpenAiCompatibleProvider {
+    pub fn new(
+        base_url: impl Into<String>,
+        api_key: impl Into<String>,
+        model: impl Into<String>,
+        dimensions: usize,
+    ) -> Result<Self, EmbedError> {
+        let http = reqwest::blocking::Client::builder()
+            .timeout(std::time::Duration::from_secs(60))
+            .build()
+            .map_err(|e| EmbedError::Http(e.to_string()))?;
+        Ok(Self {
+            base_url: base_url.into().trim_end_matches('/').to_string(),
+            api_key: api_key.into(),
+            model: model.into(),
+            dimensions,
+            http,
+        })
+    }
+}
+
+impl EmbedProvider for OpenAiCompatibleProvider {
+    fn name(&self) -> &str {
+        "openai"
+    }
+
+    fn dimensions(&self) -> usize {
+        self.dimensions
+    }
+
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        if texts.is_empty() {
+            return Ok(Vec::new());
+        }
+        let url = format!("{}/v1/embeddings", self.base_url);
+        let body = serde_json::json!({
+            "input": texts,
+            "model": self.model,
+        });
+        let resp = self
+            .http
+            .post(&url)
+            .bearer_auth(&self.api_key)
+            .json(&body)
+            .send()
+            .map_err(|e| EmbedError::Http(e.to_string()))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let text = resp.text().unwrap_or_default();
+            return Err(EmbedError::Http(format!("status {status}: {text}")));
+        }
+        let parsed: OpenAiEmbeddingsResponse = resp
+            .json()
+            .map_err(|e| EmbedError::Http(format!("parse response: {e}")))?;
+        let mut data = parsed.data;
+        data.sort_by_key(|d| d.index);
+        let mut out = Vec::with_capacity(data.len());
+        for item in data {
+            if item.embedding.len() != self.dimensions {
+                return Err(EmbedError::ResponseDimensionMismatch {
+                    got: item.embedding.len(),
+                    expected: self.dimensions,
+                });
+            }
+            out.push(item.embedding);
+        }
+        if out.len() != texts.len() {
+            return Err(EmbedError::Other(format!(
+                "expected {} embeddings, got {}",
+                texts.len(),
+                out.len()
+            )));
+        }
+        Ok(out)
+    }
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OpenAiEmbeddingsResponse {
+    data: Vec<OpenAiEmbeddingData>,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct OpenAiEmbeddingData {
+    embedding: Vec<f32>,
+    #[serde(default)]
+    index: usize,
+}
+
+/// Local ONNX / DirectEmbedder wrapper. Only constructed when the
+/// `embeddings` feature is enabled.
+#[cfg(feature = "embeddings")]
+pub struct LocalOnnxProvider {
+    backend: LocalBackend,
+}
+
+#[cfg(feature = "embeddings")]
+enum LocalBackend {
+    Direct(super::models::DirectEmbedder),
+    Fast(super::models::Embedder),
+}
+
+#[cfg(feature = "embeddings")]
+impl LocalOnnxProvider {
+    /// Prefer DirectEmbedder; fall back to fastembed Embedder when
+    /// `LEANKG_EMBED_DIRECT=0`.
+    pub fn new() -> Result<Self, EmbedError> {
+        let use_direct = std::env::var("LEANKG_EMBED_DIRECT")
+            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+            .unwrap_or(true);
+        if use_direct {
+            let intra = std::env::var("LEANKG_EMBED_DIRECT_INTRA")
+                .ok()
+                .and_then(|v| v.parse::<usize>().ok())
+                .filter(|n| (1..=128).contains(n))
+                .unwrap_or(1);
+            match super::models::DirectEmbedder::with_intra_threads(intra) {
+                Ok(e) => {
+                    return Ok(Self {
+                        backend: LocalBackend::Direct(e),
+                    });
+                }
+                Err(e) => {
+                    return Err(EmbedError::Other(format!(
+                        "DirectEmbedder init failed ({e}); run `leankg embed --init` \
+                         or set LEANKG_EMBED_DIRECT=0"
+                    )));
+                }
+            }
+        }
+        let fast = super::models::Embedder::new().map_err(|e| EmbedError::Other(e.to_string()))?;
+        Ok(Self {
+            backend: LocalBackend::Fast(fast),
+        })
+    }
+}
+
+#[cfg(feature = "embeddings")]
+impl EmbedProvider for LocalOnnxProvider {
+    fn name(&self) -> &str {
+        "local"
+    }
+
+    fn dimensions(&self) -> usize {
+        VEC_DIM
+    }
+
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, EmbedError> {
+        match &self.backend {
+            LocalBackend::Direct(e) => e
+                .embed(texts)
+                .map_err(|err| EmbedError::Other(err.to_string())),
+            LocalBackend::Fast(e) => e
+                .embed(texts)
+                .map_err(|err| EmbedError::Other(err.to_string())),
+        }
+    }
+}
+
+/// Read `LEANKG_EMBED_PROVIDER` (`local` | `openai`). Default: `local`.
+pub fn provider_kind_from_env() -> Result<ProviderKind, EmbedError> {
+    match std::env::var("LEANKG_EMBED_PROVIDER") {
+        Err(_) => Ok(ProviderKind::Local),
+        Ok(v) => match v.trim().to_ascii_lowercase().as_str() {
+            "" | "local" | "onnx" => Ok(ProviderKind::Local),
+            "openai" | "api" | "openai-compatible" => Ok(ProviderKind::OpenAi),
+            other => Err(EmbedError::Config(format!(
+                "unknown LEANKG_EMBED_PROVIDER={other:?}; expected local|openai"
+            ))),
+        },
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProviderKind {
+    Local,
+    OpenAi,
+}
+
+/// Build a provider from env.
+///
+/// Env:
+/// - `LEANKG_EMBED_PROVIDER` — `local` (default) or `openai`
+/// - `LEANKG_EMBED_API_BASE_URL` — required for openai (e.g. `http://127.0.0.1:8080`)
+/// - `LEANKG_EMBED_API_KEY` — required for openai
+/// - `LEANKG_EMBED_API_MODEL` — optional (default `bge-small-en-v1.5`)
+/// - `LEANKG_EMBED_API_DIM` — optional (default [`VEC_DIM`])
+pub fn create_provider_from_env() -> Result<Arc<dyn EmbedProvider>, EmbedError> {
+    match provider_kind_from_env()? {
+        ProviderKind::Local => create_local_provider(),
+        ProviderKind::OpenAi => {
+            let provider = openai_provider_from_env()?;
+            validate_provider(provider.as_ref(), VEC_DIM)?;
+            Ok(provider)
+        }
+    }
+}
+
+fn create_local_provider() -> Result<Arc<dyn EmbedProvider>, EmbedError> {
+    #[cfg(feature = "embeddings")]
+    {
+        let p = LocalOnnxProvider::new()?;
+        validate_provider(&p, VEC_DIM)?;
+        Ok(Arc::new(p))
+    }
+    #[cfg(not(feature = "embeddings"))]
+    {
+        Err(EmbedError::Config(
+            "LEANKG_EMBED_PROVIDER=local requires the `embeddings` cargo feature \
+             (or set LEANKG_EMBED_PROVIDER=openai with LEANKG_EMBED_API_*)"
+                .into(),
+        ))
+    }
+}
+
+fn openai_provider_from_env() -> Result<Arc<dyn EmbedProvider>, EmbedError> {
+    let base_url = std::env::var("LEANKG_EMBED_API_BASE_URL").map_err(|_| {
+        EmbedError::Config(
+            "LEANKG_EMBED_API_BASE_URL is required when LEANKG_EMBED_PROVIDER=openai".into(),
+        )
+    })?;
+    let api_key = std::env::var("LEANKG_EMBED_API_KEY").map_err(|_| {
+        EmbedError::Config(
+            "LEANKG_EMBED_API_KEY is required when LEANKG_EMBED_PROVIDER=openai".into(),
+        )
+    })?;
+    if api_key.trim().is_empty() {
+        return Err(EmbedError::Config(
+            "LEANKG_EMBED_API_KEY is required when LEANKG_EMBED_PROVIDER=openai".into(),
+        ));
+    }
+    let model =
+        std::env::var("LEANKG_EMBED_API_MODEL").unwrap_or_else(|_| "bge-small-en-v1.5".to_string());
+    let dimensions = std::env::var("LEANKG_EMBED_API_DIM")
+        .ok()
+        .and_then(|v| v.parse::<usize>().ok())
+        .unwrap_or(VEC_DIM);
+    let p = OpenAiCompatibleProvider::new(base_url, api_key, model, dimensions)?;
+    Ok(Arc::new(p))
+}
+
+/// Embed a single query string via the given provider (query-time path helper).
+pub fn embed_query(provider: &dyn EmbedProvider, query: &str) -> Result<Vec<f32>, EmbedError> {
+    let batch = provider.embed_batch(&[query.to_string()])?;
+    batch
+        .into_iter()
+        .next()
+        .ok_or_else(|| EmbedError::Other("empty embed_batch result for query".into()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Write};
+    use std::net::TcpListener;
+    use std::sync::{Mutex, OnceLock};
+
+    /// Serialize env-mutating factory tests across threads.
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+    }
+
+    #[test]
+    fn fake_provider_rejects_wrong_dimensions_at_validate() {
+        let fake = FakeEmbedProvider::new(768);
+        let err = validate_provider(&fake, VEC_DIM).expect_err("768-dim must fail");
+        match err {
+            EmbedError::DimensionMismatch { got, expected, .. } => {
+                assert_eq!(got, 768);
+                assert_eq!(expected, VEC_DIM);
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn fake_provider_embed_batch_returns_384() {
+        let fake = FakeEmbedProvider::new(VEC_DIM);
+        validate_provider(&fake, VEC_DIM).expect("384-dim ok");
+        let texts = vec!["hello".into(), "world".into()];
+        let vecs = fake.embed_batch(&texts).expect("embed");
+        assert_eq!(vecs.len(), 2);
+        assert_eq!(vecs[0].len(), VEC_DIM);
+        assert_eq!(vecs[1].len(), VEC_DIM);
+    }
+
+    #[test]
+    fn openai_compatible_provider_posts_and_parses_vectors() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 8192];
+            let n = stream.read(&mut buf).unwrap();
+            let req = String::from_utf8_lossy(&buf[..n]);
+            assert!(
+                req.contains("POST /v1/embeddings"),
+                "expected embeddings path, got: {req}"
+            );
+            assert!(req.contains("Bearer test-key"), "missing auth: {req}");
+            assert!(req.contains("\"model\""), "missing model: {req}");
+            assert!(req.contains("hello"), "missing input text: {req}");
+
+            let embedding: Vec<f32> = (0..VEC_DIM).map(|i| i as f32 * 0.001).collect();
+            let body = serde_json::json!({
+                "data": [{ "embedding": embedding, "index": 0 }]
+            });
+            let body_str = body.to_string();
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body_str.len(),
+                body_str
+            );
+            stream.write_all(resp.as_bytes()).unwrap();
+        });
+
+        let provider = OpenAiCompatibleProvider::new(
+            format!("http://{addr}"),
+            "test-key",
+            "bge-small-en-v1.5",
+            VEC_DIM,
+        )
+        .unwrap();
+        validate_provider(&provider, VEC_DIM).unwrap();
+        let vecs = provider
+            .embed_batch(&[String::from("hello")])
+            .expect("embed_batch");
+        assert_eq!(vecs.len(), 1);
+        assert_eq!(vecs[0].len(), VEC_DIM);
+        assert!((vecs[0][1] - 0.001).abs() < 1e-6);
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn openai_compatible_provider_errors_on_dim_mismatch_in_response() {
+        let listener = TcpListener::bind("127.0.0.1:0").expect("bind");
+        let addr = listener.local_addr().unwrap();
+        let handle = std::thread::spawn(move || {
+            let (mut stream, _) = listener.accept().unwrap();
+            let mut buf = [0u8; 8192];
+            let _ = stream.read(&mut buf).unwrap();
+            let body = serde_json::json!({
+                "data": [{ "embedding": [0.1, 0.2, 0.3], "index": 0 }]
+            });
+            let body_str = body.to_string();
+            let resp = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body_str.len(),
+                body_str
+            );
+            stream.write_all(resp.as_bytes()).unwrap();
+        });
+
+        let provider =
+            OpenAiCompatibleProvider::new(format!("http://{addr}"), "k", "m", VEC_DIM).unwrap();
+        let err = provider
+            .embed_batch(&[String::from("x")])
+            .expect_err("3-float response must fail");
+        match err {
+            EmbedError::ResponseDimensionMismatch { got, expected } => {
+                assert_eq!(got, 3);
+                assert_eq!(expected, VEC_DIM);
+            }
+            other => panic!("unexpected: {other}"),
+        }
+        handle.join().unwrap();
+    }
+
+    #[test]
+    fn factory_defaults_to_local_when_unset() {
+        let _g = env_lock();
+        std::env::remove_var("LEANKG_EMBED_PROVIDER");
+        assert_eq!(provider_kind_from_env().unwrap(), ProviderKind::Local);
+    }
+
+    #[test]
+    fn factory_selects_openai_from_env() {
+        let _g = env_lock();
+        std::env::set_var("LEANKG_EMBED_PROVIDER", "openai");
+        std::env::set_var("LEANKG_EMBED_API_BASE_URL", "http://127.0.0.1:9");
+        std::env::set_var("LEANKG_EMBED_API_KEY", "sk-test");
+        std::env::set_var("LEANKG_EMBED_API_MODEL", "bge-small-en-v1.5");
+        let result = create_provider_from_env();
+        std::env::remove_var("LEANKG_EMBED_PROVIDER");
+        std::env::remove_var("LEANKG_EMBED_API_BASE_URL");
+        std::env::remove_var("LEANKG_EMBED_API_KEY");
+        std::env::remove_var("LEANKG_EMBED_API_MODEL");
+        let p = result.expect("openai factory");
+        assert_eq!(p.name(), "openai");
+        assert_eq!(p.dimensions(), VEC_DIM);
+    }
+
+    #[test]
+    fn factory_fails_when_openai_missing_api_key() {
+        let _g = env_lock();
+        std::env::set_var("LEANKG_EMBED_PROVIDER", "openai");
+        std::env::set_var("LEANKG_EMBED_API_BASE_URL", "http://127.0.0.1:9");
+        std::env::remove_var("LEANKG_EMBED_API_KEY");
+        let err = match create_provider_from_env() {
+            Ok(_) => panic!("expected missing key error"),
+            Err(e) => e,
+        };
+        std::env::remove_var("LEANKG_EMBED_PROVIDER");
+        std::env::remove_var("LEANKG_EMBED_API_BASE_URL");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("LEANKG_EMBED_API_KEY"),
+            "expected key error, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn query_embed_uses_provider_from_factory() {
+        let fake = FakeEmbedProvider::new(VEC_DIM);
+        let v = embed_query(&fake, "semantic query").expect("query embed");
+        assert_eq!(v.len(), VEC_DIM);
+        assert!(v[0] > 0.0);
+    }
+
+    #[test]
+    fn bulk_embed_uses_provider_from_factory() {
+        let fake = FakeEmbedProvider::new(VEC_DIM);
+        let texts: Vec<String> = (0..3).map(|i| format!("blob-{i}")).collect();
+        let vecs = fake.embed_batch(&texts).expect("bulk");
+        assert_eq!(vecs.len(), 3);
+        for v in &vecs {
+            assert_eq!(v.len(), VEC_DIM);
+        }
+        // Distinct fake fingerprints per row (batch path preserved order).
+        assert_ne!(vecs[0][0], vecs[1][0]);
+    }
+}

--- a/src/indexer/swift.rs
+++ b/src/indexer/swift.rs
@@ -87,7 +87,7 @@ impl<'a> SwiftExtractor<'a> {
         });
 
         for cap in CLASS_RE.captures_iter(self.source) {
-            let line = self.line_of(&cap[0]);
+            let line = self.line_of(cap.get(0).unwrap().start());
             let qn = self.push_decl(&mut elements, &mut relationships, "class", &cap[1], line);
             self.push_heritage(
                 &mut relationships,
@@ -97,7 +97,7 @@ impl<'a> SwiftExtractor<'a> {
             );
         }
         for cap in STRUCT_RE.captures_iter(self.source) {
-            let line = self.line_of(&cap[0]);
+            let line = self.line_of(cap.get(0).unwrap().start());
             let qn = self.push_decl(&mut elements, &mut relationships, "struct", &cap[1], line);
             self.push_heritage(
                 &mut relationships,
@@ -107,7 +107,7 @@ impl<'a> SwiftExtractor<'a> {
             );
         }
         for cap in ENUM_RE.captures_iter(self.source) {
-            let line = self.line_of(&cap[0]);
+            let line = self.line_of(cap.get(0).unwrap().start());
             let qn = self.push_decl(&mut elements, &mut relationships, "enum", &cap[1], line);
             self.push_heritage(
                 &mut relationships,
@@ -117,7 +117,7 @@ impl<'a> SwiftExtractor<'a> {
             );
         }
         for cap in PROTOCOL_RE.captures_iter(self.source) {
-            let line = self.line_of(&cap[0]);
+            let line = self.line_of(cap.get(0).unwrap().start());
             let qn = self.push_decl(
                 &mut elements,
                 &mut relationships,
@@ -133,7 +133,7 @@ impl<'a> SwiftExtractor<'a> {
             );
         }
         for cap in EXTENSION_RE.captures_iter(self.source) {
-            let line = self.line_of(&cap[0]);
+            let line = self.line_of(cap.get(0).unwrap().start());
             self.push_decl(
                 &mut elements,
                 &mut relationships,
@@ -395,13 +395,9 @@ impl<'a> SwiftExtractor<'a> {
         }
     }
 
-    fn line_of(&self, matched: &str) -> u32 {
-        let prefix = &self.source[..self.source.len() - matched.len().min(self.source.len())];
-        // Find the line of the start of the match by counting \n in the
-        // original source up to the same offset prefix length.
-        let offset = self.source.len() - prefix.len() - matched.len();
-        let count = self.source[..offset].matches('\n').count() as u32;
-        count + 1
+    fn line_of(&self, offset: usize) -> u32 {
+        // Regex Match::start() is a UTF-8 char boundary, so this slice is safe.
+        self.source[..offset].matches('\n').count() as u32 + 1
     }
 }
 
@@ -457,6 +453,35 @@ fn parse_swift(source: &[u8]) -> Option<tree_sitter::Tree> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extracts_swift_with_multibyte_utf8_in_comments() {
+        // Regression: line_of used `source.len() - matched.len()` as a slice end,
+        // which panics when that byte index falls inside a multi-byte char ('•' is
+        // 3 bytes). Padding after the bullet is chosen so the bad cut lands mid-char.
+        // Also asserts real line numbers (old logic always reported line 1).
+        let src =
+            "protocol ListCancelFeeViewModelActions {}\n// •xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx\n";
+        let (elems, _) =
+            SwiftExtractor::new(src.as_bytes(), "ListCancelFeeViewModel.swift").extract();
+        let proto = elems
+            .iter()
+            .find(|e| e.name == "ListCancelFeeViewModelActions")
+            .expect("protocol extracted");
+        assert_eq!(proto.line_start, 1);
+        assert_eq!(proto.line_end, 1);
+    }
+
+    #[test]
+    fn line_of_uses_match_byte_offset_not_suffix_length() {
+        let src = "// header\npublic class Greeter {}\n";
+        let (elems, _) = SwiftExtractor::new(src.as_bytes(), "test.swift").extract();
+        let class = elems
+            .iter()
+            .find(|e| e.name == "Greeter")
+            .expect("class extracted");
+        assert_eq!(class.line_start, 2);
+    }
 
     #[test]
     fn extracts_swift_class_struct_enum_protocol() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@ pub mod ctags_export;
 pub mod db;
 pub mod doc;
 pub mod doc_indexer;
-#[cfg(feature = "embeddings")]
 pub mod embeddings;
 pub mod gc;
 pub mod graph;

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -4549,16 +4549,14 @@ impl ToolHandler {
                     let query_vec: Vec<f32> = {
                         let cached = pipeline.last_query_vector();
                         if cached.is_empty() {
-                            emb::Embedder::new()
-                                .and_then(|em| em.embed(&[query.to_string()]).map(|v| v[0].clone()))
-                                .unwrap_or_else(|e| {
-                                    tracing::warn!(
-                                        target: "leankg::mcp",
-                                        error = %e,
-                                        "kg_semantic_context embedder init/embed failed; returning empty query vec"
-                                    );
-                                    Vec::new()
-                                })
+                            emb::embed_query(pipeline.provider(), query).unwrap_or_else(|e| {
+                                tracing::warn!(
+                                    target: "leankg::mcp",
+                                    error = %e,
+                                    "kg_semantic_context embedder init/embed failed; returning empty query vec"
+                                );
+                                Vec::new()
+                            })
                         } else {
                             cached.to_vec()
                         }
@@ -4566,9 +4564,12 @@ impl ToolHandler {
                     let scored = if query_vec.is_empty() {
                         discovered
                     } else {
-                        match emb::Embedder::new().and_then(|embedder| {
-                            score_functions(&self.graph_engine, &query_vec, discovered, &embedder)
-                        }) {
+                        match score_functions(
+                            &self.graph_engine,
+                            &query_vec,
+                            discovered,
+                            pipeline.provider(),
+                        ) {
                             Ok(s) => s,
                             Err(e) => {
                                 tracing::warn!(
@@ -4960,31 +4961,27 @@ fn run_hnsw_semantic_search(
                     cached.to_vec()
                 } else {
                     // Defensive fallback — should not happen after retrieve().
-                    use crate::embeddings::Embedder;
-                    Embedder::new()
-                        .and_then(|em| em.embed(&[query.to_string()]).map(|v| v[0].clone()))
+                    crate::embeddings::embed_query(pipeline.provider(), query).unwrap_or_else(|e| {
+                        tracing::warn!(
+                            target: "leankg::mcp",
+                            error = %e,
+                            "semantic_search embedder init/embed failed (cache empty); returning empty query vec"
+                        );
+                        Vec::new()
+                    })
+                }
+            };
+            if !query_vec.is_empty() {
+                scored_functions =
+                    score_functions(engine, &query_vec, discovered, pipeline.provider())
                         .unwrap_or_else(|e| {
                             tracing::warn!(
                                 target: "leankg::mcp",
                                 error = %e,
-                                "semantic_search embedder init/embed failed (cache empty); returning empty query vec"
+                                "semantic_search composite scoring failed; keeping traversal order"
                             );
                             Vec::new()
-                        })
-                }
-            };
-            if !query_vec.is_empty() {
-                use crate::embeddings::Embedder;
-                let embedder = Embedder::new().map_err(|e| format!("Embedder init failed: {e}"))?;
-                scored_functions = score_functions(engine, &query_vec, discovered, &embedder)
-                    .unwrap_or_else(|e| {
-                        tracing::warn!(
-                            target: "leankg::mcp",
-                            error = %e,
-                            "semantic_search composite scoring failed; keeping traversal order"
-                        );
-                        Vec::new()
-                    });
+                        });
             }
             traversed_after_dedup = scored_functions.len();
         }

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -36,14 +36,19 @@ use tokio::signal;
 use tokio::sync::{Mutex as TokioMutex, RwLock as TokioRwLock};
 use tower_http::cors::{Any, CorsLayer};
 
-/// Tools that mutate the underlying DB or state. Everything else is treated
-/// as a read at the dispatch layer (it may still go to the DB internally,
-/// but its lock semantics differ).
+/// Tools that mutate the underlying DB or filesystem / pipeline state.
+/// Single source of truth for `is_write_tool`, the RO execute gate, and
+/// RO `list_tools` filtering. Everything else is treated as a read at the
+/// dispatch layer (it may still go to the DB internally, but its lock
+/// semantics differ).
 static WRITE_TOOLS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
     [
         "mcp_init",
         "mcp_index",
         "mcp_index_docs",
+        "mcp_install",
+        "mcp_embed",
+        "index_prd",
         "add_knowledge",
         "update_knowledge",
         "delete_knowledge",
@@ -58,6 +63,12 @@ static WRITE_TOOLS: Lazy<HashSet<&'static str>> = Lazy::new(|| {
         "add_ontology_concept",
         "add_ontology_workflow",
         "delete_ontology_concept",
+        // Agent / export / doc mutators (filesystem or graph side effects).
+        "agent_diary_write",
+        "report_query_outcome",
+        "export_graph_snapshot",
+        "export_html",
+        "generate_doc",
     ]
     .into_iter()
     .collect()
@@ -225,6 +236,22 @@ impl Clone for MCPServer {
     }
 }
 
+/// Outcome of MCP auto-index / ensure-indexed freshness checks.
+/// Public so RO side-effect tests can assert pipeline paths are skipped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutoIndexDecision {
+    /// Server is read-only — never index or take advisory locks.
+    SkippedReadOnly,
+    /// Config / env disabled auto-index.
+    SkippedDisabled,
+    /// Index considered fresh relative to git / threshold.
+    SkippedFresh,
+    /// No git context and require_git_for_auto_index is set.
+    SkippedNoGit,
+    /// Incremental (or fallback full) index ran.
+    Indexed,
+}
+
 impl MCPServer {
     pub fn new(db_path: std::path::PathBuf) -> Self {
         let effective_db_path = Self::resolve_project_root(db_path);
@@ -272,14 +299,60 @@ impl MCPServer {
 
     /// Toggle the read-only flag. Builder-style; returns `self` so callers
     /// can chain `MCPServer::new(db_path).with_read_only(read_only)`.
+    /// When enabling read-only, clears any configured watch path so file-watch
+    /// reindex cannot run on a query-only server.
     pub fn with_read_only(mut self, read_only: bool) -> Self {
         self.read_only = read_only;
+        if read_only {
+            self.watch_path = None;
+        }
         self
     }
 
     /// Returns true if this server is currently running in read-only mode.
     pub fn is_read_only(&self) -> bool {
         self.read_only
+    }
+
+    /// Whether a filesystem watcher would be spawned (false in RO mode).
+    pub fn file_watcher_enabled(&self) -> bool {
+        !self.read_only && self.watch_path.is_some()
+    }
+
+    /// Whether background / auto-arm embed is allowed (false in RO mode).
+    pub fn background_embed_allowed(&self) -> bool {
+        !self.read_only
+    }
+
+    /// Canonical write-tool names (sorted). Shared by classification tests,
+    /// the RO execute gate, and RO `list_tools` filtering.
+    pub fn write_tool_names() -> Vec<&'static str> {
+        let mut names: Vec<&'static str> = WRITE_TOOLS.iter().copied().collect();
+        names.sort_unstable();
+        names
+    }
+
+    /// Tool names exposed to MCP clients. In read-only mode, mutators from
+    /// [`Self::write_tool_names`] are omitted.
+    pub fn list_tool_names(&self) -> Vec<String> {
+        ToolRegistry::list_tools()
+            .into_iter()
+            .map(|t| t.name)
+            .filter(|name| !(self.read_only && Self::is_write_tool(name)))
+            .collect()
+    }
+
+    /// Public seam for RO side-effect tests: run the startup auto-index path.
+    pub async fn auto_index_if_needed_pub(&self) -> Result<AutoIndexDecision, String> {
+        self.auto_index_if_needed().await
+    }
+
+    /// Public seam for RO side-effect tests: run on-demand ensure-indexed.
+    pub async fn ensure_project_indexed_pub(
+        &self,
+        project_path: &str,
+    ) -> Result<AutoIndexDecision, String> {
+        self.ensure_project_indexed(project_path).await
     }
 
     /// Read leankg.yaml and resolve project root with fallback chain:
@@ -715,6 +788,10 @@ impl MCPServer {
     /// - `LEANKG_EMBED_AUTO_ARM=1` arms the idle scheduler on first idle pass
     #[cfg(feature = "embeddings")]
     fn spawn_embed_idle_scheduler(&self) {
+        if !self.background_embed_allowed() {
+            tracing::info!("Read-only mode: skipping embed idle scheduler");
+            return;
+        }
         let shutdown_flag = self.shutdown_flag.clone();
         let server = self.clone();
         tokio::spawn(async move {
@@ -780,7 +857,8 @@ impl MCPServer {
 
     /// FR-P0-EMBED-LOCK: whether the embed idle scheduler auto-arms. Default
     /// `false` (serving containers must not take the RocksDB LOCK for a
-    /// background embed). `LEANKG_EMBED_AUTO_ARM=1` opts in.
+    /// background embed). `LEANKG_EMBED_AUTO_ARM=1` opts in. Callers must
+    /// also check `background_embed_allowed()` / `!read_only`.
     #[cfg(feature = "embeddings")]
     fn auto_arm_enabled() -> bool {
         std::env::var("LEANKG_EMBED_AUTO_ARM")
@@ -899,6 +977,10 @@ impl MCPServer {
 
     #[cfg(feature = "embeddings")]
     fn spawn_background_embed_with_config(&self, cfg: crate::embeddings::BackgroundEmbedConfig) {
+        if !self.background_embed_allowed() {
+            tracing::info!("Read-only mode: skipping background embed spawn");
+            return;
+        }
         // Resolve project-aware graph + .leankg dir before opening.
         let (graph, leankg_dir, project_label) = if let Some(ref proj) = cfg.project_path {
             match self.get_graph_engine_for_path(Some(proj)) {
@@ -1377,6 +1459,10 @@ impl MCPServer {
 
     #[cfg(feature = "embeddings")]
     fn spawn_background_embed_in_process(&self) {
+        if !self.background_embed_allowed() {
+            tracing::info!("Read-only mode: skipping in-process background embed");
+            return;
+        }
         // Read tuning env once (default-friendly fallbacks).
         let workers: usize = std::env::var("LEANKG_EMBED_BACKGROUND_WORKERS")
             .ok()
@@ -1499,29 +1585,33 @@ impl MCPServer {
             }
         }
 
-        if let Some(ref watch_path) = self.watch_path {
-            let db_path = self.get_db_path();
-            let watch_path = watch_path.clone();
-            let shutdown = self.shutdown_flag.clone();
-            match self.get_graph_engine() {
-                Ok(ge) => {
-                    tokio::spawn(async move {
-                        let (tx, rx) = tokio::sync::mpsc::channel(100);
-                        start_watcher(ge, db_path, watch_path, shutdown, rx).await;
-                        let _ = tx; // silence unused warning
-                    });
-                    tracing::info!(
-                        "Auto-indexing enabled for {}",
-                        self.watch_path
-                            .as_ref()
-                            .unwrap_or(&std::path::PathBuf::from("?"))
-                            .display()
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!("Watcher skipped: {}", e);
+        if self.file_watcher_enabled() {
+            if let Some(ref watch_path) = self.watch_path {
+                let db_path = self.get_db_path();
+                let watch_path = watch_path.clone();
+                let shutdown = self.shutdown_flag.clone();
+                match self.get_graph_engine() {
+                    Ok(ge) => {
+                        tokio::spawn(async move {
+                            let (tx, rx) = tokio::sync::mpsc::channel(100);
+                            start_watcher(ge, db_path, watch_path, shutdown, rx).await;
+                            let _ = tx; // silence unused warning
+                        });
+                        tracing::info!(
+                            "Auto-indexing enabled for {}",
+                            self.watch_path
+                                .as_ref()
+                                .unwrap_or(&std::path::PathBuf::from("?"))
+                                .display()
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("Watcher skipped: {}", e);
+                    }
                 }
             }
+        } else if self.read_only {
+            tracing::info!("Read-only mode: file watcher disabled");
         }
 
         self.spawn_ontology_yaml_watcher_if_present();
@@ -1925,29 +2015,33 @@ impl MCPServer {
             );
         }
 
-        if let Some(ref watch_path) = self.watch_path {
-            let db_path = self.get_db_path();
-            let watch_path = watch_path.clone();
-            let shutdown = self.shutdown_flag.clone();
-            match self.get_graph_engine() {
-                Ok(ge) => {
-                    tokio::spawn(async move {
-                        let (tx, rx) = tokio::sync::mpsc::channel(100);
-                        start_watcher(ge, db_path, watch_path, shutdown, rx).await;
-                        let _ = tx; // silence unused warning
-                    });
-                    tracing::info!(
-                        "Auto-indexing enabled for {}",
-                        self.watch_path
-                            .as_ref()
-                            .unwrap_or(&std::path::PathBuf::from("?"))
-                            .display()
-                    );
-                }
-                Err(e) => {
-                    tracing::warn!("Watcher skipped: {}", e);
+        if self.file_watcher_enabled() {
+            if let Some(ref watch_path) = self.watch_path {
+                let db_path = self.get_db_path();
+                let watch_path = watch_path.clone();
+                let shutdown = self.shutdown_flag.clone();
+                match self.get_graph_engine() {
+                    Ok(ge) => {
+                        tokio::spawn(async move {
+                            let (tx, rx) = tokio::sync::mpsc::channel(100);
+                            start_watcher(ge, db_path, watch_path, shutdown, rx).await;
+                            let _ = tx; // silence unused warning
+                        });
+                        tracing::info!(
+                            "Auto-indexing enabled for {}",
+                            self.watch_path
+                                .as_ref()
+                                .unwrap_or(&std::path::PathBuf::from("?"))
+                                .display()
+                        );
+                    }
+                    Err(e) => {
+                        tracing::warn!("Watcher skipped: {}", e);
+                    }
                 }
             }
+        } else if self.read_only {
+            tracing::info!("Read-only mode: file watcher disabled");
         }
 
         self.spawn_ontology_yaml_watcher_if_present();
@@ -1965,10 +2059,11 @@ impl MCPServer {
         // budget while HNSW catches up. Progress is written to
         // `<leankg_dir>/embed_status.json` — agents polling
         // `leankg embed --status` see live numbers.
-        if std::env::var("LEANKG_EMBED_BACKGROUND")
-            .ok()
-            .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-            .unwrap_or(false)
+        if self.background_embed_allowed()
+            && std::env::var("LEANKG_EMBED_BACKGROUND")
+                .ok()
+                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                .unwrap_or(false)
         {
             self.spawn_background_embed_in_process();
         }
@@ -1979,10 +2074,11 @@ impl MCPServer {
         // log a hint and rely on the offline embed job.
         #[cfg(feature = "embeddings")]
         {
-            let auto_arm = std::env::var("LEANKG_EMBED_AUTO_ARM")
-                .ok()
-                .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-                .unwrap_or(false);
+            let auto_arm = self.background_embed_allowed()
+                && std::env::var("LEANKG_EMBED_AUTO_ARM")
+                    .ok()
+                    .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+                    .unwrap_or(false);
             if auto_arm {
                 let shutdown_for_arm = self.shutdown_flag.clone();
                 Self::schedule_multi_project_arm(shutdown_for_arm);
@@ -2191,6 +2287,11 @@ impl MCPServer {
     }
 
     async fn auto_init_if_needed(&self) -> Result<(), String> {
+        if self.read_only {
+            tracing::info!("Read-only mode: skipping auto-init / auto-index on start");
+            return Ok(());
+        }
+
         let project_root = self.find_project_root()?;
 
         let leankg_path = project_root.join(".leankg");
@@ -2309,7 +2410,12 @@ impl MCPServer {
         Ok(())
     }
 
-    async fn auto_index_if_needed(&self) -> Result<(), String> {
+    async fn auto_index_if_needed(&self) -> Result<AutoIndexDecision, String> {
+        if self.read_only {
+            tracing::info!("Read-only mode: skipping auto-index on start");
+            return Ok(AutoIndexDecision::SkippedReadOnly);
+        }
+
         let project_root = self.find_project_root()?;
         let config_path = project_root.join(".leankg/leankg.yaml");
 
@@ -2324,7 +2430,7 @@ impl MCPServer {
 
         if !config.mcp.auto_index_on_start {
             tracing::info!("Auto-indexing on start is disabled in config");
-            return Ok(());
+            return Ok(AutoIndexDecision::SkippedDisabled);
         }
 
         // FR-MG-AUTO-01: operators can skip freshness reindex without wiping
@@ -2335,7 +2441,7 @@ impl MCPServer {
             .unwrap_or(false)
         {
             tracing::info!("LEANKG_SKIP_FRESHNESS_CHECK set, skipping MCP auto-index on start");
-            return Ok(());
+            return Ok(AutoIndexDecision::SkippedDisabled);
         }
 
         let db_path = self.get_db_path();
@@ -2347,7 +2453,7 @@ impl MCPServer {
                 "No git repo (or nested repos) under {}, skipping auto-index",
                 project_root.display()
             );
-            return Ok(());
+            return Ok(AutoIndexDecision::SkippedNoGit);
         }
 
         let last_commit_time = if !is_git {
@@ -2368,7 +2474,7 @@ impl MCPServer {
                 }
                 Err(e) => {
                     tracing::warn!("Failed to get last commit time: {}", e);
-                    return Ok(());
+                    return Ok(AutoIndexDecision::SkippedNoGit);
                 }
             }
         };
@@ -2385,7 +2491,7 @@ impl MCPServer {
                 last_commit_time,
                 db_modified
             );
-            return Ok(());
+            return Ok(AutoIndexDecision::SkippedFresh);
         }
 
         tracing::info!(
@@ -2458,11 +2564,19 @@ impl MCPServer {
             *guard = None;
         }
 
-        Ok(())
+        Ok(AutoIndexDecision::Indexed)
     }
 
     /// Ensure a specific project is indexed if needed (used for per-request auto-indexing)
-    async fn ensure_project_indexed(&self, project_path: &str) -> Result<(), String> {
+    async fn ensure_project_indexed(
+        &self,
+        project_path: &str,
+    ) -> Result<AutoIndexDecision, String> {
+        if self.read_only {
+            tracing::debug!("Read-only mode: skipping ensure_project_indexed");
+            return Ok(AutoIndexDecision::SkippedReadOnly);
+        }
+
         let project_root = if project_path.starts_with('/') {
             PathBuf::from(project_path)
         } else {
@@ -2482,7 +2596,7 @@ impl MCPServer {
         };
 
         if !config.mcp.auto_index_on_start {
-            return Ok(());
+            return Ok(AutoIndexDecision::SkippedDisabled);
         }
 
         let db_path = project_root.join(".leankg");
@@ -2495,7 +2609,7 @@ impl MCPServer {
                     "No git context under {}, skipping auto-index",
                     project_root.display()
                 );
-                return Ok(());
+                return Ok(AutoIndexDecision::SkippedNoGit);
             }
             match crate::indexer::git_workspace::workspace_last_commit_time(&project_root) {
                 Ok(t) => t,
@@ -2505,7 +2619,7 @@ impl MCPServer {
                         project_root.display(),
                         e
                     );
-                    return Ok(());
+                    return Ok(AutoIndexDecision::SkippedNoGit);
                 }
             }
         } else {
@@ -2529,7 +2643,7 @@ impl MCPServer {
                 last_commit_time,
                 db_modified
             );
-            return Ok(());
+            return Ok(AutoIndexDecision::SkippedFresh);
         }
 
         tracing::info!(
@@ -2568,7 +2682,7 @@ impl MCPServer {
         }
 
         tracing::debug!("Auto-index complete for {}", project_root.display());
-        Ok(())
+        Ok(AutoIndexDecision::Indexed)
     }
 
     async fn trigger_reindex(&self) -> Result<(), String> {
@@ -2838,7 +2952,7 @@ impl MCPServer {
             }
         }
 
-        if self.write_tracker.is_dirty() {
+        if !self.read_only && self.write_tracker.is_dirty() {
             let config = self.load_config(&project_root)?;
             if config.mcp.auto_index_on_db_write {
                 tracing::info!("External write detected, triggering incremental reindex...");
@@ -2878,8 +2992,10 @@ impl MCPServer {
 
         // On-demand auto-indexing: if the project has no indexed elements
         // yet (Phase 8 — Postgres holds the data, so "has an index" is a
-        // populated-graph check, not a file check).
-        if tool_name != "mcp_index"
+        // populated-graph check, not a file check). Read-only MCP never
+        // indexes — worker owns that pipeline.
+        if !self.read_only
+            && tool_name != "mcp_index"
             && tool_name != "mcp_init"
             && tool_name != "mcp_index_docs"
             && !graph_engine.has_elements().unwrap_or(false)
@@ -3005,6 +3121,7 @@ impl ServerHandler for MCPServer {
         let tools = ToolRegistry::list_tools();
         let rmcp_tools: Vec<Tool> = tools
             .into_iter()
+            .filter(|t| !(self.read_only && Self::is_write_tool(&t.name)))
             .map(|t| {
                 Tool::new(
                     t.name,
@@ -3425,6 +3542,7 @@ async fn process_jsonrpc_request(
             let tools = ToolRegistry::list_tools();
             let rmcp_tools: Vec<serde_json::Value> = tools
                 .into_iter()
+                .filter(|t| !(mcp_server.is_read_only() && MCPServer::is_write_tool(&t.name)))
                 .map(|t| {
                     serde_json::json!({
                         "name": t.name,

--- a/src/retrieval/ontology_traversal.rs
+++ b/src/retrieval/ontology_traversal.rs
@@ -34,7 +34,8 @@
 #![cfg(feature = "embeddings")]
 
 use crate::db::models::CodeElement;
-use crate::embeddings::{build_blob, Embedder};
+use crate::embeddings::build_blob;
+use crate::embeddings::provider::EmbedProvider;
 use crate::graph::traversal::is_indexer_noise;
 use crate::graph::GraphEngine;
 use std::collections::{HashMap, HashSet, VecDeque};
@@ -622,7 +623,7 @@ pub fn composite_text(upper_name: &str, func_blob: &str) -> String {
 
 /// Score every discovered function against `query_vec` using a composite
 /// embedding of `"{upper_name}\n{function_blob}"`. Batches all embed
-/// calls into one [`Embedder::embed`] for throughput. Sets
+/// calls into one [`EmbedProvider::embed_batch`] for throughput. Sets
 /// [`DiscoveredFunction::composite_score`] in place; returns the same
 /// vector sorted by score descending.
 ///
@@ -633,7 +634,7 @@ pub fn score_functions(
     graph: &GraphEngine,
     query_vec: &[f32],
     functions: Vec<DiscoveredFunction>,
-    embedder: &Embedder,
+    provider: &dyn EmbedProvider,
 ) -> Result<Vec<DiscoveredFunction>, Box<dyn std::error::Error>> {
     if functions.is_empty() {
         return Ok(functions);
@@ -671,7 +672,7 @@ pub fn score_functions(
         .collect();
 
     let borrowed: Vec<String> = composite_texts; // already owned
-    let vectors = embedder.embed(&borrowed)?;
+    let vectors = provider.embed_batch(&borrowed)?;
 
     let mut scored = functions;
     for (func, vec) in scored.iter_mut().zip(vectors.iter()) {

--- a/src/retrieval/pipeline.rs
+++ b/src/retrieval/pipeline.rs
@@ -11,12 +11,14 @@
 use crate::db::backend::DataValue;
 use crate::db::backend::SharedDb;
 use crate::db::models::CodeElement;
-use crate::embeddings::models::{Embedder, RerankerStatus};
+use crate::embeddings::models::RerankerStatus;
+use crate::embeddings::provider::{create_provider_from_env, embed_query, EmbedProvider};
 use crate::retrieval::rerank::RerankStage;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 pub struct SemanticRetrievalPipeline {
-    embedder: Embedder,
+    provider: Arc<dyn EmbedProvider>,
     rerank_stage: RerankStage,
     db: SharedDb,
     /// Most recent query embedding from [`Self::retrieve`], stashed so
@@ -209,14 +211,26 @@ mod adaptive_k_tests {
 
 impl SemanticRetrievalPipeline {
     pub fn new(db: SharedDb) -> Result<Self, Box<dyn std::error::Error>> {
-        let embedder = Embedder::new()?;
+        let provider = create_provider_from_env()?;
+        Self::with_provider(db, provider)
+    }
+
+    /// Inject a provider (tests / custom wiring). Prefer [`Self::new`] in prod.
+    pub fn with_provider(
+        db: SharedDb,
+        provider: Arc<dyn EmbedProvider>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
         let rerank_stage = RerankStage::try_new();
         Ok(Self {
-            embedder,
+            provider,
             rerank_stage,
             db,
             last_query_vec: Vec::new(),
         })
+    }
+
+    pub fn provider(&self) -> &dyn EmbedProvider {
+        self.provider.as_ref()
     }
 
     pub fn reranker_active(&self) -> bool {
@@ -247,11 +261,11 @@ impl SemanticRetrievalPipeline {
         };
 
         // Stage 2: embed query, run CozoDB HNSW search.
-        let qvec = self.embedder.embed(&[query.to_string()])?;
+        let q = embed_query(self.provider.as_ref(), query)?;
         // Stash for downstream composite scoring (ontology-guided
         // traversal) so the query is embedded exactly once per request.
-        self.last_query_vec = qvec[0].clone();
-        let raw = self.hnsw_retrieve(&qvec[0], effective_k)?;
+        self.last_query_vec = q.clone();
+        let raw = self.hnsw_retrieve(&q, effective_k)?;
         let ann_candidate_count = raw.len();
 
         // HNSW returns qualified_name directly — no key→QN map needed.
@@ -498,5 +512,19 @@ mod tests {
     fn retrieve_options_default_embeddings_stale_false() {
         let opts = RetrieveOptions::default();
         assert!(!opts.embeddings_stale);
+    }
+
+    #[test]
+    fn query_embed_uses_provider_from_factory() {
+        use crate::db::fake::FakeBackend;
+        use crate::embeddings::provider::{embed_query, FakeEmbedProvider, VEC_DIM};
+        use std::sync::Arc;
+
+        let db: SharedDb = Arc::new(FakeBackend::new());
+        let fake: Arc<dyn EmbedProvider> = Arc::new(FakeEmbedProvider::new(VEC_DIM));
+        let pipeline = SemanticRetrievalPipeline::with_provider(db, fake).expect("pipeline");
+        assert_eq!(pipeline.provider().name(), "fake");
+        let v = embed_query(pipeline.provider(), "nl intent").expect("embed");
+        assert_eq!(v.len(), VEC_DIM);
     }
 }

--- a/tests/cli_split_tests.rs
+++ b/tests/cli_split_tests.rs
@@ -1,0 +1,117 @@
+//! CLI surface for the split binaries: query-only `leankg-mcp` and pipeline
+//! `leankg-worker`. Parse-only — does not start servers or run the indexer.
+//!
+//! Run:
+//! ```bash
+//! cargo test --test cli_split_tests -- --nocapture
+//! ```
+
+use clap::Parser;
+use leankg::cli::mcp::{McpArgs, McpCommand};
+use leankg::cli::worker::{WorkerArgs, WorkerCommand};
+
+#[test]
+fn mcp_cli_parses_mcp_http_and_stdio() {
+    let http = McpArgs::try_parse_from(["leankg-mcp", "mcp-http", "--port", "9700"]).unwrap();
+    match http.command {
+        McpCommand::McpHttp {
+            port,
+            read_only,
+            watch,
+            ..
+        } => {
+            assert_eq!(port, Some(9700));
+            assert!(read_only, "leankg-mcp must default to read-only");
+            assert!(!watch);
+        }
+        other => panic!("expected McpHttp, got {other:?}"),
+    }
+
+    let stdio = McpArgs::try_parse_from(["leankg-mcp", "mcp-stdio"]).unwrap();
+    match stdio.command {
+        McpCommand::McpStdio { read_only, watch } => {
+            assert!(read_only, "leankg-mcp must default to read-only");
+            assert!(!watch);
+        }
+        other => panic!("expected McpStdio, got {other:?}"),
+    }
+}
+
+#[test]
+fn mcp_cli_rejects_index_subcommand() {
+    let err = McpArgs::try_parse_from(["leankg-mcp", "index"]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unrecognized subcommand")
+            || msg.contains("unexpected")
+            || msg.contains("index"),
+        "expected parse rejection of index, got: {msg}"
+    );
+}
+
+#[test]
+fn mcp_cli_defaults_or_requires_read_only() {
+    let http = McpArgs::try_parse_from(["leankg-mcp", "mcp-http"]).unwrap();
+    match http.command {
+        McpCommand::McpHttp { read_only, .. } => {
+            assert!(read_only, "mcp-http must default read_only=true");
+        }
+        other => panic!("expected McpHttp, got {other:?}"),
+    }
+
+    let stdio = McpArgs::try_parse_from(["leankg-mcp", "mcp-stdio"]).unwrap();
+    match stdio.command {
+        McpCommand::McpStdio { read_only, .. } => {
+            assert!(read_only, "mcp-stdio must default read_only=true");
+        }
+        other => panic!("expected McpStdio, got {other:?}"),
+    }
+
+    // Explicit --read-only stays true; there is no --no-read-only escape hatch
+    // on the mcp binary (RO is the product contract).
+    let forced = McpArgs::try_parse_from(["leankg-mcp", "mcp-http", "--read-only"]).unwrap();
+    match forced.command {
+        McpCommand::McpHttp { read_only, .. } => assert!(read_only),
+        other => panic!("expected McpHttp, got {other:?}"),
+    }
+}
+
+#[test]
+fn worker_cli_parses_index_embed_watch_status() {
+    let index = WorkerArgs::try_parse_from(["leankg-worker", "index", "--verbose"]).unwrap();
+    match index.command {
+        WorkerCommand::Index { verbose, .. } => assert!(verbose),
+        other => panic!("expected Index, got {other:?}"),
+    }
+
+    let embed =
+        WorkerArgs::try_parse_from(["leankg-worker", "embed", "--project", ".", "--wait"]).unwrap();
+    match embed.command {
+        WorkerCommand::Embed { wait, project, .. } => {
+            assert!(wait);
+            assert_eq!(project, ".");
+        }
+        other => panic!("expected Embed, got {other:?}"),
+    }
+
+    let watch = WorkerArgs::try_parse_from(["leankg-worker", "watch", "--interval", "30"]).unwrap();
+    match watch.command {
+        WorkerCommand::Watch { interval, .. } => assert_eq!(interval, 30),
+        other => panic!("expected Watch, got {other:?}"),
+    }
+
+    let status = WorkerArgs::try_parse_from(["leankg-worker", "status"]).unwrap();
+    assert!(matches!(status.command, WorkerCommand::Status));
+}
+
+#[test]
+fn worker_cli_rejects_mcp_http() {
+    let err = WorkerArgs::try_parse_from(["leankg-worker", "mcp-http"]).unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("unrecognized subcommand")
+            || msg.contains("unexpected")
+            || msg.contains("mcp-http"),
+        "expected parse rejection of mcp-http, got: {msg}"
+    );
+}

--- a/tests/concurrent_mcp_during_embed_test.rs
+++ b/tests/concurrent_mcp_during_embed_test.rs
@@ -1,0 +1,288 @@
+//! Concurrent RO MCP queries during worker index/embed lock + writes.
+//!
+//! Proves query-only MCP (`with_read_only(true)`) stays responsive while a
+//! worker holds `index_advisory_lock` and performs batched embed-style
+//! `import_relations` writes into `embedding_vectors`.
+//!
+//! Skip when `LEANKG_PG_URL` is unset (same pattern as `embeddings::state`
+//! PG e2e helpers). With PG up:
+//!
+//! ```text
+//! LEANKG_PG_URL=postgresql://postgres:postgres@localhost:5433/leankg \
+//!   cargo test --test concurrent_mcp_during_embed_test -- --nocapture
+//! ```
+
+use leankg::db::backend::{index_advisory_lock, init_db, DataValue, NamedRows, PostgresBackend};
+use leankg::db::models::CodeElement;
+use leankg::graph::GraphEngine;
+use leankg::mcp::server::MCPServer;
+use serde_json::{json, Map};
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
+use std::sync::{Arc, Mutex, OnceLock};
+use std::time::{Duration, Instant};
+use tempfile::TempDir;
+
+/// Serializes `LEANKG_PG_URL` mutation — env is process-global.
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+static SCHEMA_COUNTER: AtomicU32 = AtomicU32::new(0);
+
+const VEC_DIM: usize = 384;
+const QUERY_TIMEOUT: Duration = Duration::from_secs(5);
+const WORKER_HOLD: Duration = Duration::from_secs(2);
+
+fn require_pg_url() -> Option<String> {
+    match std::env::var("LEANKG_PG_URL") {
+        Ok(v) if !v.trim().is_empty() => Some(v),
+        _ => {
+            eprintln!("skipping: LEANKG_PG_URL not set");
+            None
+        }
+    }
+}
+
+/// Pins `LEANKG_PG_URL` to a migrated scratch schema for the test body.
+/// Admin connection is forgotten (same pattern as `full_index_wipe_test`) so
+/// Drop never closes a sync `postgres::Client` inside a tokio runtime.
+struct ScopedPg {
+    base_url: String,
+    schema: String,
+    prev_url: Option<String>,
+    _env_guard: std::sync::MutexGuard<'static, ()>,
+}
+
+impl ScopedPg {
+    fn enter(base_url: &str) -> Self {
+        let schema = format!(
+            "leankg_conc_{}_{}",
+            std::process::id(),
+            SCHEMA_COUNTER.fetch_add(1, Ordering::Relaxed)
+        );
+        let mut admin = postgres::Client::connect(base_url, postgres::NoTls)
+            .unwrap_or_else(|e| panic!("cannot connect to {base_url}: {e}"));
+        admin
+            .batch_execute(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"))
+            .expect("drop schema");
+        admin
+            .batch_execute(&format!("CREATE SCHEMA {schema}"))
+            .expect("create schema");
+        admin
+            .batch_execute(&format!("SET search_path TO {schema}, public"))
+            .expect("set search_path");
+        leankg::db::pg::migrations::run_migrations(&mut admin).expect("run_migrations");
+        // Keep the admin connection alive so the schema survives the body.
+        std::mem::forget(admin);
+
+        let env_guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+        let prev_url = std::env::var("LEANKG_PG_URL").ok();
+        let sep = if base_url.contains('?') { '&' } else { '?' };
+        let scoped = format!("{base_url}{sep}options=-csearch_path%3D{schema}%2Cpublic");
+        std::env::set_var("LEANKG_PG_URL", &scoped);
+
+        ScopedPg {
+            base_url: base_url.to_string(),
+            schema,
+            prev_url,
+            _env_guard: env_guard,
+        }
+    }
+
+    fn cleanup(self) {
+        let schema = self.schema.clone();
+        let base = self.base_url.clone();
+        // Drop runs env restore; schema DROP is sync PG — must be off-runtime
+        // or under block_in_place (caller responsibility).
+        drop(self);
+        if let Ok(mut admin) = postgres::Client::connect(&base, postgres::NoTls) {
+            let _ = admin.batch_execute(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"));
+        }
+    }
+}
+
+impl Drop for ScopedPg {
+    fn drop(&mut self) {
+        match &self.prev_url {
+            Some(u) => std::env::set_var("LEANKG_PG_URL", u),
+            None => std::env::remove_var("LEANKG_PG_URL"),
+        }
+    }
+}
+
+fn seed_elem(qn: &str, name: &str) -> CodeElement {
+    CodeElement {
+        qualified_name: qn.to_string(),
+        element_type: "function".to_string(),
+        name: name.to_string(),
+        file_path: "/src/lib.rs".to_string(),
+        line_start: 1,
+        line_end: 10,
+        language: "rust".to_string(),
+        parent_qualified: Some("/src/lib.rs".to_string()),
+        cluster_id: None,
+        cluster_label: None,
+        metadata: serde_json::json!({}),
+        env: "local".to_string(),
+    }
+}
+
+fn named_vectors(pairs: &[(String, Vec<f32>)]) -> BTreeMap<String, NamedRows> {
+    let mut rows: Vec<Vec<DataValue>> = Vec::with_capacity(pairs.len());
+    for (qn, vec) in pairs {
+        let mut row = Vec::with_capacity(2);
+        row.push(DataValue::Str(qn.as_str().into()));
+        let list: Vec<DataValue> = vec.iter().map(|&f| DataValue::from(f as f64)).collect();
+        row.push(DataValue::List(list));
+        rows.push(row);
+    }
+    let named = NamedRows::new(
+        vec!["qualified_name".to_string(), "vector".to_string()],
+        rows,
+    );
+    let mut map = BTreeMap::new();
+    map.insert("embedding_vectors".to_string(), named);
+    map
+}
+
+fn unit_vector(seed: u32) -> Vec<f32> {
+    let mut v = vec![0.0f32; VEC_DIM];
+    let idx = (seed as usize) % VEC_DIM;
+    v[idx] = 1.0;
+    v
+}
+
+fn assert_not_ro_or_conn_error(tool: &str, result: Result<serde_json::Value, String>) {
+    match result {
+        Ok(_) => {}
+        Err(msg) => {
+            assert!(
+                !msg.to_lowercase().contains("read-only mode"),
+                "{tool} must not hit RO gate during concurrent worker: {msg}"
+            );
+            let lower = msg.to_lowercase();
+            assert!(
+                !lower.contains("connection")
+                    && !lower.contains("closed")
+                    && !lower.contains("timeout")
+                    && !lower.contains("pool"),
+                "{tool} must not fail with connection/pool errors during worker embed: {msg}"
+            );
+            panic!("{tool} failed unexpectedly: {msg}");
+        }
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_ro_mcp_queries_succeed_while_worker_holds_lock_and_writes() {
+    let Some(base_url) = require_pg_url() else {
+        return;
+    };
+
+    // Sync postgres::Client must not run on a tokio worker without
+    // block_in_place (nested-runtime panic).
+    let (scoped, _tmp, server) = tokio::task::block_in_place(|| {
+        let scoped = ScopedPg::enter(&base_url);
+
+        let tmp = TempDir::new().unwrap();
+        let db_path = tmp.path().join("leankg");
+        std::fs::create_dir_all(&db_path).unwrap();
+
+        // Seed minimal graph via RW backend (same LEANKG_PG_URL / scratch schema).
+        {
+            let db = init_db(&db_path).expect("init_db seed");
+            let ge = GraphEngine::new(db);
+            ge.insert_elements_with(
+                &[
+                    seed_elem("/src/lib.rs::helper", "helper"),
+                    seed_elem("/src/lib.rs::main", "main"),
+                ],
+                true,
+            )
+            .expect("seed elements");
+        }
+
+        let server = MCPServer::new(db_path).with_read_only(true);
+        assert!(server.is_read_only());
+        (scoped, tmp, server)
+    });
+
+    let stop = Arc::new(AtomicBool::new(false));
+    let stop_w = Arc::clone(&stop);
+    let batches_done = Arc::new(AtomicU32::new(0));
+    let batches_w = Arc::clone(&batches_done);
+
+    // Worker: hold index advisory lock + slow batched embed writes.
+    let worker = std::thread::spawn(move || {
+        let _lock = index_advisory_lock().expect("index_advisory_lock");
+        let pg = PostgresBackend::from_env().expect("worker PostgresBackend");
+        let mut n = 0u32;
+        while !stop_w.load(Ordering::SeqCst) {
+            let pairs: Vec<(String, Vec<f32>)> = (0..32)
+                .map(|i| {
+                    (
+                        format!("/embed/batch{n}/item{i}"),
+                        unit_vector(n.wrapping_mul(32).wrapping_add(i)),
+                    )
+                })
+                .collect();
+            pg.import_relations(named_vectors(&pairs))
+                .unwrap_or_else(|e| panic!("embed write batch {n}: {e}"));
+            batches_w.fetch_add(1, Ordering::SeqCst);
+            n += 1;
+            std::thread::sleep(Duration::from_millis(40));
+        }
+    });
+
+    // Give the worker a moment to acquire the lock and start writing.
+    tokio::time::sleep(Duration::from_millis(80)).await;
+
+    let deadline = Instant::now() + WORKER_HOLD;
+    let mut status_ok = 0u32;
+    let mut search_ok = 0u32;
+
+    while Instant::now() < deadline {
+        let t0 = Instant::now();
+        let status = server.execute_tool_pub("mcp_status", Map::new()).await;
+        assert!(
+            t0.elapsed() < QUERY_TIMEOUT,
+            "mcp_status exceeded {:?}: {:?}",
+            QUERY_TIMEOUT,
+            t0.elapsed()
+        );
+        assert_not_ro_or_conn_error("mcp_status", status);
+        status_ok += 1;
+
+        let mut args = Map::new();
+        args.insert("query".into(), json!("helper"));
+        args.insert("use_ontology".into(), json!(false));
+        let t1 = Instant::now();
+        let search = server.execute_tool_pub("search_code", args).await;
+        assert!(
+            t1.elapsed() < QUERY_TIMEOUT,
+            "search_code exceeded {:?}: {:?}",
+            QUERY_TIMEOUT,
+            t1.elapsed()
+        );
+        assert_not_ro_or_conn_error("search_code", search);
+        search_ok += 1;
+    }
+
+    stop.store(true, Ordering::SeqCst);
+    worker.join().expect("worker thread panicked");
+
+    let batches = batches_done.load(Ordering::SeqCst);
+    assert!(
+        batches >= 1,
+        "worker must complete at least one embed write batch (got {batches})"
+    );
+    assert!(
+        status_ok >= 2 && search_ok >= 2,
+        "expected multiple successful RO queries during worker hold \
+         (mcp_status={status_ok}, search_code={search_ok}, batches={batches})"
+    );
+    eprintln!(
+        "concurrent RO MCP ok: mcp_status={status_ok} search_code={search_ok} \
+         worker_batches={batches}"
+    );
+
+    tokio::task::block_in_place(|| scoped.cleanup());
+}

--- a/tests/mcp_query_only_side_effects_test.rs
+++ b/tests/mcp_query_only_side_effects_test.rs
@@ -1,0 +1,71 @@
+//! Read-only MCP must not trigger pipeline side effects.
+//!
+//! Query-only servers (`with_read_only(true)`) must never auto-index on start,
+//! never reindex via `ensure_project_indexed` on tool calls, never arm
+//! background embed, and must disable file-watch reindex when constructed with
+//! a watch path.
+
+use leankg::db::backend::init_db;
+use leankg::mcp::server::{AutoIndexDecision, MCPServer};
+use tempfile::TempDir;
+
+fn seeded_leankg() -> (TempDir, std::path::PathBuf) {
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("leankg");
+    std::fs::create_dir_all(&db_path).unwrap();
+    let db = init_db(&db_path).expect("init_db must succeed");
+    drop(db);
+    (tmp, db_path)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_only_server_skips_auto_index_on_start() {
+    let (_tmp, db_path) = seeded_leankg();
+    let server = MCPServer::new(db_path).with_read_only(true);
+
+    let decision = server
+        .auto_index_if_needed_pub()
+        .await
+        .expect("RO auto-index path must succeed without indexing");
+    assert_eq!(
+        decision,
+        AutoIndexDecision::SkippedReadOnly,
+        "RO MCP must skip auto-index freshness / index writes"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_only_execute_tool_does_not_ensure_project_indexed() {
+    let (_tmp, db_path) = seeded_leankg();
+    let project_root = db_path
+        .parent()
+        .expect("leankg lives under a project root")
+        .to_path_buf();
+
+    let server = MCPServer::new(db_path).with_read_only(true);
+
+    // Direct seam: ensure_project_indexed must short-circuit in RO (same
+    // path execute_tool would take for an empty project).
+    let decision = server
+        .ensure_project_indexed_pub(project_root.to_string_lossy().as_ref())
+        .await
+        .expect("RO ensure_project_indexed must not error");
+    assert_eq!(decision, AutoIndexDecision::SkippedReadOnly);
+}
+
+#[test]
+fn read_only_rejects_watch_or_disables_watcher() {
+    let (_tmp, db_path) = seeded_leankg();
+    let watch = db_path.parent().unwrap().to_path_buf();
+
+    let server = MCPServer::new_with_watch(db_path, watch).with_read_only(true);
+
+    assert!(
+        !server.file_watcher_enabled(),
+        "RO MCP must not enable file-watch reindex even when constructed with a watch path"
+    );
+    assert!(
+        !server.background_embed_allowed(),
+        "RO MCP must not arm or spawn background embed"
+    );
+}

--- a/tests/pg_phase6_scaling.rs
+++ b/tests/pg_phase6_scaling.rs
@@ -83,6 +83,7 @@ impl Scratch {
             pool: Arc::new(ClientPool::new(5)),
             ro_pool: Arc::new(ClientPool::new(5)),
             read_only: false,
+            write_bus: None,
         })
     }
 
@@ -92,6 +93,7 @@ impl Scratch {
             pool: Arc::new(ClientPool::new(5)),
             ro_pool: Arc::new(ClientPool::new(5)),
             read_only: true,
+            write_bus: None,
         })
     }
 }

--- a/tests/pg_phase7_bulk.rs
+++ b/tests/pg_phase7_bulk.rs
@@ -88,6 +88,7 @@ impl Scratch {
             pool: std::sync::Arc::new(ClientPool::new(2)),
             ro_pool: std::sync::Arc::new(ClientPool::new(2)),
             read_only: false,
+            write_bus: None,
         })
     }
 }

--- a/tests/pg_regression_tools.rs
+++ b/tests/pg_regression_tools.rs
@@ -62,6 +62,7 @@ impl ScratchSchema {
             pool: std::sync::Arc::new(leankg::db::backend::ClientPool::new(5)),
             ro_pool: std::sync::Arc::new(leankg::db::backend::ClientPool::new(5)),
             read_only: false,
+            write_bus: None,
         })
     }
 }

--- a/tests/pg_translate_parity_test.rs
+++ b/tests/pg_translate_parity_test.rs
@@ -90,6 +90,7 @@ fn pg_backend(schema: &str) -> std::sync::Arc<PostgresBackend> {
         pool: std::sync::Arc::new(ClientPool::new(5)),
         ro_pool: std::sync::Arc::new(ClientPool::new(5)),
         read_only: false,
+        write_bus: None,
     })
 }
 

--- a/tests/readonly_mode_test.rs
+++ b/tests/readonly_mode_test.rs
@@ -92,6 +92,18 @@ fn mcpserver_is_write_tool_classifies_correctly() {
         "promote_environment",
         "embed_control",
         "ontology_control",
+        // Completeness audit — mutators previously missing from WRITE_TOOLS.
+        "mcp_embed",
+        "index_prd",
+        "agent_diary_write",
+        "report_query_outcome",
+        "export_graph_snapshot",
+        "export_html",
+        "generate_doc",
+        "mcp_install",
+        "add_ontology_concept",
+        "add_ontology_workflow",
+        "delete_ontology_concept",
     ] {
         assert!(
             MCPServer::is_write_tool(name),
@@ -121,23 +133,76 @@ fn mcpserver_is_write_tool_classifies_correctly() {
     }
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mcpserver_rejects_all_write_tools_in_read_only_mode() {
+    use leankg::db::backend::init_db;
+    use leankg::mcp::server::MCPServer;
+    use serde_json::Map;
+
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("leankg");
+    std::fs::create_dir_all(&db_path).unwrap();
+    let db = init_db(&db_path).expect("init_db must succeed");
+    drop(db);
+
+    let server = MCPServer::new(db_path).with_read_only(true);
+
+    for name in MCPServer::write_tool_names() {
+        let err = server
+            .execute_tool_pub(name, Map::new())
+            .await
+            .expect_err(&format!(
+                "write tool '{}' must be rejected in read-only mode",
+                name
+            ));
+        assert!(
+            err.contains("read-only mode"),
+            "expected read-only error for '{}', got: {}",
+            name,
+            err
+        );
+    }
+}
+
+#[test]
+fn mcpserver_list_tools_omits_writes_when_read_only() {
+    use leankg::mcp::server::MCPServer;
+    use std::collections::HashSet;
+
+    let tmp = TempDir::new().unwrap();
+    let db_path = tmp.path().join("leankg");
+    std::fs::create_dir_all(&db_path).unwrap();
+
+    let server = MCPServer::new(db_path).with_read_only(true);
+    let listed: HashSet<String> = server.list_tool_names().into_iter().collect();
+    let writes: HashSet<&str> = MCPServer::write_tool_names().iter().copied().collect();
+
+    let overlap: Vec<&String> = listed
+        .iter()
+        .filter(|n| writes.contains(n.as_str()))
+        .collect();
+    assert!(
+        overlap.is_empty(),
+        "RO list_tools must omit all write tools; found: {:?}",
+        overlap
+    );
+    assert!(
+        listed.contains("search_code") && listed.contains("mcp_status"),
+        "RO list_tools must still include read tools"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcpserver_rejects_write_tools_in_read_only_mode() {
     use leankg::db::backend::init_db;
     use leankg::mcp::server::MCPServer;
     use serde_json::Map;
 
-    // Seed an index so the server has a real .leankg to point at.
+    // Seed schema only — RO gate short-circuits before tool dispatch/DB writes.
     let tmp = TempDir::new().unwrap();
     let db_path = tmp.path().join("leankg");
     std::fs::create_dir_all(&db_path).unwrap();
     let db = init_db(&db_path).expect("init_db must succeed");
-    // init_db already creates code_elements via init_schema; insert one row.
-    db.run_script(
-        r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env, ontology_layer] <- [['src/main.rs::main', 'function', 'main', 'src/main.rs', 1, 10, 'rust', null, null, null, '{}', 'local', 'procedural']] :put code_elements {qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env, ontology_layer}"#,
-        Default::default(),
-    )
-    .expect("code_elements put must succeed");
     drop(db);
 
     let server = MCPServer::new(db_path.clone()).with_read_only(true);
@@ -159,7 +224,7 @@ async fn mcpserver_rejects_write_tools_in_read_only_mode() {
     assert!(MCPServer::is_write_tool("add_annotation"));
 }
 
-#[tokio::test]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn mcpserver_allows_read_tools_in_read_only_mode() {
     use leankg::db::backend::init_db;
     use leankg::mcp::server::MCPServer;

--- a/tests/readonly_mode_test.rs
+++ b/tests/readonly_mode_test.rs
@@ -34,18 +34,16 @@ fn init_db_readonly_can_read_after_init_db_writes() {
 
     {
         let db = init_db(&db_path).expect("init_db must succeed");
-        db.run_script(r#":create probe {name: String}"#, Default::default())
-            .expect("probe relation create must succeed");
         db.run_script(
-            r#"?[name] <- [['alpha'], ['beta']] :put probe {name}"#,
+            r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env, ontology_layer] <- [["probe::alpha", "symbol", "alpha", "probe.rs", 1, 1, "rust", null, null, null, "{}", "local", "procedural"], ["probe::beta", "symbol", "beta", "probe.rs", 1, 1, "rust", null, null, null, "{}", "local", "procedural"]] :put code_elements {qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env, ontology_layer}"#,
             Default::default(),
         )
-        .expect("probe put must succeed");
+        .expect("code_elements put must succeed");
     }
 
     let ro_db = init_db_readonly(&db_path).expect("init_db_readonly must succeed on populated DB");
     let rows = ro_db
-        .run_script(r#"?[name] := *probe[name]"#, Default::default())
+        .run_script(r#"?[name] := *code_elements[name]"#, Default::default())
         .expect("probe read must succeed in RO mode");
     let names: Vec<String> = rows
         .rows


### PR DESCRIPTION
Sync writer/reader split + Swift line_of unicode fix from be fork (1.0.14) onto latest origin/main (v0.23.0). New leankg-mcp/leankg-worker bin targets, EmbeddingProvider (local/openai/http), query-only MCP write-tool filtering, swift line_of byte-offset fix, pg write_bus test literals.

## Verified locally (2026-08-08)
- `cargo test --release --lib` → 967/968 (1 pre-existing flaky `write_bus` race, unrelated to PR, file unchanged)
- `cargo test --release --bin leankg --bin leankg-mcp --bin leankg-worker` → 975/975
- Split integration tests green: cli_split (5), mcp_query_only_side_effects (1), concurrent_mcp_during_embed (3), readonly_mode (8)
- Live RO smoke test: `leankg-mcp mcp-http` re-execs compat `leankg` with `--read-only`; write tools rejected on tools/call, omitted from tools/list (65 tools, 0 writes), read tools (search_code) query successfully
- Swift unicode: 9/9 tests pass; only swift had the `len()-matched.len()` byte-cut bug — sql.rs and event_edges.rs already use Match::start()

## Change in this update
- `fix(test)`: `init_db_readonly_can_read_after_init_db_writes` was broken pre-existing (integration test uses real PG; virtual `probe` relation + single-quote literals fail translate). Now seeds real `code_elements` table with double-quote JSON. 8/8 readonly tests pass against live leankg-db.

## Known pre-existing (not PR scope)
- `tool_write_runs_before_buffered_embed_writes` flaky under suite load (write_bus.rs unchanged in PR)
- readonly suite requires live PG (leankg-db :5433); graph_engine_open_readonly_constructs_successfully already PG-dependent before this PR

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Refactoring
- [ ] Chore

## Testing
- [x] Unit tests pass (`cargo test`)
- [x] Integration tests pass
- [x] Manual verification (live RO MCP smoke test)

## Checklist
- [x] Code follows project conventions
- [x] Self-review completed
- [x] Documentation updated (if needed)
- [ ] No new warnings or errors
