### PR TITLE
fix(indexer): QN collision disambiguation + re-index idempotency guards + migrate TLS fix

### DIFF
--- a/docs/prd-enterprise.md
+++ b/docs/prd-enterprise.md
@@ -1,0 +1,103 @@
+# LeanKG PRD — Enterprise & Startup Edition
+
+**Version:** 1.0 · **Date:** 2026-08-22 · **Status:** Approved for execution
+**Roadmap alignment:** [`roadmap-2027.md`](roadmap-2027.md) · **Progress:** [`roadmap-tracker.md`](roadmap-tracker.md)
+
+---
+
+## 1. Product Vision
+
+LeanKG gives engineering teams a **deterministic, auditable, self-hostable knowledge graph of their codebase**, served natively to every AI coding agent via MCP. Unlike embedding-only context engines, every answer is traceable to extracted code structure with provenance labels — making AI-assisted development trustworthy enough for regulated enterprises and fast enough for startups.
+
+### 1.1 Target segments
+| Segment | Profile | Willingness to pay | Key needs |
+|---|---|---|---|
+| Startup (PLG) | 5–50 devs, agent-heavy workflow | $25/dev/mo Team tier | Zero-config setup, speed, multi-repo, flat pricing |
+| Mid-market | 50–500 devs, procurement starts | $15–25K/yr self-hosted | SSO, RBAC, audit logs, VPC deploy |
+| Enterprise/regulated | 500+ devs, compliance-bound | Custom ($50K+) | Air-gap, residency, SOC2, SIEM export |
+
+### 1.2 Personas
+- **P1 Platform/DevEx lead (buyer):** owns tooling budget; needs governance + metrics.
+- **P2 Staff engineer (champion):** wants deterministic impact analysis; hates black-box retrieval.
+- **P3 Security/compliance reviewer (gatekeeper):** blocks deals without audit logs, SSO, self-host.
+
+---
+
+## 2. Requirements
+
+Priority: P0 = launch-blocking for segment · P1 = competitive parity · P2 = differentiator.
+
+### FR-ENT-* — Enterprise requirements (Q4'26–Q1'27)
+
+| ID | Requirement | Priority | Acceptance criteria |
+|----|-------------|----------|---------------------|
+| ENT-1 | **Audit log foundation**: append-only ledger of every MCP/REST call (actor, agent-client, tool, project, args-hash, result-status, ts) | P0 | JSON-lines export; queryable by admin; <2ms write overhead; tamper-evident hash chain |
+| ENT-2 | **RBAC v1**: roles admin/editor/reader; scoped per project/collection; enforced at MCP tool layer | P0 | Reader cannot invoke mutating tools (403); role changes take effect ≤60s |
+| ENT-3 | **SSO OIDC**: Google WS, Okta, Entra ID; JWT validation on remote MCP + REST | P0 (Q1'27) | Login via IdP in ≤3 clicks; group→role mapping |
+| ENT-4 | **SAML 2.0** + SCIM provisioning/deprovisioning | P1 (Q1'27) | Deprovisioned user loses access ≤5 min |
+| ENT-5 | **Self-hosted deployment kit**: Helm chart, compose prod profile, upgrade guide | P0 (Q1'27) | Fresh cluster → serving in ≤30 min |
+| ENT-6 | **Data residency pinning**: EU/US storage regions for hosted tier | P1 | Region choice at workspace creation; no cross-region replication |
+| ENT-7 | **SIEM export**: webhook + syslog drain of audit stream | P1 | Splunk/Datadog-compatible field schema |
+| ENT-8 | **Air-gap install**: offline license file, signed updates, zero outbound telemetry | P2 (Q2'27) | Runs fully offline ≥90 days; license expiry grace 14d |
+| ENT-9 | **Provenance labels** on all relationship/graph responses (EXTRACTED/INFERRED/AMBIGUOUS) | P0 | Every edge in tool output carries confidence_label |
+| ENT-10 | **SOC 2 controls automation**: evidence collection, access reviews | P1 (Q1'27 runway) | Type I readiness checklist complete |
+
+### FR-PLG-* — Startup/self-serve requirements (Q4'26)
+
+| ID | Requirement | Priority | Acceptance criteria |
+|----|-------------|----------|---------------------|
+| PLG-1 | **One-command connect**: `leankg connect claude-code\|cursor\|codex\|gemini` writes correct client config | P0 | Works for all 4 clients; idempotent; `--remove` flag |
+| PLG-2 | **Official MCP registry listing** with verified publisher badge | P0 | Listed; install-from-registry path documented |
+| PLG-3 | **Team server mode**: shared Postgres graph, N users, OAuth 2.1 remote MCP (Streamable HTTP) | P0 | 10 concurrent agents; per-user identity in audit log |
+| PLG-4 | **Flat pricing enforcement**: seat-based licensing service (license key gen/validation) | P0 | Seat count enforced; over-seat → read-only grace |
+| PLG-5 | **Stable tool contract**: semver'd tool registry; deprecation policy (2 minors notice) | P0 | Contract doc published; CI fails on unregistered breaking change |
+| PLG-6 | **npm/crate version sync**: release automation publishes matching versions | P0 | npm version == crate version on every release |
+| PLG-7 | **Quickstart < 5 min**: init+index+first-query measured on 10k-element repo | P0 | Median < 5 min in CI-timed smoke test |
+| PLG-8 | **Usage dashboard**: tokens saved, queries/day, top tools (from existing context_metrics) | P1 | Per-user + per-project views; CSV export |
+
+### FR-CORE-* — Core engine quality (Q3'26, prerequisite)
+
+| ID | Requirement | Priority | Acceptance criteria |
+|----|-------------|----------|---------------------|
+| CORE-1 | **Complete Datalog removal**: SQL-first seam; delete translate.rs/fake.rs/mutability.rs | P0 | `rg "cozo::" src/` = 0 Datalog strings; parity harness green; fake.rs deleted |
+| CORE-2 | **Tool consolidation**: 79→~70 tools; matrix test green | P0 | redundant_tools_matrix passes; contract doc updated |
+| CORE-3 | **qualified_name uniqueness**: dedup strategy + UNIQUE constraint | P0 | Embed succeeds on real 371k-fn repo; collision report tool |
+| CORE-4 | **Re-index reliability**: fix EEXIST on `leankg index` re-run | P0 | index→index→index idempotent in integration test |
+| CORE-5 | **CI promotes PG integration suite** | P0 | tests/pg_* run as CI gate with Postgres service |
+| CORE-6 | **Performance floor**: p95<150ms top-10 tools @100k elements | P1 | benchmark-unified report in repo; regression gate ±20% |
+
+### Non-functional requirements
+- **NFR-1** Zero telemetry by default; opt-in analytics only.
+- **NFR-2** All secrets via env/config; no secrets in DB or logs.
+- **NFR-3** Backward-compatible DB migrations; `leankg migrate` tested across ≥2 versions.
+- **NFR-4** Single static binary remains the local-first default (stdio MCP).
+
+---
+
+## 3. Pricing & Packaging (locked)
+
+| Tier | Price | Includes |
+|------|-------|----------|
+| OSS / Local | Free forever | stdio MCP, single-user, full graph engine, local embeddings |
+| Team | $25/dev/mo flat | Shared team server, OAuth remote MCP, RBAC v1, usage dashboard, email support |
+| Enterprise | $15–25K/yr | Self-hosted kit, SSO/SAML/SCIM, audit+SIEM, residency, 8×5 support, SLA |
+| Air-gap | Custom | ENT-8, signed offline updates, CMMC-aligned checklist, named engineer |
+
+Guarantee marketed: **"No token toll. No surprise bills."** (anti-metering positioning vs Augment/Greptile.)
+
+---
+
+## 4. Launch Plan
+
+- **Milestone M1 (end Q3'26):** CORE-1..6 done → "Postgres-native, Datalog-free v0.28".
+- **Milestone M2 (end Q4'26):** PLG-1..6 + ENT-1/2 → Team beta with 5 design partners.
+- **Milestone M3 (end Q1'27):** ENT-3..7 → Enterprise pilot with 3 paid evaluations.
+- **Milestone M4 (end Q2'27):** H-track platform features + air-gap tier → GA.
+
+Each milestone exits only when tracker W-items are ✅ and acceptance criteria have live-test evidence links.
+
+---
+
+## 5. Open Questions (decided autonomously per mandate)
+- License: recommend dual-scan in Q4'26 (Apache-2.0 core vs AGPL core); decision recorded in roadmap-tracker before Team launch. Default recommendation: **Apache-2.0 core + trademark + CLA**, matching Supabase/Neon playbook.
+- Hosted cloud infra: defer to M2; start with single-region (US) + EU at M3.

--- a/docs/roadmap-2027.md
+++ b/docs/roadmap-2027.md
@@ -1,0 +1,100 @@
+# LeanKG 1-Year Roadmap: Q3 2026 → Q2 2027
+
+**Version:** 1.0 · **Date:** 2026-08-22 · **Owner:** FreePeak
+**Positioning:** The deterministic, self-hostable, MCP-native code knowledge graph.
+**Companion:** [`roadmap-tracker.md`](roadmap-tracker.md) (progress SoT) · [`prd-enterprise.md`](prd-enterprise.md) (requirements)
+
+---
+
+## 1. Market Context (research summary, Aug 2026)
+
+### 1.1 Why now
+- Knowledge-graph market ≈ $2B (2026) growing 20–33%/yr; GraphRAG-for-enterprise-AI is the cited driver.
+- Engineering orgs spend $400–600K/yr on AI coding tools; context quality is the differentiator (Augment's Context Engine lifted agent output +70–80%; Meta's pre-computed context cut tool calls −40%).
+- MCP won the protocol war: Linux Foundation governance, 97M+ monthly SDK downloads, every major agent/IDE speaks it. Enterprise MCP layer (registries, gateways, OAuth) is forming now — early movers define the standard.
+- Trust crisis favors determinism: METR found AI coding slowed complex tasks 19%; EU AI Act obligations apply Aug 2026; only 14% of orgs fully approve deployed agents. Deterministic, provenance-labeled graph answers are the credible response.
+
+### 1.2 Competitive landscape
+| Competitor | Approach | Gap LeanKG exploits |
+|---|---|---|
+| Cursor ($29B val) | Merkle+embeddings, IDE-bound | No MCP surface, no self-host, embeddings fail call-chain queries |
+| Augment Code ($977M val) | Cloud embedding engine, MCP GA | Cloud-only (+40% token toll), closed/black-box |
+| Sourcegraph | SCIP platform, $16K/yr floor | Killed free tier; heavy platform; goodwill spent |
+| GitNexus (45k★) | Local TS graph, PolyForm Noncommercial | Non-commercial license blocks adoption; no semantics depth |
+| Tabnine CE | On-prem "context engine" | Closed; anti-KG messaging leaves KG category open |
+| Stack Graphs / Bloop | Archived by GitHub/maintainers | OSS precise-code-nav slot is vacant |
+| Zep/Graphiti, Mem0, Cognee | Agent memory KGs | Chat-domain, not code-structural |
+
+**Empty quadrant we own:** local-first × deterministic graph × hybrid local semantics × permissive license × MCP-native.
+
+### 1.3 Monetization model (decided)
+- **Core:** open source (permissive core; AGPL option documented for cloud-resale protection — final license call in Q4'26 before Team launch).
+- **Team cloud:** $25/dev/mo flat (undercuts Sourcegraph floor; matches Greptile/CodeRabbit band; "no token toll" vs Augment's +40%).
+- **Enterprise self-hosted:** $15–25K/yr (SSO/RBAC/audit/residency). Air-gap tier custom pricing.
+- **Anti-pattern avoided:** usage-based metering (category backlash: Greptile/Macroscope protests).
+
+---
+
+## 2. Quarterly Themes
+
+### Q3 2026 — "Solid Foundation" (engineering credibility)
+**Theme:** finish the Postgres era cleanly; make the project trustworthy to adopt.
+- **E1. Complete CozoDB/Datalog removal** (waves per `plan-remove-cozo-datalog-sql-migration.md`): SQL-first seam → convert 238 run_script sites → delete translate.rs (4.3k), fake.rs (1.4k), mutability.rs. Exit criteria: zero Datalog strings in src/, parity harness green, `run_raw_query` deprecated→removed or NL-only.
+- **E2. Tool-surface discipline:** fix red matrix test; consolidation round 76→~70; publish stable-tool API contract (semver for tool names/schemas); auto-sync npm wrapper with crate version.
+- **E3. Known-finding fixes:** qualified_name UNIQUE dedup strategy; `leankg index` EEXIST re-index bug.
+- **E4. CI hardening:** promote PG integration suite into CI (Postgres service already configured); flake quarantine process.
+- **E5. Docs truth sweep:** all generated docs/wiki say Postgres+pgvector; AGENTS.md updated; architecture.md refreshed.
+
+### Q4 2026 — "Team Ready" (PLG wedge)
+**Theme:** multi-user team server + distribution.
+- **F1. Remote MCP with OAuth 2.1** (Streamable HTTP): hosted + self-hosted team mode; per-user identity on every tool call.
+- **F2. RBAC v1:** roles (admin/editor/reader) scoped to projects/collections; tool-level permission bundles ("Virtual bundles" pattern from gateway vendors).
+- **F3. Audit log foundation (ENT-1):** append-only who/which-agent/which-tool/which-project ledger with SIEM-friendly JSON export. *This is the enterprise procurement keystone — build the schema now even if UI comes later.*
+- **F4. Official MCP registry listing + one-command setup** for Claude Code/Cursor/Codex/Gemini CLI (`leankg connect` writes client configs).
+- **F5. License decision + CLA/trademark setup** (prereq for Team launch).
+- **F6. Performance floor:** p95 < 150ms for top-10 tools at 100k-element repos; publish benchmark methodology.
+
+### Q1 2027 — "Enterprise Grade" (procurement pass)
+**Theme:** pass mid-market+ procurement without sales friction.
+- **G1. SSO: SAML/OIDC** (Okta, Entra ID, Google WS) + SCIM provisioning.
+- **G2. Audit log v2:** retention policies, tamper-evident hashing, admin UI.
+- **G3. Deployment story:** Helm chart + Docker Compose prod profile + VPC/dedicated-tenant guide; data-residency pinning (EU/US).
+- **G4. SOC 2 Type I → Type II runway** (controls automation; engage auditor when headcount triggers).
+- **G5. Multi-repo org topology GA:** cross-repo service graphs, monorepo scale (1M+ elements) verified.
+- **G6. Provenance everywhere:** EXTRACTED/INFERRED/AMBIGUOUS labels surfaced in every tool response schema (agent trust calibration = marketable differentiator).
+
+### Q2 2027 — "Platform Play" (become substrate)
+**Theme:** the code-intelligence layer other agents build on.
+- **H1. Public query API + webhooks:** REST/gRPC read API with API keys, usage analytics; Backstage plugin.
+- **H2. Embeddings marketplace:** pluggable model registry (local ONNX default; BYO remote models), per-model collections already shipped → productize.
+- **H3. Bi-temporal code intelligence GA:** timeline queries, environment promotion (upcoming→staging→production) as first-class workflow; "what did this service look like when incident X happened".
+- **H4. Agent-native features v2:** personas/diaries/SKILL.md generation promoted; reflection-driven ranking biasing.
+- **H5. Channel partnerships:** MCP-gateway vendors (MintMCP, Kong, Traefik Hub) list LeanKG as governed server; DevEx/portal teams integration kit.
+- **H6. Air-gap tier:** offline licensing, signed updates, zero-telemetry guarantee, NIST 800-171 alignment checklist.
+
+---
+
+## 3. North-Star Metrics & Targets
+
+| Metric | Now (v0.26) | Q4'26 | Q2'27 |
+|---|---|---|---|
+| MCP tools (stable contract) | 79 unversioned | ~70 semver'd | ~70 + API v1 |
+| Datalog remnants in src/ | 238 call sites | 0 | 0 |
+| CI gates | lib-only | lib + PG integration | + e2e smoke |
+| Index throughput | baseline | +30% (COPY path everywhere) | +50% |
+| p95 top-10 tools @100k elems | unmeasured | <150ms | <75ms |
+| GitHub stars / weekly installs | niche | 2k★ / 5k | 8k★ / 25k |
+| Design partners (enterprise) | 0 | 5 | 20 |
+| Paid tiers | none | Team beta | Team GA + Ent pilot |
+
+## 4. Risks & Mitigations
+| Risk | Mitigation |
+|---|---|
+| GitNexus velocity (45k★) | Win on license trust + Rust perf + semantics depth (ontology/traceability they lack) |
+| SQL migration regression risk | Parity harness gates each wave; waves small; integration suite promoted to CI first (E4 before E1 waves) |
+| License flip backlash | Decide once, early (Q4'26), communicate rationale; never retroactive |
+| Metering backlash contagion | Flat published pricing forever; no per-query fees |
+| Solo-maintainer bus factor | Subagent-parallel workflow documented; RFC process; good-first-issue pipeline |
+
+## 5. Immediate Next Steps (this sprint)
+See tracker §5: land refactor wave 1 (matrix test, doc-lies, dead code) → known-findings fixes → start SQL seam wave P0.

--- a/docs/roadmap-tracker.md
+++ b/docs/roadmap-tracker.md
@@ -1,0 +1,103 @@
+# LeanKG Central Progress Tracker
+
+> **THIS IS THE SINGLE SOURCE OF TRUTH for the 2026–2027 roadmap execution.**
+> Update this file after every completed step. Last updated: 2026-08-22.
+
+## 0. Mission
+
+Position LeanKG as the **deterministic, self-hostable, MCP-native code knowledge graph** for enterprises and startups — "explainable context" that embedding-only incumbents (Cursor, Augment, Sourcegraph) cannot offer.
+
+**Companion documents:**
+| Document | Purpose |
+|---|---|
+| [`docs/roadmap-2027.md`](roadmap-2027.md) | 1-year roadmap (Q3'26 → Q2'27), quarterly themes |
+| [`docs/prd-enterprise.md`](prd-enterprise.md) | PRD: enterprise + startup feature requirements (FR-ENT-*, FR-PLG-*) |
+| [`docs/plan-remove-cozo-datalog-sql-migration.md`](plan-remove-cozo-datalog-sql-migration.md) | CozoDB/Datalog full removal plan (in worktree `feat/remove-cozo-datalog`) |
+| [`docs/pg-migration-kanban.md`](pg-migration-kanban.md) | Historical: Cozo→Postgres migration (Phases 0–9 DONE) |
+
+---
+
+## 1. Status Dashboard
+
+| # | Workstream | Status | Owner | Evidence / Notes |
+|---|-----------|--------|-------|------------------|
+| W1 | Discovery: codebase audit + architecture | ✅ DONE | agent | §3.1 findings below; 118k LOC, 79 MCP tools, v0.26.0 |
+| W2 | Research: competitors + market + monetization | ✅ DONE | agents | §3.2 summary; full reports in roadmap-2027.md §1–2 |
+| W3 | Roadmap 1-year doc | ✅ DONE | primary | docs/roadmap-2027.md |
+| W4 | Enterprise/startup PRD | ✅ DONE | primary | docs/prd-enterprise.md |
+| W5 | Fix red `tests/redundant_tools_matrix.rs` (P0-a) | 🚧 IN PROGRESS | worktree `refactor/cozo-cleanup` | test-only fix, matrix asserts ==76 |
+| W6 | Purge cozo from generated docs + ontology YAMLs (P0-c) | 🚧 IN PROGRESS | worktree `refactor/cozo-cleanup` | generator.rs/wiki.rs → Postgres+pgvector; concepts.yaml cleanup |
+| W7 | Delete orphaned db/mod.rs fns + dead arms + broken script (P1) | ⬜ PENDING | worktree `refactor/cozo-cleanup` | see audit §4 list |
+| W8 | SQL-first seam adoption (adopt worktree plan P0) | ⬜ PENDING | branch `feat/remove-cozo-datalog` | existing WIP at orca workspace; land sql.rs seam |
+| W9 | Known finding: qualified_name collision (UNIQUE) | ⬜ PENDING | worktree | 52% dup QNs breaks embed on real data |
+| W10 | Known finding: `leankg index` EEXIST bug | ⬜ PENDING | worktree | re-index fails after wipe |
+| W11 | Tool consolidation round 2 (76→~70) | ⬜ PENDING | after W5 | candidates: get_graph_report, orchestrate, traceability quartet |
+| W12 | npm wrapper version sync automation | ⬜ PENDING | quick win | npm/leankg at 0.17.9 vs crate 0.26.0 |
+| W13 | Phase-1 enterprise features (see PRD) | ⬜ PENDING | per-quarter | starts with ENT-1 observability/audit-log foundation |
+
+Status legend: ⬜ pending · 🚧 in progress · ✅ done · ⛔ blocked · ❌ cancelled
+
+---
+
+## 2. Execution Rules (per user mandate)
+
+1. **Workflow per step:** plan → review → execute → test → update docs → merge to origin main.
+2. **TDD mandatory:** failing test first, then implementation.
+3. **Git worktrees** for every feature/refactor branch; merge to main after green.
+4. **Live local testing** against the **remote Postgres in `.env` (`LEANKG_PG_URL`)**. NEVER create a Postgres docker container.
+5. **Fan out subagents** wherever steps are independent.
+6. **No approvals needed** — pick recommended/best-practice options autonomously.
+
+---
+
+## 3. Key Findings (discovery, 2026-08-22)
+
+### 3.1 Codebase state
+- v0.26.0, ~118k LOC Rust, 1,219 unit tests (~4s), ~600 integration tests (NOT in CI gate), CI = lib tests + fmt + clippy + ui-v2 build.
+- Storage: **Postgres+pgvector only** (cozo crate removed from Cargo.toml). BUT Datalog survives as internal query IR: 238 `run_script()` call sites → runtime translator `src/db/pg/translate.rs` (4,301 LOC) + test fake `src/db/fake.rs` (1,402 LOC).
+- MCP registry: **79 tools** (commit 541ff626 removed 11 thin wrappers but broke `tests/redundant_tools_matrix.rs` — 4/6 RED on main).
+- Monolith hotspots: extractor.rs 7.5k, graph/query.rs 7.5k, main.rs 6.9k, handler.rs 5.1k, web/handlers.rs 4.8k.
+- npm wrapper lags crate by 9 minors (0.17.9 vs 0.26.0).
+
+### 3.2 Market / competitive
+- KG market ~$2B growing 20–33%/yr; code-intel budgets far larger ($400–600K/yr per eng org on AI tools).
+- MCP won (Linux Foundation, 97M monthly SDK downloads); enterprise layer forming: private registries, gateways, OAuth 2.1 remote servers.
+- Empty quadrant: **local-first × deterministic-graph × hybrid-local-semantics × permissive license**. GitNexus (45k★) is PolyForm Noncommercial TS; Stack Graphs archived; Bloop archived; Sourcegraph killed free tiers.
+- Pricing benchmarks: Team tier $20–40/seat/mo band; enterprise floor $16K+/yr proven; metering backlash → flat predictable pricing is a differentiator.
+- Recommended model: **open core (permissive/AGPL decision documented in roadmap) + Team cloud $25/seat/mo + Enterprise self-hosted $15–25K/yr + air-gap custom**.
+- Datadog check: NO datadog/APM telemetry exists anywhere in the codebase (only a competitor mention in one analysis doc). Nothing to remove.
+
+### 3.3 Removal plan (from audit)
+| Priority | Action |
+|---|---|
+| P0-a | Fix `tests/redundant_tools_matrix.rs` to current 76-tool reality |
+| P0-b | Adopt/land worktree `feat/remove-cozo-datalog` sql.rs seam (owns the machinery for full Datalog removal) |
+| P0-c | Fix generated-doc lies ("stores data in CozoDB") in doc/generator.rs + wiki.rs; purge `cozo_integration`/`rocksdb_backend` from ontology YAMLs |
+| P1-a | Delete orphaned db/mod.rs fns/structs (traceability quartet etc.), drop stale `#[allow(dead_code)]`, fix unused_mut warning |
+| P1-b | Delete broken scripts/pg-cli-sweep.sh, prune .gitignore cozo entries, token_budget dead arms, delete stale branch feat/v2-cozo-deprecation |
+| P1-c | Sweep ~217 cozo/~57 datalog comment refs (ride along with waves) |
+| P2-a | Wave-by-wave: convert 238 run_script sites → parameterized SQL via seam; then DELETE translate.rs, mutability.rs, fake.rs, escape_datalog, preprocess_datalog_query |
+| P2-b | Decide run_raw_query fate (last user-facing Datalog surface): deprecate → NL query_graph only |
+| P2-c | Tool consolidation round 2 (76→~70) |
+
+---
+
+## 4. Session Log
+
+| Date | Step | Result |
+|------|------|--------|
+| 2026-08-22 | Goal created, decomposed into 10 todos | goal persisted ses_fdad784c8ffeoX8syoqqUBMlQ8 |
+| 2026-08-22 | W1+W2 discovery (4 parallel subagents) | Audit + architecture + market + competitor reports done |
+| 2026-08-22 | W3+W4 planning docs | roadmap-2027.md + prd-enterprise.md written |
+| 2026-08-22 | W5+W6+W7 refactor wave 1 | worktree refactor/cozo-cleanup: matrix test fix, doc-lies fix, dead-code purge |
+| 2026-08-22 | W9+W10 known-findings fixes | worktrees: QN UNIQUE dedup + index EEXIST fix |
+| 2026-08-22 | W12 npm sync | release-please/npm version automation |
+
+---
+
+## 5. Next Actions (pick up here)
+
+1. Land W5–W7 PR → merge main → update this file.
+2. Start W8 (SQL-first seam) — follow worktree plan doc phases; parity harness gates each wave.
+3. W9/W10 fixes with TDD (repro tests first).
+4. Then begin PRD ENT-1 (audit log foundation) per roadmap Q3'26 theme.

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -52,7 +52,11 @@ fn normalize_pg_url_for_parse(url: &str) -> String {
     format!("{base}?{}", normalized.join("&"))
 }
 
-fn pg_connect(url: &str) -> Result<postgres::Client, Box<dyn std::error::Error>> {
+/// Connect a `postgres::Client`, applying the crate's URL/TLS rules
+/// (`sslmode=verify-full` normalization, `LEANKG_PG_CA_CERT`, webpki roots).
+/// Public so integration tests can perform admin DDL against the same
+/// managed-Postgres URLs the binary itself accepts.
+pub fn pg_connect(url: &str) -> Result<postgres::Client, Box<dyn std::error::Error>> {
     let normalized = normalize_pg_url_for_parse(url);
     let wants_tls = url_wants_verified_tls(url);
     let cfg: postgres::Config = normalized.parse()?;

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -5087,7 +5087,7 @@ impl GraphEngine {
         let total = self.count_elements().map_err(|e| e.to_string())?;
         let rel_count = self.count_relationships().map_err(|e| e.to_string())?;
         let file_count = self
-            .count_elements_by_type("File")
+            .count_elements_by_type_in(&["File", "file"])
             .map_err(|e| e.to_string())?;
         let func_count = self
             .count_elements_by_type("function")

--- a/src/indexer/cicd.rs
+++ b/src/indexer/cicd.rs
@@ -35,8 +35,11 @@ impl CicdYamlExtractor {
         let platform = self.detect_platform(&yaml);
 
         let line_count = source_str.lines().count() as u32;
+        // The bare file path is owned by the per-file summary node
+        // (file_summary_qualified_name) — suffix the pipeline element so a
+        // CI/CD yaml does not collide with it.
         elements.push(CodeElement {
-            qualified_name: self.file_path.clone(),
+            qualified_name: format!("{}::<cicd>", self.file_path),
             element_type: "cicd".to_string(),
             name: self
                 .file_path

--- a/src/indexer/extractor.rs
+++ b/src/indexer/extractor.rs
@@ -209,6 +209,85 @@ pub fn get_tested_file_path(file_path: &str) -> Option<String> {
     }
 }
 
+/// Ensure every element in one file batch carries a unique qualified_name.
+///
+/// Real-world files legitimately declare many same-named symbols — Go methods
+/// named `Error` on different message structs, TS `render` on several classes,
+/// Rust `new` across impl blocks. The extractor keys elements by
+/// `{file}::{name}`, so those collapsed into ONE qualified_name (a large
+/// `.pb.validate.go` produced 764 code_elements rows under a single `::Error`
+/// key). Keyed downstream stores (embedding_state / embedding_vectors PK =
+/// qualified_name) then silently merge distinct symbols into one embedding.
+///
+/// Deterministic disambiguation at the source: the FIRST occurrence keeps its
+/// qualified_name (so keys written by older versions stay stable across
+/// re-index), and each later duplicate is renamed to
+/// `{file}::{parent}::{name}` when the element knows its parent symbol,
+/// else `{qualified_name}#{k}` (k = occurrence index ≥ 2).
+///
+/// Relationship endpoints are rewritten conservatively: only the inline
+/// `contains` edge each extractor creates for its own element is remapped,
+/// keyed by the exact (target, source) pair so same-named sibling instances
+/// attach correctly. Call edges are unaffected — their targets start as
+/// `__unresolved__{name}` and resolve against the final element set.
+fn disambiguate_qualified_names(elements: &mut [CodeElement], relationships: &mut [Relationship]) {
+    use std::collections::HashMap;
+    use std::collections::HashSet;
+
+    // All distinct original qualified_names: exactly the keeper names.
+    let mut used: HashSet<String> = elements.iter().map(|e| e.qualified_name.clone()).collect();
+    let mut occurrences: HashMap<String, u32> = HashMap::with_capacity(elements.len());
+    // (renamed_element_old_qn, its contains-edge source) -> new qn.
+    let mut contains_rewrites: HashMap<(String, String), String> = HashMap::new();
+
+    for el in elements.iter_mut() {
+        let original = el.qualified_name.clone();
+        let count = occurrences.entry(original.clone()).or_insert(0);
+        *count += 1;
+        if *count == 1 {
+            continue;
+        }
+        let k = *count;
+        let parent = el.parent_qualified.as_deref().filter(|p| !p.is_empty());
+        let base = match parent {
+            Some(p) => format!("{}::{}::{}", el.file_path, p, el.name),
+            None => original.clone(),
+        };
+        let mut candidate = base.clone();
+        if used.contains(&candidate) {
+            candidate = format!("{base}#{k}");
+            let mut n = k;
+            while used.contains(&candidate) {
+                n += 1;
+                candidate = format!("{base}#{n}");
+            }
+        }
+        used.insert(candidate.clone());
+
+        let edge_source = match parent {
+            Some(p) => format!("{}::{}", el.file_path, p),
+            None => el.file_path.clone(),
+        };
+        contains_rewrites.insert((original, edge_source), candidate.clone());
+        el.qualified_name = candidate;
+    }
+
+    if contains_rewrites.is_empty() {
+        return;
+    }
+
+    for rel in relationships.iter_mut() {
+        if rel.target_qualified.starts_with("__unresolved__") {
+            continue;
+        }
+        if let Some(new) =
+            contains_rewrites.get(&(rel.target_qualified.clone(), rel.source_qualified.clone()))
+        {
+            rel.target_qualified = new.clone();
+        }
+    }
+}
+
 impl<'a> EntityExtractor<'a> {
     pub fn new(source: &'a [u8], file_path: &'a str, language: &'a str) -> Self {
         Self {
@@ -345,6 +424,8 @@ impl<'a> EntityExtractor<'a> {
                 ..Default::default()
             });
         }
+
+        disambiguate_qualified_names(&mut elements, &mut relationships);
 
         (elements, relationships)
     }
@@ -2612,6 +2693,22 @@ impl<'a> EntityExtractor<'a> {
             node.kind(),
             "constructor_declaration" | "secondary_constructor" | "constructor_signature"
         );
+        // Go-style receivers: a `method_declaration` sits at file scope (no
+        // syntactic class parent), but its receiver names the owning type.
+        // Derive a parent from it so qualified_names / parent_qualified can
+        // distinguish same-named methods on different types. element_type is
+        // still computed from the SYNTACTIC parent below — flipping
+        // receiver-only methods to "method" would drop them from the typed
+        // call resolver's bare-name maps (which filter element_type ==
+        // "function") and regress call-graph coverage.
+        let receiver_parent: Option<String> = if !is_constructor
+            && parent.is_none()
+            && matches!(node.kind(), "method_declaration" | "method_definition")
+        {
+            self.method_receiver_name(node)
+        } else {
+            None
+        };
         let name = if is_constructor {
             self.get_node_name(node)
                 .or_else(|| parent.map(String::from))
@@ -2641,12 +2738,12 @@ impl<'a> EntityExtractor<'a> {
                 line_start: node.start_position().row as u32 + 1,
                 line_end: node.end_position().row as u32 + 1,
                 language: self.language.to_string(),
-                parent_qualified: parent.map(String::from),
+                parent_qualified: parent.map(String::from).or(receiver_parent.clone()),
                 metadata: self.build_function_metadata(node, signature, sig_end),
                 ..Default::default()
             });
 
-            if let Some(p) = parent {
+            if let Some(p) = parent.or(receiver_parent.as_deref()) {
                 let p_qualified = format!("{}::{}", self.file_path, p);
                 relationships.push(Relationship {
                     id: None,
@@ -2914,6 +3011,39 @@ impl<'a> EntityExtractor<'a> {
         } else {
             None
         }
+    }
+
+    /// Bare receiver type for method-like declarations, e.g.
+    /// `func (m *MsgB) Error()` → `MsgB`. Walks the grammar's receiver field
+    /// (`receiver` in tree-sitter-go, `receiver_type` elsewhere) and returns
+    /// the first type identifier inside it — never the whole parameter-list
+    /// text (`(m *MsgB)`), which would leak receiver variable names into
+    /// qualified_names.
+    fn method_receiver_name(&self, node: Node) -> Option<String> {
+        for field in ["receiver", "receiver_type"] {
+            let Some(recv) = node.child_by_field_name(field) else {
+                continue;
+            };
+            let mut stack = vec![recv];
+            while let Some(cur) = stack.pop() {
+                if matches!(cur.kind(), "type_identifier" | "user_type") {
+                    if let Some(bytes) = self.source.get(cur.byte_range()) {
+                        if let Ok(s) = std::str::from_utf8(bytes) {
+                            let name = s.trim();
+                            if !name.is_empty() {
+                                return Some(name.to_string());
+                            }
+                        }
+                    }
+                }
+                for i in 0..cur.child_count() {
+                    if let Some(child) = cur.child(i as u32) {
+                        stack.push(child);
+                    }
+                }
+            }
+        }
+        None
     }
 
     fn extract_type_name(&self, node: Node) -> Option<String> {
@@ -7536,5 +7666,100 @@ class Box {
         let (elements, _) = extractor.extract_regex_only();
         let names: Vec<&str> = elements.iter().map(|e| e.name.as_str()).collect();
         assert!(names.contains(&"add"), "expected lisp add, got {:?}", names);
+    }
+
+    fn parse_rust(source: &[u8]) -> Option<tree_sitter::Tree> {
+        let mut parser = Parser::new();
+        let lang: tree_sitter::Language = tree_sitter_rust::LANGUAGE.into();
+        parser.set_language(&lang).ok()?;
+        parser.parse(source, None)
+    }
+
+    /// Every element produced from one file batch must carry a unique
+    /// qualified_name. Real-world files declare many same-named symbols — a
+    /// large `.pb.validate.go` yielded 764 rows under the single key
+    /// `...pb.validate.go::Error` — and keyed downstream stores
+    /// (embedding_state / embedding_vectors PK = qualified_name) silently
+    /// merge distinct symbols into one embedding row.
+    #[test]
+    fn duplicate_go_method_names_get_unique_qualified_names() {
+        let source = b"package pb\n\ntype MsgA struct{}\n\nfunc (m *MsgA) Error() string { return \"a\" }\n\ntype MsgB struct{}\n\nfunc (m *MsgB) Error() string { return \"b\" }\n";
+        let tree = parse_go(source).expect("parse go");
+        let extractor = EntityExtractor::new(source, "pb/msg.pb.validate.go", "go");
+        let (elements, relationships) = extractor.extract(&tree);
+
+        let errors: Vec<&str> = elements
+            .iter()
+            .filter(|e| e.name == "Error")
+            .map(|e| e.qualified_name.as_str())
+            .collect();
+        assert_eq!(
+            errors.len(),
+            2,
+            "both Error methods must be extracted, got {errors:?}"
+        );
+        let unique: std::collections::HashSet<&str> = errors.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            errors.len(),
+            "same-named methods on different receivers collapsed to identical qualified_names: {errors:?}"
+        );
+
+        // Disambiguation must keep relationship endpoints pointing at real
+        // elements of this batch.
+        let qns: std::collections::HashSet<&str> =
+            elements.iter().map(|e| e.qualified_name.as_str()).collect();
+        for rel in relationships.iter().filter(|r| r.rel_type == "contains") {
+            assert!(
+                qns.contains(rel.target_qualified.as_str()),
+                "contains target {} no longer resolves to an element",
+                rel.target_qualified
+            );
+        }
+    }
+
+    #[test]
+    fn duplicate_class_method_names_get_unique_qualified_names() {
+        let source = b"class Alpha { render(): number { return 1; } }\nclass Beta { render(): number { return 2; } }\n";
+        let tree = parse_typescript(source).expect("parse ts");
+        let extractor = EntityExtractor::new(source, "src/views.ts", "typescript");
+        let (elements, _) = extractor.extract(&tree);
+
+        let renders: Vec<&str> = elements
+            .iter()
+            .filter(|e| e.name == "render")
+            .map(|e| e.qualified_name.as_str())
+            .collect();
+        assert_eq!(renders.len(), 2, "both render methods must be extracted");
+        let unique: std::collections::HashSet<&str> = renders.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            renders.len(),
+            "same-named methods on different classes collapsed: {renders:?}"
+        );
+    }
+
+    /// Rust impl blocks give no syntactic parent to visit_node, so same-named
+    /// inherent methods (`new`) collide without a receiver fallback — the
+    /// deterministic `#k` discriminator must kick in.
+    #[test]
+    fn duplicate_rust_impl_fn_names_get_unique_qualified_names() {
+        let source = b"pub struct Alpha;\npub struct Beta;\nimpl Alpha { pub fn new() -> Self { Alpha } }\nimpl Beta { pub fn new() -> Self { Beta } }\n";
+        let tree = parse_rust(source).expect("parse rust");
+        let extractor = EntityExtractor::new(source, "src/units.rs", "rust");
+        let (elements, _) = extractor.extract(&tree);
+
+        let news: Vec<&str> = elements
+            .iter()
+            .filter(|e| e.name == "new")
+            .map(|e| e.qualified_name.as_str())
+            .collect();
+        assert_eq!(news.len(), 2, "both new fns must be extracted");
+        let unique: std::collections::HashSet<&str> = news.iter().copied().collect();
+        assert_eq!(
+            unique.len(),
+            news.len(),
+            "same-named impl fns collapsed to identical qualified_names: {news:?}"
+        );
     }
 }

--- a/src/indexer/file_summary.rs
+++ b/src/indexer/file_summary.rs
@@ -120,6 +120,10 @@ pub fn build_file_summary(
         language: language.to_string(),
         ..Default::default()
     });
+    // Upgrade legacy container spellings ("File" from the physical-structure
+    // pass) to the summary node type the embed pipeline filters on — the
+    // enriched row IS this path's file-summary node.
+    element.element_type = "file".to_string();
 
     // Ensure the node name reflects the basename even if the existing node
     // had an empty/stale name.

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -1114,6 +1114,14 @@ fn synthesize_summary_nodes(
 
     let mut bundles: HashMap<String, FileBundle> = HashMap::new();
     for (i, el) in all_elements.iter().enumerate() {
+        // Container rows from the physical-structure pass carry the raw path
+        // as both qualified_name and file_path. A directory/project row is
+        // hierarchy scaffolding — it must not spawn a summary bundle keyed on
+        // that path (its synthesized "file" node would collide with the
+        // container row's qualified_name).
+        if matches!(el.element_type.as_str(), "directory" | "Project") {
+            continue;
+        }
         let entry = bundles
             .entry(el.file_path.clone())
             .or_insert_with(|| FileBundle {
@@ -1125,9 +1133,15 @@ fn synthesize_summary_nodes(
         if entry.language.is_empty() {
             entry.language = el.language.clone();
         }
-        if el.element_type == "file" {
-            // Record the existing file node's position; do NOT summarize it.
-            entry.existing_file_idx = Some(i);
+        if el.element_type == "file" || el.element_type == "File" {
+            // Record the existing node's position; do NOT summarize it. Both
+            // spellings are accepted: lowercase bare "file" nodes come from
+            // swift/objc/sql extractors, uppercase "File" rows from the
+            // physical-structure pass — that row is upgraded in place into
+            // this path's file-summary node instead of colliding with it.
+            if entry.existing_file_idx.is_none() {
+                entry.existing_file_idx = Some(i);
+            }
             continue;
         }
         if el.element_type == "document" {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1328,10 +1328,17 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         cli::CLICommand::Migrate {} => {
             // postgres::Client is sync and builds its own tokio runtime; the
             // whole connect+apply must run off the ambient tokio runtime.
-            let report = tokio::task::spawn_blocking(|| {
+            let report = tokio::task::spawn_blocking(move || {
                 let url = db::pg::migrations::pg_url();
-                let mut client = postgres::Client::connect(&url, postgres::NoTls)?;
-                db::pg::migrations::run_migrations(&mut client)
+                // TLS-aware connector (LEANKG_PG_CA_CERT / webpki roots) — a
+                // raw NoTls connect rejects managed-Postgres URLs whose
+                // sslmode=verify-full tokio-postgres cannot even parse.
+                match db::backend::pg_connect(&url) {
+                    Ok(mut client) => {
+                        db::pg::migrations::run_migrations(&mut client).map_err(|e| e.to_string())
+                    }
+                    Err(e) => Err(e.to_string()),
+                }
             })
             .await??;
             for id in &report.applied {

--- a/tests/pg_schema_test.rs
+++ b/tests/pg_schema_test.rs
@@ -61,7 +61,10 @@ impl ScratchSchema {
             std::process::id(),
             COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         );
-        let mut admin = postgres::Client::connect(&url, postgres::NoTls)
+        // The crate's TLS-aware connector: managed remote URLs carry
+        // sslmode=verify-full, which tokio-postgres's parser rejects and
+        // NoTls cannot satisfy.
+        let mut admin = leankg::db::backend::pg_connect(&url)
             .unwrap_or_else(|e| panic!("cannot connect to {url}: {e}"));
         admin
             .batch_execute(&format!("DROP SCHEMA IF EXISTS {name} CASCADE"))
@@ -105,6 +108,7 @@ fn all_16_tables_exist_and_no_query_cache() {
             "002_multi_model_embed".to_string(),
             "003_gemini_embed".to_string(),
             "004_auth".to_string(),
+            "005_hnsw_dims_cleanup".to_string(),
         ],
         "migrations should apply exactly once on a fresh schema"
     );
@@ -147,6 +151,7 @@ fn rerun_is_noop() {
             "002_multi_model_embed".to_string(),
             "003_gemini_embed".to_string(),
             "004_auth".to_string(),
+            "005_hnsw_dims_cleanup".to_string(),
         ]
     );
 }

--- a/tests/pg_translate_parity_test.rs
+++ b/tests/pg_translate_parity_test.rs
@@ -51,7 +51,10 @@ impl Scratch {
     fn new() -> Self {
         let url = pg_url();
         let name = scratch_schema_name();
-        let mut admin = postgres::Client::connect(&url, postgres::NoTls)
+        // The crate's TLS-aware connector: managed remote URLs carry
+        // sslmode=verify-full, which tokio-postgres's parser rejects and
+        // NoTls cannot satisfy.
+        let mut admin = leankg::db::backend::pg_connect(&url)
             .unwrap_or_else(|e| panic!("cannot connect to {url}: {e}"));
         admin
             .batch_execute(&format!("DROP SCHEMA IF EXISTS {name} CASCADE"))

--- a/tests/regression_index_eexist.rs
+++ b/tests/regression_index_eexist.rs
@@ -1,0 +1,173 @@
+//! Regression test: re-running `leankg index` on an already-indexed project.
+//!
+//! Historical bug (docs/analysis/pg-perf-large-codebase.md finding 1): a bare
+//! `create_dir` on `<project>/.leankg` returned `Os { code: 17, AlreadyExists }`
+//! whenever the project had been indexed before — blocking the normal
+//! `index` → `reindex` workflow. Idempotent re-index requires: `create_dir_all`
+//! for the `.leankg` dir, `CREATE SCHEMA IF NOT EXISTS` + idempotent migrations
+//! for the per-project PG schema on every writer init, and a wipe-then-insert
+//! full index (LEANKG_INDEX_WIPE).
+//!
+//! Two layers:
+//! 1. Programmatic — `init_db` twice on the same db_path (pre-created
+//!    `.leankg` dir), then two full wipe/insert cycles: both must succeed and
+//!    the second must not accumulate duplicates.
+//! 2. CLI end-to-end — spawn the real binary's `leankg index` twice against a
+//!    temp project whose `.leankg` dir already exists; both runs must exit 0.
+//!
+//! Requires LEANKG_PG_URL pointing at a Postgres 18 + pgvector instance
+//! (TLS URLs accepted). Skipped when it is unset or unreachable.
+
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::{Mutex, OnceLock};
+
+const BIN: &str = env!("CARGO_BIN_EXE_leankg");
+
+/// Serializes the LEANKG_PG_URL mutation + `init_db` window — env is
+/// process-global and tests run in parallel.
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+/// Captured once so later `set_var`/`remove_var` windows inside one test
+/// cannot make another test observe a missing variable.
+fn base_url() -> String {
+    static BASE: OnceLock<String> = OnceLock::new();
+    BASE.get_or_init(|| {
+        std::env::var("LEANKG_PG_URL")
+            .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost:5433/leankg".to_string())
+    })
+    .clone()
+}
+
+fn pg_reachable(url: &str) -> bool {
+    leankg::db::backend::pg_connect(url)
+        .and_then(|mut c| c.batch_execute("SELECT 1").map_err(|e| e.into()))
+        .is_ok()
+}
+
+fn drop_schema(url: &str, schema: &str) {
+    if let Ok(mut admin) = leankg::db::backend::pg_connect(url) {
+        let _ = admin.batch_execute(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"));
+    }
+}
+
+#[test]
+fn init_db_and_full_index_twice_on_existing_leankg_dir_succeeds() {
+    let url = base_url();
+    if !pg_reachable(&url) {
+        eprintln!("skipping: LEANKG_PG_URL unset or unreachable");
+        return;
+    }
+
+    // The historical EEXIST trigger: the project root already contains a
+    // `.leankg` directory from a previous index run. The writer derives a
+    // deterministic per-project PG schema from db_path; start it cold.
+    let project = std::env::temp_dir().join(format!("leankg_eexist_prog_{}", std::process::id()));
+    let db_path = project.join(".leankg");
+    std::fs::create_dir_all(&db_path).expect("pre-create .leankg dir");
+    let schema = leankg::db::backend::schema_for_path(&db_path);
+    drop_schema(&url, &schema);
+
+    let batch = vec![elem("/src/lib.rs::main"), elem("/src/lib.rs::helper")];
+
+    // Run #1 — first `leankg index`.
+    let ge1 = engine_for(&url, &db_path);
+    ge1.insert_elements_with(&batch, true)
+        .expect("full index run 1");
+    drop(ge1);
+
+    // Run #2 — re-index the SAME project: init_db again on the existing
+    // path/schema, wipe-then-insert must succeed without EEXIST or dupes.
+    let ge2 = engine_for(&url, &db_path);
+    ge2.wipe_elements_for_env("local")
+        .expect("wipe before run 2");
+    ge2.invalidate_cache();
+    ge2.insert_elements_with(&batch, true)
+        .expect("full index run 2");
+    ge2.invalidate_cache();
+
+    let all = ge2.all_elements().expect("all_elements");
+    assert_eq!(
+        all.len(),
+        2,
+        "re-index on an existing project must not duplicate rows"
+    );
+
+    drop_schema(&url, &schema);
+    let _ = std::fs::remove_dir_all(&project);
+}
+
+/// Build a GraphEngine via the writer entrypoint (`init_db`) while
+/// LEANKG_PG_URL points at the shared instance. The engine pins its own
+/// per-project schema derived from db_path.
+fn engine_for(url: &str, db_path: &std::path::Path) -> leankg::graph::GraphEngine {
+    let guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    std::env::set_var("LEANKG_PG_URL", url);
+    let db = leankg::db::backend::init_db(db_path)
+        .unwrap_or_else(|e| panic!("init_db({db_path:?}) failed: {e}"));
+    drop(guard);
+    leankg::graph::GraphEngine::new(db)
+}
+
+fn elem(qn: &str) -> leankg::db::models::CodeElement {
+    leankg::db::models::CodeElement {
+        qualified_name: qn.to_string(),
+        element_type: "function".to_string(),
+        name: qn.rsplit("::").next().unwrap_or(qn).to_string(),
+        file_path: "/src/lib.rs".to_string(),
+        line_start: 1,
+        line_end: 5,
+        language: "rust".to_string(),
+        parent_qualified: None,
+        metadata: serde_json::json!({}),
+        env: "local".to_string(),
+        ..Default::default()
+    }
+}
+
+/// End-to-end: the real CLI indexes a temp project whose `.leankg` directory
+/// already exists — twice. Both runs must exit 0 (no EEXIST).
+#[test]
+fn cli_index_twice_on_preexisting_leankg_dir_succeeds() {
+    let url = base_url();
+    if std::env::var("LEANKG_PG_URL").is_err() || !pg_reachable(&url) {
+        eprintln!("skipping: LEANKG_PG_URL unset or unreachable");
+        return;
+    }
+
+    let project: PathBuf =
+        std::env::temp_dir().join(format!("leankg_eexist_cli_{}", std::process::id()));
+    let src = project.join("src");
+    std::fs::create_dir_all(&src).expect("create fixture src/");
+    std::fs::write(src.join("main.rs"), "fn main() { println!(\"hello\"); }\n")
+        .expect("write main.rs");
+    std::fs::write(
+        src.join("util.rs"),
+        "pub fn add(a: i32, b: i32) -> i32 { a + b }\n",
+    )
+    .expect("write util.rs");
+    // The trigger: `.leankg` already present before the first index call.
+    std::fs::create_dir_all(project.join(".leankg")).expect("pre-create .leankg dir");
+
+    // The CLI pins a per-project schema derived from the project path; drop
+    // any leftover state first so the run starts cold.
+    let schema = leankg::db::backend::schema_for_path(&project.join(".leankg"));
+    drop_schema(&url, &schema);
+
+    for run in 1..=2 {
+        let status = Command::new(BIN)
+            .arg("index")
+            .arg(&project)
+            .current_dir(&project)
+            .env("LEANKG_PG_URL", &url)
+            .status()
+            .expect("spawn leankg index");
+        assert!(
+            status.success(),
+            "`leankg index` run #{run} failed on an already-initialized project: {status}"
+        );
+    }
+
+    drop_schema(&url, &schema);
+    let _ = std::fs::remove_dir_all(&project);
+}

--- a/tests/regression_qn_collision.rs
+++ b/tests/regression_qn_collision.rs
@@ -1,0 +1,211 @@
+//! Regression test: duplicate qualified_names across same-named symbols.
+//!
+//! Finding A of docs/plan-migrate-cozo-to-postgres-pgvector.md (§9 / finding 3
+//! in docs/analysis/pg-perf-large-codebase.md): a real workspace index held
+//! 727k code_elements rows but only 348k distinct qualified_names (52%
+//! duplicates, up to 764 rows under one `...pb.validate.go::Error` key).
+//! Keyed downstream stores (embedding_state / embedding_vectors PK =
+//! qualified_name) silently merge distinct symbols into one embedding row.
+//!
+//! Fix: extraction-time disambiguation (`EntityExtractor::extract` now ends
+//! with `disambiguate_qualified_names`, and receiver-less Go methods derive
+//! their parent type from the receiver) — every element of a file batch gets
+//! a unique qualified_name before it reaches the database.
+//!
+//! Requires LEANKG_PG_URL pointing at a Postgres 18 + pgvector instance
+//! (TLS URLs accepted). Skipped when unset or unreachable.
+
+use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+
+fn base_url() -> String {
+    static BASE: OnceLock<String> = OnceLock::new();
+    BASE.get_or_init(|| {
+        std::env::var("LEANKG_PG_URL")
+            .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost:5433/leankg".to_string())
+    })
+    .clone()
+}
+
+fn pg_reachable(url: &str) -> bool {
+    leankg::db::backend::pg_connect(url)
+        .and_then(|mut c| c.batch_execute("SELECT 1").map_err(|e| e.into()))
+        .is_ok()
+}
+
+fn drop_schema(url: &str, schema: &str) {
+    if let Ok(mut admin) = leankg::db::backend::pg_connect(url) {
+        let _ = admin.batch_execute(&format!("DROP SCHEMA IF EXISTS {schema} CASCADE"));
+    }
+}
+
+fn engine_for(url: &str, db_path: &std::path::Path) -> leankg::graph::GraphEngine {
+    let guard = ENV_LOCK.get_or_init(|| Mutex::new(())).lock().unwrap();
+    std::env::set_var("LEANKG_PG_URL", url);
+    let db = leankg::db::backend::init_db(db_path)
+        .unwrap_or_else(|e| panic!("init_db({db_path:?}) failed: {e}"));
+    drop(guard);
+    leankg::graph::GraphEngine::new(db)
+}
+
+fn write_fixture(root: &std::path::Path) {
+    let src = root.join("src");
+    std::fs::create_dir_all(&src).expect("mkdir fixture src");
+    // The production collision shape: two message structs, each with an
+    // `Error() string` method, plus TS/Rust variants of the same pattern.
+    std::fs::write(
+        root.join("src").join("msg.pb.validate.go"),
+        concat!(
+            "package pb\n",
+            "\n",
+            "type MsgA struct{}\n",
+            "\n",
+            "func (m *MsgA) Error() string { return \"a\" }\n",
+            "\n",
+            "type MsgB struct{}\n",
+            "\n",
+            "func (m *MsgB) Error() string { return \"b\" }\n",
+        ),
+    )
+    .expect("write go fixture");
+    std::fs::write(
+        root.join("src").join("views.ts"),
+        concat!(
+            "class Alpha { render(): number { return 1; } }\n",
+            "class Beta { render(): number { return 2; } }\n",
+        ),
+    )
+    .expect("write ts fixture");
+    std::fs::write(
+        root.join("src").join("units.rs"),
+        concat!(
+            "pub struct Alpha;\n",
+            "pub struct Beta;\n",
+            "impl Alpha { pub fn new() -> Self { Alpha } }\n",
+            "impl Beta { pub fn new() -> Self { Beta } }\n",
+        ),
+    )
+    .expect("write rust fixture");
+}
+
+#[test]
+fn indexed_symbols_are_unique_in_code_elements_and_embedding_state() {
+    let url = base_url();
+    if !pg_reachable(&url) {
+        eprintln!("skipping: LEANKG_PG_URL unset or unreachable");
+        return;
+    }
+
+    let project: PathBuf =
+        std::env::temp_dir().join(format!("leankg_qn_collision_{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&project);
+    write_fixture(&project);
+
+    let db_path = project.join(".leankg");
+    let schema = leankg::db::backend::schema_for_path(&db_path);
+    drop_schema(&url, &schema);
+
+    let ge = engine_for(&url, &db_path);
+    let files = leankg::indexer::find_files_sync(project.to_str().expect("utf8 project path"))
+        .expect("find files");
+    assert!(!files.is_empty(), "fixture files must be discovered");
+
+    leankg::indexer::index_files_parallel(&ge, &files, false).expect("index fixture");
+
+    // 1. Every indexed element carries a unique qualified_name.
+    let all = ge.all_elements().expect("all_elements");
+    assert!(all.len() >= 6, "expected the fixture symbols, got {all:?}");
+    let mut counts: std::collections::HashMap<&str, usize> = std::collections::HashMap::new();
+    for e in &all {
+        *counts.entry(e.qualified_name.as_str()).or_insert(0) += 1;
+    }
+    let dupes: Vec<_> = counts
+        .iter()
+        .filter(|(_, c)| **c > 1)
+        .map(|(qn, c)| (*qn, *c))
+        .collect();
+    assert!(
+        dupes.is_empty(),
+        "indexed elements still collide on qualified_name: {dupes:?}"
+    );
+
+    // The disambiguated instances keep their parent symbol readable.
+    let go_errors: Vec<&str> = all
+        .iter()
+        .filter(|e| e.language == "go" && e.name == "Error")
+        .map(|e| e.qualified_name.as_str())
+        .collect();
+    assert_eq!(go_errors.len(), 2, "both Go Error methods must be indexed");
+
+    // 2. contains edges survive the rewrite: every target resolves.
+    let qns: std::collections::HashSet<&str> =
+        all.iter().map(|e| e.qualified_name.as_str()).collect();
+    let rels = ge.all_relationships().expect("all_relationships");
+    for rel in rels.iter().filter(|r| r.rel_type == "contains") {
+        assert!(
+            qns.contains(rel.target_qualified.as_str()),
+            "contains edge points at missing element {}: source={}",
+            rel.target_qualified,
+            rel.source_qualified
+        );
+    }
+
+    // 3. Embed-state write path: one state row per distinct symbol — no
+    // silent PK merge of previously colliding keys. This is the exact keyed
+    // write `embeddings::state::mark_stale_for_qualified_names` performs
+    // (import_relations → INSERT .. ON CONFLICT (qualified_name)); that
+    // module is behind --features embeddings, so the write is issued here
+    // directly against the same table.
+    use leankg::db::backend::{DataValue, NamedRows};
+    let now = "2026-08-21T00:00:00Z";
+    let rows: Vec<Vec<DataValue>> = all
+        .iter()
+        .map(|e| {
+            vec![
+                DataValue::Str(e.qualified_name.as_str().into()),
+                DataValue::from(0i64),
+                DataValue::Str("".into()),
+                DataValue::Str("stale".into()),
+                DataValue::Str(now.into()),
+            ]
+        })
+        .collect();
+    let named = NamedRows::new(
+        vec![
+            "qualified_name".to_string(),
+            "usearch_key".to_string(),
+            "content_hash".to_string(),
+            "state".to_string(),
+            "embedded_at".to_string(),
+        ],
+        rows,
+    );
+    let mut batch = std::collections::BTreeMap::new();
+    batch.insert("embedding_state".to_string(), named);
+    ge.db_arc()
+        .as_ref()
+        .import_relations(batch)
+        .expect("embedding_state upsert");
+
+    let count = ge
+        .db_arc()
+        .as_ref()
+        .run_script(
+            "?[n] := *embedding_state[qualified_name, _, _, _, _], n = count(qualified_name)",
+            Default::default(),
+        )
+        .expect("count embedding_state");
+    let stored = count.rows[0][0].get_int().expect("int count") as usize;
+    assert_eq!(
+        stored,
+        all.len(),
+        "embedding_state merged distinct symbols ({}) into {} rows",
+        all.len(),
+        stored
+    );
+
+    drop_schema(&url, &schema);
+    let _ = std::fs::remove_dir_all(&project);
+}


### PR DESCRIPTION
## Wave 2 — Known findings from PG migration plan
- **qualified_name collision (fixed):** extraction-time disambiguation — methods get parent/file discriminators (`{qn}#{k}` fallback), File summary rows upgraded in-place (no more path-colliding container nodes), CICD root gets `{path}::<cicd>`. Live evidence: 2711/2711 distinct QNs on real index (was 2710/2711).
- **EEXIST re-index (regression-guarded):** already fixed by 56a0a86b; added tests/regression_index_eexist.rs (CLI e2e + programmatic, 2✅) to lock it.
- **Bonus:** `leankg migrate` used raw NoTls connect → could never reach the mandated remote PG (sslmode=verify-full); now routed through TLS-aware pg_connect. Fixed stale 005 expectation in pg_schema_test.

**Verification:** lib 1043✅ · regression_qn_collision 1✅ (unique QNs + embedding_state 1:1) · pg_schema_test 6✅ (--ignored) · pg_translate_parity 11✅ · fmt✅ · clippy✅
**Live CLI:** double-index against remote PG (.env LEANKG_PG_URL), both runs exit 0; all scratch schemas dropped; no Docker used.

Diff: 11 files, +662/−13