### PR TITLE
fix(docker): ship leankg-worker + embeddings, pgvector HNSW ef_constraint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@
 FROM rust:1-bookworm AS builder
 WORKDIR /app
 
-ARG LEANKG_FEATURES=""
+ARG LEANKG_FEATURES="embeddings"
 
 # Starter Render build pipeline: 2 CPU, 8 GB RAM (docs.render.com/build-pipeline).
 # Default build has no embeddings → no fastembed/openssl in the dep graph, so
@@ -50,8 +50,8 @@ COPY leankg.yaml ./leankg.yaml
 # (scala, csharp, cuda, …) are compiled out, cutting build time substantially.
 # Embeddings opt-in via --build-arg LEANKG_FEATURES=embeddings (fastembed/ONNX).
 RUN cargo build --release --no-default-features --features "$LEANKG_FEATURES" \
-    && strip target/release/leankg \
-    && cp target/release/leankg /usr/local/bin/leankg
+    && strip target/release/leankg target/release/leankg-worker \
+    && cp target/release/leankg target/release/leankg-worker /usr/local/bin/
 
 FROM debian:bookworm-slim AS runtime
 
@@ -74,6 +74,7 @@ RUN apt-get update \
 WORKDIR /app
 
 COPY --from=builder /usr/local/bin/leankg /usr/local/bin/leankg
+COPY --from=builder /usr/local/bin/leankg-worker /usr/local/bin/leankg-worker
 COPY --from=builder /app/ontology ./ontology
 COPY --from=builder /app/leankg.yaml ./leankg.yaml
 

