### PR TITLE
ci(update-graph): add Postgres service — leankg index is Postgres-only (D4)

### DIFF
--- a/.github/workflows/leankg-update.yml
+++ b/.github/workflows/leankg-update.yml
@@ -14,6 +14,24 @@ on:
 jobs:
   update-graph:
     runs-on: ubuntu-latest
+    # `leankg index` writes into PostgreSQL (Postgres is the only engine, D4) —
+    # without a live instance it fails with "connection refused".
+    services:
+      postgres:
+        image: pgvector/pgvector:pg18
+        env:
+          POSTGRES_DB: leankg
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+        ports:
+          - 5433:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres -d leankg"
+          --health-interval 2s
+          --health-timeout 3s
+          --health-retries 15
+    env:
+      LEANKG_PG_URL: postgresql://postgres:postgres@localhost:5433/leankg
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Why

The `update-graph` job in `.github/workflows/leankg-update.yml` has been **red on every main push since v0.20.0** (the CozoDB → PostgreSQL migration, #207):

```
$ ./target/release/leankg index ./src --env production ...
Error: Error { kind: Connect, cause: Some(Os { code: 111, kind: ConnectionRefused, message: "Connection refused" }) }
##[error]Process completed with exit code 1.
```

Postgres is now the only storage engine (D4 — `init_db` fails loudly with no fallback), but the job runs on a bare `ubuntu-latest` runner with no database, so `leankg index` can't open the project schema. Last passing run: `c5df69ca` (Aug 4); every run since `f9066b09` (Aug 5) fails the same way.

## What changed

Restored the pgvector Postgres service container that `ci.yml` used before it was dropped in `5e9f1f5b`, plus `LEANKG_PG_URL` pointing at it:

- Service: `pgvector/pgvector:pg18`, mapped to `localhost:5433`, with the same health check as the old test workflow.
- Job env: `LEANKG_PG_URL=postgresql://postgres:postgres@localhost:5433/leankg`.

The push step is unchanged — it still runs only when `secrets.LEANKG_TOKEN` is set (empty on the public repo, so it logs "skipping push").

## Verification

- YAML parses (`python3 -c "import yaml"`).
- The equivalent Postgres service container previously ran green in `ci.yml` (until `5e9f1f5b`).
- The new PR/CI run on `update-graph` should go green (needs PG once, as the job runs on push to main only — can be verified on merge).