### PR TITLE
fix: index .tsx/.jsx files and route them to the TSX grammar

### DIFF
--- a/src/indexer/lang/registry.rs
+++ b/src/indexer/lang/registry.rs
@@ -1662,6 +1662,26 @@ pub static LANG_SPECS: &[LanguageSpec] = &[
         grammar: Some(|| tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
     },
     LanguageSpec {
+        // The plain "typescript" grammar (LANGUAGE_TYPESCRIPT) cannot parse
+        // JSX syntax (`<Foo>...`), so .tsx/.jsx files need the TSX grammar
+        // variant. Previously .tsx/.jsx had no LanguageSpec entry at all
+        // (not even routed to a parser), so every such file silently
+        // produced zero extracted elements regardless of project config.
+        name: "tsx",
+        extensions: &["tsx", "jsx"],
+        config_files: EMPTY,
+        tier: Tier::Full,
+        kinds: NodeKinds {
+            functions: &["function_definition", "function_declaration"],
+            classes: &["class_declaration"],
+            interfaces: &["interface_declaration"],
+            properties: EMPTY,
+            imports: &["import_statement"],
+            calls: &["call_expression"],
+        },
+        grammar: Some(|| tree_sitter_typescript::LANGUAGE_TSX.into()),
+    },
+    LanguageSpec {
         name: "go",
         extensions: &["go"],
         config_files: EMPTY,

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -287,7 +287,9 @@ pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Er
     let extensions = [
         "go",
         "ts",
+        "tsx",
         "js",
+        "jsx",
         "py",
         "rs",
         "java",


### PR DESCRIPTION
## Summary

`.tsx`/`.jsx` files silently produce **zero** extracted elements in every recent release (tested v0.19.33 through v0.24.0), despite commit 2d476355 ("fix: index *.tsx/*.jsx files and fix query regex patterns") having fixed this once before, back in April.

Root-caused by running LeanKG against a real-world Next.js App Router codebase behind a Postgres-backed multi-project setup: `.ts` files in the exact same directory tree indexed correctly (confirmed via direct DB inspection — hundreds of correct rows for sibling `.ts` files), while `.tsx` never produced a single row, for any project, regardless of project config, `project_path`, or server restart/cache state. Ruled out config/caching causes empirically before digging into the indexer itself.

## Root cause — two independent regressions stacked on top of each other

1. **`find_files_sync`'s extension whitelist** in `src/indexer/mod.rs` (the walker `mcp_index` actually calls at runtime) dropped `"tsx"`/`"jsx"` in commit 2eb2c71c28b197e95d164e53a8f4fc4c89da987e (PR #40, an unrelated web UI/UX rework, 2026-04-12 — 3 days after 2d476355590c0022494ae6df2b9a4a0201692efa added them). Several other extensions removed in that same commit (`kt`, `cpp`, `rb`, `php`, etc.) were restored in later commits; `tsx`/`jsx` were not, so affected files were never even discovered by the walker regardless of any project's `leankg.yaml` `include` patterns.

2. **`src/indexer/lang/registry.rs`'s `LanguageSpec` table never had a dedicated `tsx`/`jsx` entry.** Only `"typescript"` existed (`extensions: ["ts", "mts", "cts"]`), using `tree_sitter_typescript::LANGUAGE_TYPESCRIPT` — which cannot parse JSX syntax. `tree_sitter_typescript::LANGUAGE_TSX` (the JSX-aware grammar variant, bundled in the same crate) was never referenced anywhere in the codebase, in any commit.

Either regression alone would have blocked `.tsx`/`.jsx` indexing; both needed fixing together.

## Fix

- Add `"tsx"`/`"jsx"` back to the `find_files_sync` extension whitelist (`src/indexer/mod.rs`).
- Add a new `"tsx"` `LanguageSpec` entry (`extensions: ["tsx", "jsx"]`) using `tree_sitter_typescript::LANGUAGE_TSX`, so `get_language()` → `get_parser_for_language()` route these files to a grammar that actually understands JSX (`src/indexer/lang/registry.rs`).

## Test plan

- [x] Rebuilt from source (`cargo build --release --features embeddings`) with the fix applied
- [x] Ran `mcp_index` against a real Next.js App Router project (~260 source files across `apps/api`, `apps/web`, `apps/etl`) via the MCP HTTP server
- [x] Indexed file count went from 166 → 261 (exactly the missing `.tsx`/`.jsx` files)
- [x] Queried Postgres directly (bypassing any read-path caching): `.tsx` element count went from 0 → 178 correctly extracted elements
- [x] Spot-checked a specific component file (`app-sidebar.tsx`, a `"use client"` React function component with JSX) — confirmed `function`, `class`, and `method` elements now extracted correctly (`AppSidebar`, `AppSidebarProps`, `useDataFreshnessLabel`, `load`)
- [x] Confirmed `.ts` files continued to index correctly throughout (regression check — sibling files in the same directories, before and after)

## Risk / notes

- Minimal, additive change — no existing `LanguageSpec` entries or extension mappings were modified, only extended.
- `NodeKinds` for the new `tsx` entry mirror the existing `typescript` entry (same node kind names apply — `LANGUAGE_TSX` is a superset grammar of `LANGUAGE_TYPESCRIPT` that additionally parses JSX constructs).