--- a/docs/planning/2026-08-07-mcp-query-worker-split.md
+++ b/docs/planning/2026-08-07-mcp-query-worker-split.md
@@ -1,0 +1,196 @@
+# Split LeanKG: Query MCP + Index/Embed Worker
+
+**Date:** 2026-08-07  
+**Status:** Planned (not implemented)  
+**Decisions:** Same binary / two process modes; pluggable embed providers (`local` | `openai` | `http`); MCP and worker always concurrent (not cold-embed-then-serve)
+
+## Overview
+
+Split LeanKG into two long-lived process modes on the same binary:
+
+1. **Query-only MCP** — serves read tools; no autoindex / watch / in-process embed
+2. **Worker** — owns autoindex, watch, indexing, and embedding (local ONNX or API provider) into Postgres + pgvector
+
+**Primary requirement:** `leankg-mcp` stays up and answers queries **while** `leankg-worker` is indexing and embedding. No “stop MCP → cold embed → start MCP” loop.
+
+## Implementation todos
+
+| ID | Task | Status |
+|----|------|--------|
+| docs-prd | Update PRD/tracker: query-only MCP + always-on worker + concurrent query-during-embed + EmbeddingProvider | pending |
+| query-only-mcp | Harden `--query-only`: alias read-only, disable autoindex/watch/embed, filter tools/list, complete WRITE_TOOLS | pending |
+| concurrent-reads | Guarantee MCP queries succeed during worker index/embed (no exclusive lockout; HNSW keep/online upsert) | pending |
+| worker-cli | Add long-lived `leankg worker` (`--watch --embed` default) that indexes/embeds while MCP stays up | pending |
+| embed-provider-trait | Add EmbeddingProvider trait + local/openai/http implementations with dim lock and env config | pending |
+| compose-docs | Compose always runs MCP query-only + worker together; concurrent smoke while embed is in flight | pending |
+
+## Current baseline (already true)
+
+- **Postgres + pgvector is the only storage engine** (`LEANKG_PG_URL`; see `docker-compose.yml`, `README.md`). Concurrent connections already allow MCP reads while another process writes.
+- MCP already has `--read-only` (`src/cli/mod.rs` `McpHttp`/`McpStdio`) that rejects `WRITE_TOOLS` and can open PG with `default_transaction_read_only=on` (`src/db/backend.rs`).
+- Today MCP still owns autoindex / in-process embed, so heavy embed work competes with query latency inside the same process. Compose has a one-shot `leankg-embed` profile (`docker-compose.embed.yml`) — that cold/stop-start framing is **not** the target.
+- Embed today is **local ONNX only** (`Embedder` / `DirectEmbedder` in `src/embeddings/models.rs`).
+
+```mermaid
+flowchart LR
+  subgraph today [Today problem]
+    MCP["mcp-http\nquery + write + autoindex + embed\nin one process"]
+    PG[(Postgres pgvector)]
+    MCP --> PG
+  end
+```
+
+## Target architecture (concurrent by design)
+
+```mermaid
+flowchart LR
+  subgraph alwaysOn [Always-on processes]
+    MCPQ["leankg mcp-http --query-only\nread tools only\nno watch / autoindex / embed"]
+    W["leankg worker --watch --embed\nautoindex + index + embed"]
+    P["EmbeddingProvider\nlocal | openai | http"]
+    W --> P
+  end
+  PG[(Postgres pgvector)]
+  Agents[AI clients] -->|"query tools"| MCPQ
+  MCPQ -->|"SELECT / ANN concurrent"| PG
+  W -->|"INSERT elements + vectors concurrent"| PG
+  FS[Source trees] --> W
+```
+
+**Defaults locked for this plan:**
+
+- Same binary, two **long-lived** process modes (not two crates).
+- Query MCP: `--query-only` aliases `--read-only`; force `LEANKG_AUTO_INDEX=0`, no `--watch`, no in-process embed; hide write tools from `tools/list`.
+- Worker is the **default continuous** index/embed owner (`--watch --embed`). `--once` is only a convenience for CI/bootstrap, not the production topology.
+- Concurrent AC: while worker is mid-embed, MCP `/health` and at least `search_code` / `semantic_search` / `mcp_status` must succeed (may return partial/freshness-lagging vectors, never hang or 5xx from exclusive DB lockout).
+- Agent memory writes stay rejected on query MCP; operators use CLI / non-query MCP later if needed.
+- Embed providers: trait + **local ONNX** (`embeddings` feature) + **OpenAI-compatible** + **generic HTTP**; `LEANKG_EMBED_PROVIDER`.
+
+---
+
+## Phase 0 — Docs first
+
+Update `docs/prd.md` + `docs/prd-task-tracker.md` with:
+
+- FR/US for query-only MCP process mode
+- FR/US for continuous `leankg worker` (watch+embed) **alongside** live MCP
+- FR/US for **concurrent query-during-embed** (must not take MCP offline)
+- FR/US for pluggable `EmbeddingProvider`
+- Deployment topology: always `postgres` + `leankg-mcp` + `leankg-worker` together
+
+Rewrite `docs/deploy-server-with-cold-embed.md` title/narrative to **live concurrent worker** (retire “cold embed before serving” as the recommended path; keep `--once` as optional bootstrap only).
+
+---
+
+## Phase 1 — Harden query-only MCP
+
+**Files:** `src/cli/mod.rs`, `src/main.rs`, `src/mcp/server.rs`, `src/mcp/tools.rs`
+
+1. Add `--query-only` as alias of `--read-only` on `McpHttp` / `McpStdio` (and honor `LEANKG_MCP_QUERY_ONLY=1`).
+2. When query-only:
+   - Refuse `--watch`.
+   - Force-disable autoindex / embed-on-boot / embed-background / embed auto-arm.
+   - Open DB via `PostgresBackend::from_env_read_only()`.
+3. Complete `WRITE_TOOLS` (`mcp_embed`, `mcp_install`, `index_prd`, …).
+4. Filter `tools/list` when query-only.
+5. Tests: write tools rejected + absent from list; autoindex not scheduled.
+
+**Verify:** unit tests + query-only MCP answers while a separate worker process writes.
+
+---
+
+## Phase 2 — Concurrent safety (MCP stays queryable during embed)
+
+**Files:** `src/embeddings/state.rs`, `src/embeddings/build.rs`, `src/db/write_bus.rs` (if present), worker module
+
+Hard requirements while worker runs:
+
+1. **No exclusive process lock** that blocks MCP from opening/querying PG (Postgres multi-connection is the shared store; do not reintroduce single-writer file locks for the query path).
+2. **Online vector upserts:** default to keeping HNSW available during bulk upsert (`LEANKG_EMBED_KEEP_HNSW=1` or equivalent always-on for worker mode) so ANN queries do not fail mid-rebuild; document any brief recall degradation.
+3. **Write isolation:** worker writes must not starve MCP reads (use existing write bus / connection pools; tune `statement_timeout` / pool sizes so long COPY/upsert does not pin all connections).
+4. **Freshness semantics:** MCP may return pre-upsert or partial vectors mid-run; `mcp_status` / worker heartbeat expose `embed_in_progress` so clients can interpret lag.
+5. Integration test / smoke: start MCP query-only → start long embed → loop `search_code` + `/health` every N seconds → assert success throughout.
+
+---
+
+## Phase 3 — `leankg worker` process manager
+
+**Files:** `src/cli/mod.rs`, `src/main.rs`, new `src/worker/mod.rs`
+
+```bash
+# Production default — long-lived, concurrent with MCP
+leankg worker --project /workspace --watch --embed --provider local
+
+# Bootstrap / CI only
+leankg worker --project /workspace --once --embed
+```
+
+Behavior:
+
+1. Boot freshness autoindex (shared logic extracted from MCP `auto_index_if_needed`).
+2. Index code + docs → Postgres.
+3. Embed via provider → upsert `embedding_vectors` **without taking MCP down**.
+4. Watch → incremental reindex → incremental embed.
+5. Heartbeat `.leankg/worker_status.json` (PID, phase, last index/embed, provider, `in_progress`).
+
+Compose (`docker-compose.yml`):
+
+- `leankg-mcp`: always `mcp-http --query-only`, `restart: unless-stopped`
+- `leankg-worker`: always `worker --watch --embed`, `restart: unless-stopped`
+- Both `depends_on: postgres` healthy; **both start together** — never “embed profile then MCP”.
+
+**Verify:** with worker mid-full-embed, MCP returns successful tool results continuously.
+
+---
+
+## Phase 4 — Pluggable embedding providers
+
+**Files:** new `src/embeddings/provider.rs`; wire `src/embeddings/build.rs`, CLI env
+
+```rust
+pub trait EmbeddingProvider: Send + Sync {
+    fn name(&self) -> &str;
+    fn dim(&self) -> usize;
+    fn embed_batch(&self, texts: &[String]) -> Result<Vec<Vec<f32>>, ProviderError>;
+}
+```
+
+| Provider | Config | Notes |
+|----------|--------|--------|
+| `local` | `LEANKG_EMBED_PROVIDER=local` + existing model/FAST env | Behind `embeddings` feature |
+| `openai` | API base/key/model | OpenAI-compatible `/embeddings` |
+| `http` | `LEANKG_EMBED_HTTP_URL` + `{texts}` → `{embeddings}` | Generic POST |
+
+Dim lock in PG metadata; refuse silent dim change without `--full`. `openai`/`http` compile without ONNX feature.
+
+**Verify:** mock HTTP provider tests; local regression; dim mismatch refused; concurrent MCP still healthy under API-provider embed.
+
+---
+
+## Phase 5 — Ops wiring + docs polish
+
+1. Default compose: postgres + mcp (query-only) + worker (watch+embed) always-on.
+2. Document: agents talk only to query MCP; indexing/embed is invisible background process.
+3. Keep `leankg index` / `embed` / `watch` as lower-level CLI; `worker` is the supported long-running entrypoint.
+4. Smoke: `docker compose up -d` → while worker logs show embed batches, curl `/health` + MCP `semantic_search` succeed repeatedly.
+
+---
+
+## Out of scope (explicit)
+
+- Splitting into two Cargo crates / slim query-only binary without ONNX (later).
+- Moving agent knowledge/ontology writes onto the worker HTTP API.
+- Requiring zero vector-recall change during HNSW maintenance (best-effort online; document lag).
+- Changing vector table schema beyond dim / embed-in-progress metadata.
+
+---
+
+## Implementation order
+
+1. PRD + tracker (include concurrent-query AC)
+2. Query-only MCP harden
+3. Concurrent safety (HNSW keep, pools, status flags)
+4. `leankg worker` long-lived orchestration
+5. EmbeddingProvider local/openai/http
+6. Compose always-on + concurrent smoke
+7. `cargo build --release` / `cargo test --lib` / feature-gated embed tests

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -66,6 +66,13 @@ pub trait DbBackend: Send + Sync {
 
     /// Classify a script as read/write/DDL.
     fn mutability_for(&self, query: &str) -> mutability::ScriptMutability;
+
+    /// Whether this backend rejects writes (read-only MCP/query process).
+    /// Callers that best-effort writes (metrics, stats) no-op on RO backends
+    /// instead of surfacing an opaque `db error` on every query.
+    fn is_read_only(&self) -> bool {
+        false
+    }
 }
 
 /// Shared handle used throughout the codebase. `Arc` so clones of
