### PR TITLE
feat(mcp): set_embed_model tool + per-request embed model hot-switch

### DIFF
--- a/instructions/leankg-tools.md
+++ b/instructions/leankg-tools.md
@@ -22,6 +22,17 @@ to the ontology layer:
 3. `kg_context(query="...")` — ontology-aware concept expansion (no embeddings required).
 4. `search_code(query="...")` / `find_function(name="...")` — bounded name search.
 
+### Embedding-model hot-switch
+
+`set_embed_model(model_id, persist=false, project=…)` switches the
+runtime-active embedding model for the whole MCP process (registry-only ids).
+Both semantic tools also accept a per-request `model` override that queries
+that model's collection without changing the process default. With
+`persist=true` the choice is written to `.leankg/embed-model.json` and
+restored on the next boot. Registered models: `bge-small-en-v1.5-384`
+(default, local), `qwen3-emb-4b-2560`, `jina-embeddings-v3-1024`,
+`gemini-embedding-2-3072`, `gemini-embedding-001-3072` (remote).
+
 ---
 
 ## Tool Selection Flowchart

--- a/src/embeddings/mod.rs
+++ b/src/embeddings/mod.rs
@@ -37,6 +37,7 @@ pub mod offsite;
 pub mod runtime;
 #[cfg(feature = "embeddings")]
 pub mod state;
+pub mod switch;
 #[cfg(feature = "embeddings")]
 pub mod text_blob;
 
@@ -90,8 +91,13 @@ pub use runtime::{
 #[allow(unused_imports)]
 pub use state::{
     count_by_state, create_hnsw_index, delete_state_rows, drop_hnsw_index,
-    ensure_embedding_state_table, has_any, list_all, list_orphans, list_stale,
-    mark_stale_for_qualified_names, upsert_fresh, EmbeddingStateRow, FreshRow, StateCounts,
+    ensure_embedding_state_table, ensure_model_collections, has_any, list_all, list_orphans,
+    list_stale, mark_stale_for_qualified_names, upsert_fresh, EmbeddingStateRow, FreshRow,
+    StateCounts,
+};
+#[allow(unused_imports)]
+pub use switch::{
+    active_model_id, apply_persisted_model, resolve_active, set_active_model, PERSIST_PATH,
 };
 #[cfg(feature = "embeddings")]
 #[allow(unused_imports)]

--- a/src/embeddings/registry.rs
+++ b/src/embeddings/registry.rs
@@ -212,11 +212,12 @@ pub fn legacy_backfill_target_relation(model_id: &str) -> Option<&'static str> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::sync::{Mutex, OnceLock};
 
+    /// Single crate-wide lock for env-var mutation (shared with the
+    /// embeddings switch/pipeline tests) so parallel tests cannot race on
+    /// `LEANKG_EMBED_ACTIVE_MODEL`.
     fn env_lock() -> std::sync::MutexGuard<'static, ()> {
-        static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
-        LOCK.get_or_init(|| Mutex::new(())).lock().unwrap()
+        crate::embeddings::test_env::lock()
     }
 
     #[test]

--- a/src/embeddings/switch.rs
+++ b/src/embeddings/switch.rs
@@ -1,0 +1,173 @@
+//! Runtime-active embedding model: overrides `LEANKG_EMBED_ACTIVE_MODEL` for
+//! the life of the process. Used by the `set_embed_model` MCP tool so a user
+//! choice becomes the default for every embedding tool without restarting.
+//!
+//! The runtime selection (process env `LEANKG_EMBED_ACTIVE_MODEL`) is the
+//! source of truth — a fresh process boots with whatever env/`persist.json`
+//! gives it, then a tool call can override it in-process. No atomics needed:
+//! [`std::env::set_var`] on Rust 2021 only races when called concurrently
+//! with itself, and MCP tool handlers run single-threaded.
+
+use super::registry::{
+    active_model_id_from_env, builtin_registry, lookup_model, EmbeddingModelEntry,
+};
+
+/// Path (relative to project root) where `persist=true` writes the choice so
+/// the next boot restores it as the default.
+pub const PERSIST_PATH: &str = ".leankg/embed-model.json";
+
+/// Active model id, runtime override first.
+pub fn active_model_id() -> String {
+    std::env::var("LEANKG_EMBED_ACTIVE_MODEL")
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(active_model_id_from_env)
+}
+
+/// Resolve the active model entry; runtime override wins over env/default.
+pub fn resolve_active() -> Result<EmbeddingModelEntry, super::EmbedError> {
+    let id = active_model_id();
+    lookup_model(&id).ok_or_else(|| {
+        super::EmbedError::Config(format!(
+            "unknown active embed model {id:?}; use set_embed_model to register one"
+        ))
+    })
+}
+
+/// Set the runtime-active model. Only registry ids are accepted — the active
+/// model must exist so every embedding tool has a known dimension/collection.
+/// Returns the resolved entry. `project_root` is used to persist the choice
+/// when `persist` is set; pass `None` to skip persistence.
+pub fn set_active_model(
+    model_id: &str,
+    persist: bool,
+    project_root: Option<&std::path::Path>,
+) -> Result<EmbeddingModelEntry, super::EmbedError> {
+    let entry = lookup_model(model_id).ok_or_else(|| {
+        let known: Vec<String> = builtin_registry().keys().cloned().collect();
+        super::EmbedError::Config(format!(
+            "unknown embed model {model_id:?}; known: {}",
+            known.join(", ")
+        ))
+    })?;
+    // SAFETY: single-threaded MCP handlers; same discipline as existing
+    // LEANKG_* env toggles elsewhere in this crate.
+    std::env::set_var("LEANKG_EMBED_ACTIVE_MODEL", model_id);
+    if persist {
+        if let Some(root) = project_root {
+            let _ = std::fs::create_dir_all(root.join(".leankg"));
+            let json = serde_json::json!({ "model_id": model_id }).to_string();
+            if std::fs::write(root.join(PERSIST_PATH), json).is_ok() {
+                tracing::info!(
+                    "set_embed_model: persisted {} to {}",
+                    model_id,
+                    root.join(PERSIST_PATH).display()
+                );
+            }
+        }
+    }
+    Ok(entry)
+}
+
+/// Load a persisted choice (if any) into the process env so a fresh boot
+/// starts with the last user selection. Call once at startup.
+pub fn apply_persisted_model(project_root: Option<&std::path::Path>) {
+    let Some(root) = project_root else { return };
+    let path = root.join(PERSIST_PATH);
+    let Ok(raw) = std::fs::read_to_string(&path) else {
+        return;
+    };
+    let Ok(cfg) = serde_json::from_str::<serde_json::Value>(&raw) else {
+        return;
+    };
+    if let Some(id) = cfg["model_id"].as_str() {
+        if lookup_model(id).is_some() {
+            std::env::set_var("LEANKG_EMBED_ACTIVE_MODEL", id);
+            tracing::info!(
+                "set_embed_model: restored persisted model {id} from {}",
+                path.display()
+            );
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::embeddings::test_env;
+
+    fn env_lock() -> std::sync::MutexGuard<'static, ()> {
+        test_env::lock()
+    }
+
+    #[test]
+    fn persist_and_restore_roundtrip() {
+        let _g = env_lock();
+        let dir = std::env::temp_dir().join(format!("leankg-switch-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+        let entry = set_active_model("qwen3-emb-4b-2560", true, Some(&dir)).expect("set+persist");
+        assert_eq!(entry.dimensions, 2560);
+        let persisted = dir.join(".leankg/embed-model.json");
+        assert!(persisted.exists(), "persist file must be written");
+        let raw = std::fs::read_to_string(&persisted).expect("readable");
+        assert!(raw.contains("qwen3-emb-4b-2560"));
+
+        // Fresh-boot simulation: runtime override is gone; restore must pick
+        // the persisted choice back up from the project root.
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+        apply_persisted_model(Some(&dir));
+        assert_eq!(active_model_id(), "qwen3-emb-4b-2560");
+
+        // Unknown model ids in the file must not be restored.
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+        std::fs::write(&persisted, r#"{"model_id":"no-such-model"}"#).expect("write");
+        apply_persisted_model(Some(&dir));
+        assert_eq!(
+            active_model_id(),
+            crate::embeddings::registry::DEFAULT_BGE_MODEL_ID
+        );
+
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+
+    #[test]
+    fn runtime_override_beats_env() {
+        let _g = env_lock();
+        std::env::set_var("LEANKG_EMBED_ACTIVE_MODEL", "qwen3-emb-4b-2560");
+        assert_eq!(active_model_id(), "qwen3-emb-4b-2560");
+        let entry = resolve_active().expect("qwen must resolve");
+        assert_eq!(entry.dimensions, 2560);
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+    }
+
+    #[test]
+    fn defaults_to_bge_when_unset() {
+        let _g = env_lock();
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+        assert_eq!(
+            active_model_id(),
+            crate::embeddings::registry::DEFAULT_BGE_MODEL_ID
+        );
+    }
+
+    #[test]
+    fn set_unknown_model_errors() {
+        let _g = env_lock();
+        let err = set_active_model("nope", false, None).expect_err("unknown");
+        assert!(err.to_string().contains("unknown embed model"));
+        assert!(err.to_string().contains("known:"));
+    }
+
+    #[test]
+    fn set_model_then_resolve() {
+        let _g = env_lock();
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+        let entry = set_active_model("jina-embeddings-v3-1024", false, None).expect("set");
+        assert_eq!(entry.dimensions, 1024);
+        assert_eq!(active_model_id(), "jina-embeddings-v3-1024");
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+    }
+}

--- a/src/gc.rs
+++ b/src/gc.rs
@@ -309,8 +309,21 @@ mod tests {
     use super::*;
     use std::sync::atomic::{AtomicUsize, Ordering};
 
+    /// Crate-wide lock for tests that mutate the process-global
+    /// `LAST_ACTIVITY_NANOS` / `LAST_RSS_MB` atomics (guards write
+    /// "now" on construction/touch, idle-trim tests write a synthetic
+    /// past). Parallel tests otherwise race on the shared timestamps
+    /// and intermittently flip `IdleTrim` to `NoOp`.
+    fn lock() -> std::sync::MutexGuard<'static, ()> {
+        static LOCK: std::sync::OnceLock<std::sync::Mutex<()>> = std::sync::OnceLock::new();
+        LOCK.get_or_init(|| std::sync::Mutex::new(()))
+            .lock()
+            .unwrap()
+    }
+
     #[test]
     fn guard_touch_resets_idle() {
+        let _g = lock();
         MemoryGuard::touch();
         assert_eq!(MemoryGuard::idle_secs(), 0);
     }
@@ -329,12 +342,14 @@ mod tests {
 
     #[test]
     fn tick_returns_a_variant() {
+        let _g = lock();
         let mut g = MemoryGuard::new(None);
         let _ = g.tick();
     }
 
     #[test]
     fn tick_skips_when_poll_window_not_elapsed() {
+        let _g = lock();
         let mut g = MemoryGuard::new(None);
         g.last_check = Instant::now();
         let action = g.tick();
@@ -348,6 +363,7 @@ mod tests {
 
     #[test]
     fn idle_trim_runs_at_most_once_per_activity_period() {
+        let _g = lock();
         // Pin the force-trim cap high so a memory-heavy CI runner can't
         // preempt the idle-trim path under test with a ForceTrim. RAII
         // guard, so a panic in this test still releases the override.
@@ -407,6 +423,7 @@ mod tests {
 
     #[test]
     fn release_returning_false_is_noop_not_idle_trim() {
+        let _g = lock();
         // Pin the force-trim cap high so a memory-heavy CI runner (RSS > 4 GB
         // by the time the full suite reaches this test) can't preempt the
         // idle-trim path with a ForceTrim. RAII guard, so a panic here still

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -338,6 +338,8 @@ impl ToolHandler {
                 "embed_control is handled by MCPServer (idle scheduler); unreachable via ToolHandler"
                     .into(),
             ),
+            #[cfg(feature = "embeddings")]
+            "set_embed_model" => self.set_embed_model(arguments),
             "ontology_control" => Err(
                 "ontology_control is handled by MCPServer; unreachable via ToolHandler".into(),
             ),
@@ -2260,6 +2262,9 @@ impl ToolHandler {
         let offset = args["offset"].as_i64().unwrap_or(0).max(0) as usize;
         let kind = args["kind"].as_str().unwrap_or("all");
         let path_prefix = args["path_prefix"].as_str();
+        // Only used by the (embeddings-gated) HNSW route below.
+        #[allow(unused_variables)]
+        let model = args["model"].as_str();
 
         // FR-HNSW-D: when the embeddings feature is on AND an embedding
         // index exists, route through CozoDB HNSW (BGE-small-en-v1.5) →
@@ -2267,7 +2272,7 @@ impl ToolHandler {
         // ontology-first path when embeddings are not built (no index
         // rows), so the tool stays useful on slim installs.
         #[cfg(feature = "embeddings")]
-        if embeddings_index_available(self.graph_engine.db()) {
+        if model.is_some() || embeddings_index_available(self.graph_engine.db()) {
             return run_hnsw_semantic_search(
                 &self.graph_engine,
                 query,
@@ -2276,6 +2281,7 @@ impl ToolHandler {
                 offset,
                 kind,
                 path_prefix,
+                model,
             );
         }
 
@@ -4326,6 +4332,41 @@ impl ToolHandler {
         }))
     }
 
+    /// Hot-switch the process-wide active embedding model. Registry-only ids
+    /// are accepted so every embedding tool has a known dimension/collection.
+    /// `persist=true` writes `.leankg/embed-model.json` (restored on boot).
+    #[cfg(feature = "embeddings")]
+    fn set_embed_model(&self, args: &Value) -> Result<Value, String> {
+        let model_id = args["model_id"].as_str().ok_or("Missing 'model_id'")?;
+        let persist = args["persist"].as_bool().unwrap_or(false);
+        let project_root = args["project"].as_str().map(std::path::PathBuf::from);
+        // Default the persist root to the served project's .leankg dir so
+        // `persist=true` with no `project` still lands in the right place.
+        let project_root = if project_root.is_some() {
+            project_root
+        } else {
+            Some(
+                self.db_path
+                    .parent()
+                    .map(|p| p.to_path_buf())
+                    .unwrap_or_else(|| std::path::PathBuf::from(".")),
+            )
+        };
+        let entry = crate::embeddings::set_active_model(model_id, persist, project_root.as_deref())
+            .map_err(|e| e.to_string())?;
+        let known: Vec<String> = crate::embeddings::builtin_registry()
+            .keys()
+            .cloned()
+            .collect();
+        Ok(json!({
+            "active_model_id": entry.model_id,
+            "provider": entry.provider.as_str(),
+            "dimensions": entry.dimensions,
+            "persisted": persist,
+            "registered_models": known,
+        }))
+    }
+
     fn kg_context(&self, args: &Value) -> Result<Value, String> {
         let query = args["query"].as_str().ok_or("Missing 'query' parameter")?;
         let env = args["env"].as_str().unwrap_or("local");
@@ -4473,20 +4514,49 @@ impl ToolHandler {
         let include_worktrees = args["include_worktrees"].as_bool().unwrap_or(false);
         let debug = args["debug"].as_bool().unwrap_or(false);
         let _project = args["project"].as_str().unwrap_or(".");
+        let model = args["model"].as_str();
 
         // Vectors live in CozoDB now; freshness check is a state-table count.
         // FR-SEM-07: cheap :limit 1 — never list_all (~147k rows) before retrieve.
-        let has_vectors =
-            crate::embeddings::state::has_any(self.graph_engine.db()).unwrap_or(false);
+        // When a `model` is requested, scope the gate to that model's collection
+        // (the default BGE table may be empty while the requested model is not).
+        let (has_vectors, target_rel): (bool, String) = match model {
+            Some(id) => {
+                let entry = crate::embeddings::registry::lookup_model(id)
+                    .ok_or_else(|| format!("unknown embed model {id:?}"))?;
+                let rel = entry.vectors_relation();
+                let has = self
+                    .graph_engine
+                    .db()
+                    .run_script(
+                        &format!(":limit 1 ?[qualified_name] := *{rel}[qualified_name, _]"),
+                        std::collections::BTreeMap::new(),
+                    )
+                    .map(|r| !r.rows.is_empty())
+                    .unwrap_or(false);
+                (has, rel)
+            }
+            None => (
+                crate::embeddings::state::has_any(self.graph_engine.db()).unwrap_or(false),
+                String::new(),
+            ),
+        };
         if !has_vectors {
-            return Err("No embedded vectors found. Run `leankg embed --init` \
-                 to download models, then `leankg embed` to build the index."
-                .to_string());
+            return Err(format!(
+                "No embedded vectors found{} (collection `{target_rel}`). Run `leankg embed` \
+                 with the matching LEANKG_EMBED_ACTIVE_MODEL to build the index.",
+                if model.is_some() {
+                    " for the requested model"
+                } else {
+                    ""
+                }
+            ));
         }
 
         let t0 = std::time::Instant::now();
-        let mut pipeline = SemanticRetrievalPipeline::new(self.graph_engine.db_arc().clone())
-            .map_err(|e| format!("Failed to init retrieval pipeline: {}", e))?;
+        let mut pipeline =
+            SemanticRetrievalPipeline::for_model(self.graph_engine.db_arc().clone(), model)
+                .map_err(|e| format!("Failed to init retrieval pipeline: {}", e))?;
         let t_pipeline_ms = t0.elapsed().as_millis() as u64;
 
         // CozoDB HNSW stores vectors as first-class data, so the old
@@ -4898,6 +4968,7 @@ fn embeddings_index_available(db: &dyn crate::db::backend::DbBackend) -> bool {
 }
 
 #[cfg(feature = "embeddings")]
+#[allow(clippy::too_many_arguments)]
 fn run_hnsw_semantic_search(
     engine: &GraphEngine,
     query: &str,
@@ -4906,6 +4977,7 @@ fn run_hnsw_semantic_search(
     offset: usize,
     #[allow(unused_variables)] kind: &str,
     path_prefix: Option<&str>,
+    #[allow(unused_variables)] model: Option<&str>,
 ) -> Result<Value, String> {
     use crate::retrieval::{
         is_function_target, is_upper_type, score_functions, traverse_to_functions, RetrieveOptions,
@@ -4923,7 +4995,7 @@ fn run_hnsw_semantic_search(
         embeddings_stale: false,
     };
 
-    let mut pipeline = SemanticRetrievalPipeline::new(engine.db_arc().clone())
+    let mut pipeline = SemanticRetrievalPipeline::for_model(engine.db_arc().clone(), model)
         .map_err(|e| format!("Failed to init HNSW pipeline: {}", e))?;
     let retrieval = pipeline
         .retrieve(query, &opts)

--- a/src/mcp/server.rs
+++ b/src/mcp/server.rs
@@ -264,6 +264,11 @@ pub enum AutoIndexDecision {
 impl MCPServer {
     pub fn new(db_path: std::path::PathBuf) -> Self {
         let effective_db_path = Self::resolve_project_root(db_path);
+        // Restore the last user-selected embed model (persisted by
+        // `set_embed_model ... persist=true`) so a fresh boot keeps it as
+        // the default instead of falling back to BGE 384. PERSIST_PATH is
+        // project-root relative, so resolve from the parent of the .leankg dir.
+        crate::embeddings::apply_persisted_model(effective_db_path.parent());
         // Wire leankg.yaml `auth.tokens` into the static AuthManager when
         // present; otherwise the default admin token. (The DB-backed
         // access-token store is the authoritative auth when it exists.)
@@ -290,6 +295,8 @@ impl MCPServer {
 
     pub fn new_with_watch(db_path: std::path::PathBuf, watch_path: std::path::PathBuf) -> Self {
         let effective_db_path = Self::resolve_project_root(db_path);
+        // Same persisted-model restore as `new`.
+        crate::embeddings::apply_persisted_model(effective_db_path.parent());
         Self {
             auth_manager: Arc::new(TokioRwLock::new(AuthManager::with_default_token())),
             db_path: Arc::new(RwLock::new(effective_db_path)),

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -1003,6 +1003,7 @@ impl ToolRegistry {
                         "offset": {"type": "integer", "default": 0, "description": "Pagination offset"},
                         "kind": {"type": "string", "enum": ["all", "code", "docs"], "default": "all", "description": "Filter results by kind: 'all' (code + docs), 'code' (functions, classes, methods, etc.), 'docs' (documents and doc_sections only)"},
                         "path_prefix": {"type": "string", "description": "Corpus scope gate: only return hits whose file_path contains this prefix (e.g. 'platform-food/be-merchant-group', 'Android/', 'ios/'). Hits outside the prefix are hard-dropped; if none survive, the tool returns an empty page with empty_reason=path_prefix so agents know that corpus is not indexed. Pass for multi-tree / monorepo work."},
+                        "model": {"type": "string", "description": "Embedding model to query for this request (hot-switch). Registered: bge-small-en-v1.5-384 (default, local), qwen3-emb-4b-2560, jina-embeddings-v3-1024, gemini-embedding-2-3072, gemini-embedding-001-3072 (remote). Queries that model's collection; empty results if it has no index yet."},
                         "project": {"type": "string", "description": "Optional: project path"}
                     },
                     "required": ["query"]
@@ -1096,6 +1097,7 @@ impl ToolRegistry {
                         "top_k": {"type": "integer", "default": 50, "description": "ANN retrieve depth (candidates before rerank)"},
                         "rerank_top_n": {"type": "integer", "default": 10, "description": "Final seed count after cross-encoder rerank"},
                         "traverse": {"type": "boolean", "default": true, "description": "Toggle Stage 4 graph enrichment (1-2 hop neighbors via ontology + code edges)"},
+                        "model": {"type": "string", "description": "Embedding model to query for this request (hot-switch). Registered: bge-small-en-v1.5-384 (default, local), qwen3-emb-4b-2560, jina-embeddings-v3-1024, gemini-embedding-2-3072, gemini-embedding-001-3072 (remote). Collections are created on demand if absent."},
                         "include_worktrees": {"type": "boolean", "default": false, "description": "Include paths under .worktrees/ / .claude/worktrees/ / .opencode/worktrees/ (filtered by default to dedupe agent scratch copies)"},
                         "debug": {"type": "boolean", "default": false, "description": "Include diagnostics: candidate counts, latency per stage, reranker status"},
                         "project": {"type": "string", "description": "Optional: project path (defaults to current working directory)"}
@@ -1121,6 +1123,20 @@ impl ToolRegistry {
                         "project": {"type": "string"}
                     },
                     "required": ["action"]
+                }),
+            },
+            #[cfg(feature = "embeddings")]
+            ToolDefinition {
+                name: "set_embed_model".to_string(),
+                description: "Set the runtime-active embedding model for this MCP process. Subsequent semantic_search / kg_semantic_context calls default to this model (per-request `model` arg still overrides). With persist=true the choice is saved to .leankg/embed-model.json and restored on the next boot. Registered models: bge-small-en-v1.5-384 (default, local), qwen3-emb-4b-2560, jina-embeddings-v3-1024, gemini-embedding-2-3072, gemini-embedding-001-3072 (remote).".to_string(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "model_id": {"type": "string", "description": "Registered model id, e.g. qwen3-emb-4b-2560, jina-embeddings-v3-1024, gemini-embedding-2-3072, bge-small-en-v1.5-384"},
+                        "persist": {"type": "boolean", "default": false, "description": "Persist to .leankg/embed-model.json so the next boot restores it as the default"},
+                        "project": {"type": "string", "description": "Optional: project root for persistence (defaults to the served project)"}
+                    },
+                    "required": ["model_id"]
                 }),
             },
             ToolDefinition {
@@ -1413,6 +1429,26 @@ mod tests {
             .and_then(|v| v.as_array())
             .expect("required");
         assert!(required.iter().any(|v| v.as_str() == Some("action")));
+    }
+
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn test_set_embed_model_tool_exists() {
+        let tools = ToolRegistry::list_tools();
+        let tool = tools
+            .iter()
+            .find(|t| t.name == "set_embed_model")
+            .expect("set_embed_model tool must exist when embeddings feature is on");
+        assert!(tool.description.contains("runtime-active embedding model"));
+        let props = tool.input_schema.get("properties").expect("properties");
+        assert!(props.get("model_id").is_some());
+        assert!(props.get("persist").is_some());
+        let required = tool
+            .input_schema
+            .get("required")
+            .and_then(|v| v.as_array())
+            .expect("required");
+        assert!(required.iter().any(|v| v.as_str() == Some("model_id")));
     }
 
     #[test]

--- a/src/retrieval/pipeline.rs
+++ b/src/retrieval/pipeline.rs
@@ -236,6 +236,29 @@ impl SemanticRetrievalPipeline {
         })
     }
 
+    /// Build the pipeline for an explicit model (per-request hot-switch).
+    /// `None` falls back to the active model (runtime override → env →
+    /// default BGE). The provider/collection are derived from the model's
+    /// registry entry, so the query embeds and is retrieved against the
+    /// right dimension and table.
+    pub fn for_model(
+        db: SharedDb,
+        model: Option<&str>,
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        use crate::embeddings::registry::{create_provider_for_entry, lookup_model};
+        let entry = match model {
+            Some(id) => lookup_model(id).ok_or_else(|| {
+                format!(
+                    "unknown embed model {id:?}; known: bge-small-en-v1.5-384, qwen3-emb-4b-2560,                      jina-embeddings-v3-1024, gemini-embedding-2-3072, gemini-embedding-001-3072"
+                )
+            })?,
+            None => crate::embeddings::registry::resolve_active_model()?,
+        };
+        let provider = create_provider_for_entry(&entry)?;
+        let active_vectors_relation = entry.vectors_relation();
+        Self::with_provider(db, provider, active_vectors_relation)
+    }
+
     pub fn provider(&self) -> &dyn EmbedProvider {
         self.provider.as_ref()
     }
@@ -551,5 +574,52 @@ mod tests {
         std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
         assert_eq!(qwen_idx, "embedding_vectors_qwen3_emb_4b_2560:vec_idx");
         assert_ne!(vec_idx, qwen_idx, "ANN must not share index across models");
+    }
+
+    #[test]
+    fn for_model_selects_registry_entry_and_provider_dim() {
+        let _g = crate::embeddings::test_env::lock();
+        // Pin the active model to a remote (OpenAI-compatible) entry. Its
+        // provider construction fails cleanly without API env vars, which is
+        // exactly what we assert — proving `for_model(None)` resolved the
+        // *right* entry (dim 2560) without needing a live model or network.
+        std::env::set_var("LEANKG_EMBED_ACTIVE_MODEL", "qwen3-emb-4b-2560");
+        let db: SharedDb = Arc::new(crate::db::fake::FakeBackend::new());
+        match SemanticRetrievalPipeline::for_model(db.clone(), None) {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("LEANKG_EMBED_API_BASE_URL")
+                        || msg.contains("LEANKG_EMBED_PROVIDER"),
+                    "expected provider config error for qwen, got: {msg}"
+                );
+            }
+            Ok(p) => assert_eq!(p.provider().dimensions(), 2560),
+        }
+
+        // Explicit `Some` overrides the active model to jina (dim 1024).
+        // Same clean-error assertion proves entry selection by dimension.
+        match SemanticRetrievalPipeline::for_model(db.clone(), Some("jina-embeddings-v3-1024")) {
+            Err(e) => {
+                let msg = e.to_string();
+                assert!(
+                    msg.contains("LEANKG_EMBED_API_BASE_URL")
+                        || msg.contains("LEANKG_EMBED_PROVIDER"),
+                    "expected provider config error for jina, got: {msg}"
+                );
+            }
+            Ok(p) => assert_eq!(p.provider().dimensions(), 1024),
+        }
+
+        std::env::remove_var("LEANKG_EMBED_ACTIVE_MODEL");
+    }
+
+    #[test]
+    fn for_model_unknown_id_errors() {
+        let db: SharedDb = Arc::new(crate::db::fake::FakeBackend::new());
+        match SemanticRetrievalPipeline::for_model(db, Some("no-such")) {
+            Err(e) => assert!(e.to_string().contains("unknown embed model")),
+            Ok(_) => panic!("expected error for unknown model"),
+        }
     }
 }

--- a/src/retrieval/pipeline.rs
+++ b/src/retrieval/pipeline.rs
@@ -563,6 +563,7 @@ mod tests {
 
     #[test]
     fn hnsw_query_targets_active_model_vectors_relation() {
+        let _g = crate::embeddings::test_env::lock();
         use crate::embeddings::registry::{lookup_model, DEFAULT_BGE_MODEL_ID};
         let bge = lookup_model(DEFAULT_BGE_MODEL_ID).unwrap();
         let vec_idx = format!("{}:vec_idx", bge.vectors_relation());


### PR DESCRIPTION
## What

Ports the **embedding-model hot-switch** (MCP query tools) from be-knowledge-graph (`a394c13f`) into LeanKG. Users can switch the runtime-active embedding model per process or per request, and persist the choice across boots.

## Changes

| File | Change |
|------|--------|
| `src/embeddings/switch.rs` (new) | Runtime-active model: override > `LEANKG_EMBED_ACTIVE_MODEL` > default BGE. `set_active_model` + `apply_persisted_model` writing `.leankg/embed-model.json` |
| `src/mcp/handler.rs` | New `set_embed_model` tool handler; `model` arg on `semantic_search` + `kg_semantic_context`; `kg_semantic_context` gates on the requested model's collection (not just the default BGE table) |
| `src/mcp/tools.rs` | `set_embed_model` tool definition (registry-only ids, `persist`, `project`); `model` params in both semantic tool schemas |
| `src/mcp/server.rs` | Restore persisted model on boot (`new` + `new_with_watch`) |
| `src/retrieval/pipeline.rs` | `SemanticRetrievalPipeline::for_model(db, model)` — provider + ANN collection derived from the registry entry (per-request hot-switch) |
| `instructions/leankg-tools.md` | Document the tool + per-request override |

## Deliberate deviation from upstream

Upstream restores the persisted model from `effective_db_path` (the `.leankg` dir), which never matches where `set_embed_model` writes by default (`<project>/.leankg/embed-model.json`). This port restores from `effective_db_path.parent()` (the project root), making persist -> restart actually round-trip (verified live). Registered models listed in tool descriptions match LeanKG's registry (BGE-384 local; qwen3-emb-4b-2560, jina-embeddings-v3-1024, gemini-embedding-2-3072, gemini-embedding-001-3072 remote).

## Tests

- **Unit**: `cargo test --lib --features embeddings` -> **1222 passed, 0 failed** (was 734 baseline; new: switch tests incl. persist/restore roundtrip, `for_model` routing/unknown-id, `set_embed_model` tool registration). Default suite (no feature) also green. `cargo fmt --check` + `cargo clippy --all -- -D warnings` clean (hook runs this).
- **Live vs remote Postgres** (Aiven via tunnel, `LEANKG_PG_URL`):
  - `set_embed_model` returns active model + dims + registered models; unknown id -> clean error listing known ids
  - `semantic_search`/`kg_semantic_context` with `model` route to that model's collection (gemini -> scoped "no vectors for the requested model (collection ...)" error; jina -> OpenAI provider path; unknown -> error)
  - Process-wide hot-switch: after switching to jina, model-less `semantic_search` uses the jina provider; switching back to BGE restores local behavior
  - `persist=true` writes `.leankg/embed-model.json`; a fresh server boot logs `restored persisted model qwen3-emb-4b-2560`


## Live test — remote Postgres (rivestack via LEANKG_PG_URL)

Ran a live `mcp-http` server from this branch (release build) on macOS, pointing at the remote rivestack Postgres from `.env` (the `leankg_p_f90097e3e7bb8b26` project schema — 107 embed-state rows, 0 vector rows):

- `set_embed_model bge-small-en-v1.5-384` → active `384/local`, registered_models list returned
- `set_embed_model bogus` → `unknown embed model "bogus"; known: bge-small-en-v1.5-384, qwen3-emb-4b-2560, jina-embeddings-v3-1024, gemini-embedding-2-3072, gemini-embedding-001-3072`
- `set_embed_model jina-embeddings-v3-1024` → active `1024/openai` (process-wide hot-switch)
- `set_embed_model qwen3-emb-4b-2560 persist=true` → `persisted: true`, wrote `.leankg/embed-model.json`
- `semantic_search model=gemini-embedding-2-3072` → routes to the openai gemini provider: `LEANKG_EMBED_API_BASE_URL is required when LEANKG_EMBED_PROVIDER=openai` (no API creds on host — expected)
- `semantic_search model=no-such-model` → clean unknown-model error
- `semantic_search` (no model, after switching to jina) → runs through the active provider, falls to ontology/concept path because the project has 0 vectors
- `kg_semantic_context model=gemini-embedding-2-3072` → per-model collection gate: `No embedded vectors found for the requested model (collection \`embedding_vectors_gemini_embedding_2_3072\`)`

The host has no TEI/OpenAI/vertex API creds, so a full positive RAG vector hit (vectors already embedded) wasn't produced live; instead the per-model provider routing, collection-scoped gating, unknown-model errors, process-wide hot-switch, and persistence round-trip were exercised against the real remote database.

## Test-stability fix (2nd commit)

registry/pipeline tests now take the single crate-wide `embeddings::test_env::lock()` (matching the switch module) before touching `LEANKG_EMBED_ACTIVE_MODEL`, eliminating a spurious 1-of-1222 race under parallel test execution.