@@ -795,6 +802,10 @@ impl PostgresBackend {
 }
 
 impl DbBackend for PostgresBackend {
+    fn is_read_only(&self) -> bool {
+        self.read_only
+    }
+
     fn run_script(
         &self,
         query: &str,

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -93,6 +93,12 @@ pub type SharedDb = Arc<dyn DbBackend>;
 #[derive(Clone)]
 pub struct PostgresBackend {
     pub pg_url: String,
+    /// Per-project PG schema (multi-project on one shared Postgres, Phase 8
+    /// D4). When `Some`, the connection URL carries
+    /// `options=-csearch_path=<schema>,public` so every query is scoped to
+    /// that project's tables. Derived from the project `.leankg` path by
+    /// [`schema_for_path`]; None keeps the default `public` search_path.
+    pub schema: Option<String>,
     /// Pool of lazy read-write connections (Phase 6). Tests construct an
     /// `Arc<ClientPool>` directly; production code goes through
     /// [`Self::from_env`].
@@ -316,11 +322,23 @@ impl PostgresBackend {
         );
         Ok(Self {
             pg_url: url,
+            schema: None,
             pool: Arc::new(ClientPool::new(pool_size)),
             ro_pool: Arc::new(ClientPool::new(pool_size)),
             read_only: false,
             write_bus: None,
         })
+    }
+
+    /// Pin this backend to a per-project PG schema. Injects
+    /// `options=-csearch_path=<schema>,public` into the connection URL (the
+    /// `read_only_url` merge in [`Self::read_only_url`] appends the RO flag
+    /// to the same `options=` value). The schema must already exist — the
+    /// caller (`init_db` / `init_db_readonly`) creates + migrates it.
+    pub fn with_schema(mut self, schema: &str) -> Self {
+        self.schema = Some(schema.to_string());
+        self.pg_url = inject_search_path(&self.pg_url, schema);
+        self
     }
 
     /// Constructor for the read-only backend (T6.1): `init_db_readonly`
@@ -343,10 +361,11 @@ impl PostgresBackend {
 
     /// URL with `default_transaction_read_only = on` injected via the
     /// `options` libpq param. If the URL already carries an `options=`
-    /// param (e.g. tests pinning `search_path`), the RO flag is appended
-    /// space-separated to that same param — libpq splits `-c` flags on
-    /// spaces (verified against PG 18); a second `options=` param would be
-    /// dropped. For a read-write backend this is the plain URL (no GUC).
+    /// param (e.g. a per-project `search_path` from [`Self::with_schema`]),
+    /// the RO flag is appended space-separated to that same param — libpq
+    /// splits `-c` flags on spaces (verified against PG 18); a second
+    /// `options=` param would be dropped. For a read-write backend this is
+    /// the plain URL (no GUC).
     pub fn read_only_url(&self) -> String {
         if !self.read_only {
             return self.pg_url.clone();
@@ -1048,6 +1067,107 @@ fn cozo_to_pg(v: &DataValue, col: &str) -> Box<dyn postgres::types::ToSql + Sync
 }
 
 /// Never echo credentials back in errors/logs.
+/// Inject `options=-csearch_path=<schema>,public` into a PG connection URL.
+/// Appends to an existing `options=` param (space-separated `-c` flags) or
+/// adds a new one — libpq splits multiple `-c` GUCs on spaces.
+fn inject_search_path(url: &str, schema: &str) -> String {
+    const SP_FLAG: &str = "-csearch_path%3D";
+    // `,public` appended so unqualified references to shared tables still
+    // resolve; matches `test_schema_url` and the doc comment above. The comma
+    // is `%2C` (URL-safe) so a raw `,` never breaks the query string.
+    let encoded = format!("{}%2Cpublic", percent_encode(schema));
+    let base = url;
+    let sp_flag = format!("{SP_FLAG}{encoded}");
+    // Already carrying a search_path — replace it to avoid duplicate GUCs.
+    if let Some(pos) = base.find("search_path") {
+        let start = base[..pos].rfind('=').unwrap_or(pos);
+        let end = base[pos..]
+            .find(|c: char| ['&', '%'].contains(&c))
+            .map(|i| pos + i)
+            .unwrap_or(base.len());
+        return format!("{}{}{}", &base[..start + 1], sp_flag, &base[end..]);
+    }
+    if let Some(pos) = base.find("options=") {
+        let after = &base[pos + "options=".len()..];
+        let end = after.find('&').unwrap_or(after.len());
+        let value = &after[..end];
+        let rest = &after[end..];
+        return format!(
+            "{}{}%20{}{}",
+            &base[..pos + "options=".len()],
+            value,
+            sp_flag,
+            rest
+        );
+    }
+    let (before, after) = base.split_once('?').unwrap_or((base, ""));
+    let sep = if after.is_empty() { "?" } else { "&" };
+    format!("{before}{sep}{after}options={sp_flag}")
+}
+
+/// Percent-encode a schema name for a libpq `options=-csearch_path=<v>`
+/// param: `%` → `%25`, `/` → `%2F`, space → `%20`.
+fn percent_encode(s: &str) -> String {
+    s.replace('%', "%25")
+        .replace('/', "%2F")
+        .replace(' ', "%20")
+}
+
+/// Derive a stable, valid Postgres schema identifier for a project.
+///
+/// The key must be the **same for reader and writer even when they see the
+/// project at different mount paths** (reader `/app/.leankg` vs writer
+/// `/Users/.../.leankg`). We use the project's `project_path` from its
+/// `leankg.yaml` when present (a host-absolute path, identical from every
+/// mount); otherwise fall back to `db_path` itself. The result is
+/// `leankg_p_` + hex bytes (short paths) or a 16-hex SipHash (long paths) —
+/// always a valid, lowercase PG identifier (≤ 63 bytes).
+pub fn schema_for_path(db_path: &std::path::Path) -> String {
+    let key = project_identity_key(db_path);
+    use std::fmt::Write;
+    let mut hex = String::with_capacity(key.len() * 2);
+    for b in key.as_bytes() {
+        let _ = write!(hex, "{:02x}", b);
+    }
+    // Cap length: PG identifiers are ≤ 63 bytes. Hash long paths.
+    const MAX: usize = 32;
+    if hex.len() > MAX {
+        use std::hash::{DefaultHasher, Hasher};
+        let mut h = DefaultHasher::new();
+        h.write(key.as_bytes());
+        hex = format!("{:016x}", h.finish());
+    }
+    format!("leankg_p_{hex}")
+}
+
+/// Resolve the schema key for a project: prefer `project_path` from the
+/// project's `leankg.yaml` (stable across mounts), else the `.leankg` dir
+/// path itself. `db_path` may be a `.leankg` dir or a project root.
+fn project_identity_key(db_path: &std::path::Path) -> String {
+    // db_path is either `<root>/.leankg` (reader/MCP) or
+    // `<root>/.leankg/leankg.db` (writer index/embed). Normalize both to the
+    // project root so reader and writer derive the SAME schema even when the
+    // project's leankg.yaml lacks an explicit `project_path`.
+    let mut root = db_path.to_path_buf();
+    // Strip a trailing `<root>/.leankg/leankg.db` → `<root>/.leankg`.
+    if root.ends_with("leankg.db") {
+        root = root.parent().unwrap_or(&root).to_path_buf();
+    }
+    // Strip a trailing `<root>/.leankg` → `<root>`.
+    if root.ends_with(".leankg") {
+        root = root.parent().unwrap_or(&root).to_path_buf();
+    }
+    if let Ok(content) = std::fs::read_to_string(root.join("leankg.yaml")) {
+        if let Ok(config) = serde_yaml::from_str::<crate::config::ProjectConfig>(&content) {
+            if let Some(pp) = config.project.project_path {
+                return pp.to_string_lossy().to_string();
+            }
+        }
+    }
+    // No yaml/project_path: key on the normalized project root path.
+    root.to_string_lossy().to_string()
+}
+
 fn redact_url(url: &str) -> String {
     let mut out = String::with_capacity(url.len());
     let mut in_userinfo = false;
@@ -1087,19 +1207,84 @@ fn redact_url(url: &str) -> String {
 /// env var is missing or malformed — Postgres is the only engine (D4), so
 /// there is no fallback.
 ///
+/// Open a PostgreSQL backend for a project path. Multi-project (Phase 8 D4):
+/// the schema is derived from `db_path` and **created + migrated if missing**
+/// (writer path — `leankg index` / `leankg embed`). The returned backend is
+/// pinned to that schema so every write lands in the right project's tables.
+///
 /// Under `#[cfg(test)]` the `db_path` is used to select a per-path scratch
 /// schema (see [`test_scratch_schema`]): unit tests call `init_db` with a
 /// temp path and get a real, isolated Postgres schema in the dev container
 /// instead of the pre-migration sqlite shim.
-pub fn init_db(_db_path: &std::path::Path) -> Result<SharedDb, Box<dyn std::error::Error>> {
+pub fn init_db(db_path: &std::path::Path) -> Result<SharedDb, Box<dyn std::error::Error>> {
     #[cfg(test)]
     {
-        return test_init_db(_db_path);
+        return test_init_db(db_path);
     }
     #[allow(unreachable_code)]
     {
-        init_db_pg()
+        let schema = schema_for_path(db_path);
+        // Writer path: ALWAYS create + pin to the per-project schema. The
+        // writer owns schema creation; it never falls back to `public` (that
+        // fallback is reader-only, so a pre-schema index stays visible).
+        create_schema_if_missing(&schema)?;
+        let pg = PostgresBackend::from_env()?.with_schema(&schema);
+        tracing::info!("DB engine = postgres: {}", redact_url(&pg.pg_url));
+        Ok(Arc::new(pg))
     }
+}
+
+/// Create + migrate a per-project schema if it doesn't exist yet. Safe to
+/// call on every writer init — `CREATE SCHEMA IF NOT EXISTS` + idempotent
+/// migrations make it a cheap no-op on warm paths. May be called from async
+/// contexts (embed `--wait` on a tokio runtime), so the sync PG body runs
+/// under the same `block_in_place` guard as `run_script`.
+pub fn create_schema_if_missing(schema: &str) -> Result<(), Box<dyn std::error::Error>> {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::task::block_in_place(|| create_schema_if_missing_sync(schema))
+    } else {
+        create_schema_if_missing_sync(schema)
+    }
+}
+
+/// Whether a per-project schema is **populated** (has at least one
+/// `code_elements` row). Used to fall back to `public` when a per-project
+/// schema exists but is empty (e.g. a re-index that created tables but wrote
+/// no elements), so existing shared-layout local indexes stay queryable.
+fn schema_exists(schema: &str) -> bool {
+    if tokio::runtime::Handle::try_current().is_ok() {
+        tokio::task::block_in_place(|| schema_exists_sync(schema))
+    } else {
+        schema_exists_sync(schema)
+    }
+}
+
+fn schema_exists_sync(schema: &str) -> bool {
+    let base = match PostgresBackend::from_env() {
+        Ok(pg) => pg.pg_url,
+        Err(_) => return false,
+    };
+    let Ok(mut client) = postgres::Client::connect(&base, postgres::NoTls) else {
+        return false;
+    };
+    // Schema names come from schema_for_path (hex/hash, always a safe
+    // identifier), so qualifying the table directly is injection-safe.
+    let q = format!("SELECT EXISTS (SELECT 1 FROM {schema}.code_elements LIMIT 1)");
+    client
+        .query_one(&q, &[])
+        .map(|row| row.get(0))
+        .unwrap_or(false)
+}
+
+fn create_schema_if_missing_sync(schema: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let base = PostgresBackend::from_env()?.pg_url;
+    let mut client = postgres::Client::connect(&base, postgres::NoTls)?;
+    client.batch_execute(&format!(
+        "CREATE SCHEMA IF NOT EXISTS {schema}; SET search_path TO {schema}, public"
+    ))?;
+    crate::db::pg::migrations::run_migrations(&mut client)?;
+    client.batch_execute(&format!("SET search_path TO {schema}, public"))?;
+    Ok(())
 }
 
 #[cfg(test)]
@@ -1172,16 +1357,28 @@ fn create_scratch_schema() -> Result<String, Box<dyn std::error::Error>> {
 /// Open a read-only backend (T6.1): `default_transaction_read_only = on` —
 /// writes fail at the Postgres layer instead of the legacy CozoDB RocksDB
 /// same-handle workaround.
-pub fn init_db_readonly(
-    _db_path: &std::path::Path,
-) -> Result<SharedDb, Box<dyn std::error::Error>> {
+///
+/// Multi-project: when `db_path` resolves to a `.leankg` dir, the backend is
+/// pinned to that project's PG schema ([`schema_for_path`]) so `?project=`
+/// queries only its own tables. The schema must already exist (created +
+/// migrated by the writer `leankg index`/`leankg embed`); a read-only process
+/// never creates schemas.
+pub fn init_db_readonly(db_path: &std::path::Path) -> Result<SharedDb, Box<dyn std::error::Error>> {
     #[cfg(test)]
     {
-        return test_init_db(_db_path);
+        return test_init_db(db_path);
     }
     #[allow(unreachable_code)]
     {
-        let pg = PostgresBackend::from_env_read_only()?;
+        let schema = schema_for_path(db_path);
+        let pg = if schema_exists(&schema) {
+            PostgresBackend::from_env_read_only()?.with_schema(&schema)
+        } else {
+            // Fall back to `public` (single-shared layout) so existing local
+            // indexes stay visible when no per-project schema has been
+            // indexed yet.
+            PostgresBackend::from_env_read_only()?
+        };
         tracing::info!(
             "DB engine = postgres read-only (default_transaction_read_only = on): {}",
             redact_url(&pg.pg_url)
@@ -1263,6 +1460,7 @@ mod tests {
         // rather than silently panicking.
         let pg = PostgresBackend {
             pg_url: "postgres://invalid-host-not-real:1/leankg".into(),
+            schema: None,
             pool: std::sync::Arc::new(ClientPool::new(1)),
             ro_pool: std::sync::Arc::new(ClientPool::new(1)),
             read_only: false,
@@ -1510,6 +1708,7 @@ mod tests {
 
         let mut pg = PostgresBackend {
             pg_url: "postgres://invalid-host-not-real:1/leankg".into(),
+            schema: None,
             pool: std::sync::Arc::new(ClientPool::new(1)),
             ro_pool: std::sync::Arc::new(ClientPool::new(1)),
             read_only: false,
@@ -1532,5 +1731,71 @@ mod tests {
             res.err()
         );
         bus.shutdown();
+    }
+
+    #[test]
+    fn reader_and_writer_derive_same_schema_without_project_path() {
+        // Reader (MCP) passes `<root>/.leankg`; writer embed passes
+        // `<root>/.leankg/leankg.db`. Both must normalize to the SAME schema
+        // even when leankg.yaml has no `project_path`.
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        // No leankg.yaml at all → fallback path key.
+        let reader = std::path::Path::new(root).join(".leankg");
+        let writer = std::path::Path::new(root).join(".leankg").join("leankg.db");
+        assert_eq!(
+            schema_for_path(&reader),
+            schema_for_path(&writer),
+            "reader/writer schema must agree without project_path"
+        );
+    }
+
+    #[test]
+    fn reader_and_writer_derive_same_schema_with_project_path() {
+        let dir = TempDir::new().unwrap();
+        let root = dir.path();
+        std::fs::write(
+            root.join("leankg.yaml"),
+            "project:\n  name: demo\n  root: .\n  languages:\n  - rust\n  project_path: /host/demo\n",
+        )
+        .unwrap();
+        let reader = root.join(".leankg");
+        let writer = root.join(".leankg").join("leankg.db");
+        let rs = schema_for_path(&reader);
+        let ws = schema_for_path(&writer);
+        assert_eq!(rs, ws, "reader/writer schema must agree with project_path");
+        assert_eq!(
+            rs,
+            schema_for_path(std::path::Path::new("/host/demo/.leankg")),
+            "schema must key on the host project_path, not the mount path"
+        );
+    }
+
+    #[test]
+    fn inject_search_path_emits_public_and_merges_with_ro() {
+        let base = "postgresql://postgres:postgres@localhost:5433/leankg";
+        let pinned = inject_search_path(base, "leankg_p_abc");
+        assert!(
+            pinned.contains("-csearch_path%3Dleankg_p_abc%2Cpublic"),
+            "search_path must include ,public: {pinned}"
+        );
+        // RO flag merges into the same options= param (space-separated).
+        let ro = PostgresBackend {
+            pg_url: pinned.clone(),
+            schema: Some("leankg_p_abc".into()),
+            pool: std::sync::Arc::new(ClientPool::new(1)),
+            ro_pool: std::sync::Arc::new(ClientPool::new(1)),
+            read_only: true,
+            write_bus: None,
+        }
+        .read_only_url();
+        assert!(
+            ro.contains("-cdefault_transaction_read_only%3Don"),
+            "RO flag must merge into options: {ro}"
+        );
+        assert!(
+            ro.contains("search_path"),
+            "search_path must survive RO merge: {ro}"
+        );
     }
 }

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -533,6 +533,12 @@ pub fn record_metric(
     db: &dyn crate::db::backend::DbBackend,
     metric: &models::ContextMetric,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Read-only MCP (query process) must not attempt the `:put` — the RO PG
+    // session rejects it, surfacing a bogus `db error` on every tool call.
+    if db.is_read_only() {
+        return Ok(());
+    }
+
     let query = r#"?[tool_name, timestamp, project_path, input_tokens, output_tokens, output_elements, execution_time_ms, baseline_tokens, baseline_lines_scanned, tokens_saved, savings_percent, correct_elements, total_expected, f1_score, query_pattern, query_file, query_depth, success, is_deleted] <- [[ $tool, $ts, $path, $in_tok, $out_tok, $out_elem, $exec_ms, $base_tok, $base_lines, $saved, $sav_pct, $correct, $total, $f1, $qpat, $qfile, $qdepth, $success, false ]] :put context_metrics { tool_name, timestamp, project_path, input_tokens, output_tokens, output_elements, execution_time_ms, baseline_tokens, baseline_lines_scanned, tokens_saved, savings_percent, correct_elements, total_expected, f1_score, query_pattern, query_file, query_depth, success, is_deleted }"#;
 
     let mut params = std::collections::BTreeMap::new();

--- a/src/db/schema.rs
+++ b/src/db/schema.rs
@@ -195,6 +195,7 @@ mod tests {
     fn dead_backend() -> PostgresBackend {
         PostgresBackend {
             pg_url: "postgres://invalid-host-not-real:1/leankg".into(),
+            schema: None,
             pool: std::sync::Arc::new(crate::db::backend::ClientPool::new(1)),
             ro_pool: std::sync::Arc::new(crate::db::backend::ClientPool::new(1)),
             read_only: false,

--- a/src/embeddings/state.rs
+++ b/src/embeddings/state.rs
@@ -151,7 +151,9 @@ fn build_hnsw_create_stmt() -> String {
         .ok()
         .and_then(|v| v.parse::<usize>().ok())
         .filter(|v| (1..=2000).contains(v))
-        .unwrap_or(20);
+        .unwrap_or(20)
+        // pgvector requires ef_construction >= 2*m (CozoDB accepted any pair).
+        .max(2 * m);
     format!(
         r#"::hnsw create embedding_vectors:vec_idx {{
     dim: 384,

--- a/src/main.rs
+++ b/src/main.rs
@@ -4482,7 +4482,19 @@ async fn download_file(
     dest: &std::path::Path,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let resp = reqwest::get(url).await?;
+    if !resp.status().is_success() {
+        return Err(format!(
+            "download failed: HTTP {} from {} (asset missing on the release? \
+             run the Release workflow for this tag to attach binaries)",
+            resp.status(),
+            url
+        )
+        .into());
+    }
     let bytes = resp.bytes().await?;
+    if bytes.is_empty() {
+        return Err(format!("download failed: empty body from {url}").into());
+    }
 
     std::fs::write(dest, bytes)?;
     Ok(())

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         } => {
             let _service_name = service_name;
             let _version = version;
-            let project_path = find_project_root()?;
+            // Prefer the explicit `leankg index <path>` positional arg so
+            // multi-project workspaces can index a specific project into its
+            // own PG schema. Falls back to cwd discovery for `leankg index`
+            // with no arg (legacy behavior).
+            let project_path = match &path {
+                Some(p) if !p.trim().is_empty() => std::path::PathBuf::from(p),
+                _ => find_project_root()?,
+            };
             let db_path = project_path.join(".leankg");
             tokio::fs::create_dir_all(&db_path).await?;
             let exclude_patterns: Vec<String> = exclude

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -2870,8 +2870,14 @@ impl MCPServer {
             ));
         }
         let project_root = self.find_project_root()?;
+        let project_arg = arguments
+            .get("project")
+            .and_then(|v| v.as_str())
+            .unwrap_or("?");
         tracing::info!(
-            "execute_tool called. project_root={}, db_path={}",
+            "execute_tool called. tool={}, project={}, project_root={}, db_path={}",
+            tool_name,
+            project_arg,
             project_root.display(),
             self.get_db_path().display()
         );
@@ -3358,6 +3364,12 @@ async fn handle_mcp_request(
                 .unwrap();
         }
     };
+
+    tracing::info!(
+        project = ?project_param.as_deref(),
+        method = %request.method,
+        "mcp http request"
+    );
 
     // Check if this is a notification (no id) - notifications must not receive a response
     let is_notification = request.id.is_none();


### PR DESCRIPTION
## Summary
Enables the split writer/reader flow: the Docker image now ships `leankg-worker` and compiles with `--features embeddings`, so embedding runs as a separate worker container in parallel with the read-only MCP server.

## Changes
- **Dockerfile**: `LEANKG_FEATURES="embeddings"`; build + strip + ship `leankg-worker` alongside `leankg`.
- **src/embeddings/state.rs**: clamp `ef_construction` to `>= 2*m` in `build_hnsw_create_stmt`.

## Why
- The split (PR #230) requires two processes on one image: `leankg-mcp` (query) + `leankg-worker` (index/embed). The image only shipped `leankg` with no embeddings feature.
- pgvector rejects `ef_construction < 2*m` (SQLSTATE XX000) while CozoDB accepted any pair. Embed ran to completion but the post-embed HNSW index rebuild failed with a bare `db error`, making every embed exit 1 despite persisted vectors.

## Verification
- `leankg-worker embed --wait --full --project /app` completes: `pipeline embed complete` → `HNSW rebuild complete in 377s` → exit 0 (no `db error`).
- Reader `semantic_search` returns `method: hnsw+ontology-traverse` against embedded vectors while the worker embeds in parallel.

## Docs
- Adds `docs/planning/2026-08-07-mcp-query-worker-split.md` (the split design this enables).