### PR TITLE
Hackathon cycle 5: W8 SQL-first seam + wave-1a conversion

### DIFF
--- a/HACKATHON.md
+++ b/HACKATHON.md
@@ -98,3 +98,11 @@ Branch reset onto main cf357ad8 (cycles 1-2 banked via squash #247). Backlog thi
 ### Cycle 4 progress
 - H10 usage dashboard: leankg dashboard (--since/--format) with grouped-SQL aggregates, ASCII bars, JSON mode; 12 unit + 3 live-PG integration tests; empty-state + invalid-since handled. 18342c50
 - H8 perf regression gate: perf_gate.sh (compare/update, PERF_GATE_PCT) + run_perf_workload.sh (median-of-3) + gen_perf_fixture.py + CI workflow; 8/8 bash TDD tests; live baseline vs remote PG: index 18315ms / boot 19ms / search_code 13ms; forced-fail sensitivity proven. 33d69541→0448998b
+
+### Cycle 5 — W8 SQL-first Datalog removal begins
+- Plan doc adopted from dormant orca/cozo-removal WIP (branch wip/cozo-sql-seam-backup @ dd8018fa)
+- **P1 seam**: src/db/sql.rs (SqlParam/SqlRow/sql_query/sql_execute_batch/COPY) ported+TDD'd; run_script untouched, dual-path parity kept. 55979b60
+- **Wave-1a conversion**: db/keys.rs (7 sites) + content_hash.rs (2 sites) → typed parameterized methods; live proof shows sql_first_lines=1, cozo_lines=0 per op. c6e95d39
+- Caught during adoption: SqlRow::text() rendered NULL as Some("null") (fixed); legacy validate_key DELETE+reinsert wiped name/created_at (now updates last_used_at only)
+- Gates: lib **1213✅** · parity 11✅ · pg_schema 6✅ · fmt/clippy clean
+- Next: wave-1b (db/mod.rs ×46 helpers), then W2-W6 disjoint-file fan-out

--- a/docs/plan-remove-cozo-datalog-sql-migration.md
+++ b/docs/plan-remove-cozo-datalog-sql-migration.md
@@ -1,0 +1,140 @@
+# Plan: Remove Cozo/Datalog — All Queries Become Plain PostgreSQL
+
+> **Adopted (Hackathon C5 / W8):** this plan was authored in the dormant WIP
+> (`wip/cozo-sql-seam-backup` @ `dd8018fa`, worktree
+> `/Users/linh.doan/orca/workspaces/cozo-removal`) and is now the working plan
+> on `feature/hackathon`. Waves are executed here; deviations from the
+> original text are logged in §6 "W8 execution log" below.
+
+Worktree: `/Users/linh.doan/orca/workspaces/cozo-removal` (branch `feat/remove-cozo-datalog`, base `541ff626`).
+Status legend: `[ ]` todo, `[-]` in progress, `[x]` done.
+
+## 1. Problem
+
+Storage already lives in Postgres (Phase 8), but every query is authored as a
+Datalog script string, passed to `DbBackend::run_script()`, parsed and
+translated to SQL at runtime by `src/db/pg/translate.rs` (~4,300 lines). The
+in-memory test fake re-implements a Datalog interpreter (`src/db/fake.rs`,
+~1,400 lines). This keeps ~5,700 lines of dead-weight translator machinery,
+a legacy value model (`DataValue`/`NamedRows`, cozo-shaped), and injection-prone
+string-built scripts.
+
+## 2. Measured surface (2026-08-21 audit)
+
+| Area | Sites | Files |
+|------|-------|-------|
+| graph engine | 105 | `src/graph/query.rs` (+ nl_query, inventory 4, clustering 3) |
+| db helpers | 46 | `src/db/mod.rs` |
+| db layer | ~40 | `backend.rs` 35, `keys.rs` 7, `schema.rs` 2, `write_bus.rs` 1 |
+| embeddings | 22 | `state.rs` 15, `build.rs` 6, `control.rs` 1 |
+| auth | 15 | `accounts.rs` 9, `tokens.rs` 6 |
+| ontology | 8+ | `ontology/query.rs` 8, `sync.rs` |
+| mcp + cli | ~10 | `handler.rs` 4, `tracking_db.rs` 2, `main.rs` 2 |
+| misc | ~7 | `doc_indexer/paths.rs` 2, `retrieval/pipeline.rs` 1, `indexer/mod.rs` 1, others |
+| integration tests | 16 files | use `run_script`/`FakeBackend` directly |
+| docs mentions | ~271 across 30+ files | README, architecture, erd, mcp-tools, dated analyses |
+
+Cargo.toml/Cargo.lock: already free of cozo/rocksdb deps. Removal is purely
+the query layer + types + naming/docs.
+
+## 3. Target design (decided)
+
+### New SQL-first backend seam
+
+```rust
+pub enum SqlParam { Null, Bool, Int(i64), Float(f64), Text(String),
+                    Bytes(Vec<u8>), Json(serde_json::Value), Vector(Vec<f32>) }
+
+pub struct SqlRow { pub cols: Vec<(String, DataValue)> }   // reuse DataValue as the cell type initially; rename later
+// or typed accessors: row.get::<str>("name"), row.int(0) ...
+
+pub trait DbBackend: Send + Sync {
+    fn query(&self, sql: &str, params: &[SqlParam]) -> Result<Vec<SqlRow>>;
+    fn execute(&self, sql: &str, params: &[SqlParam]) -> Result<u64>;
+    fn transaction<T>(&self, f: impl FnOnce(&dyn SqlTx) -> Result<T>) -> Result<T>;
+    fn copy_import(&self, table: &str, columns: &[String], rows: Vec<Vec<SqlParam>>);
+}
+```
+
+Decisions:
+- **Keep `DataValue` as the cell type** through the migration (call sites
+  already consume `.get_str()/.get_int()`); rename module later to `row.rs`
+  semantics without changing call-site code twice. Drop `Bot`, `next`
+  pagination chain on `NamedRows` at the end.
+- **Delete, not wrap**: `translate.rs`, `mutability.rs`, Datalog parser paths,
+  `run_script`/`submit_write`/`import_relations`/`submit_import`/
+  `mutability_for` all leave the trait once the last caller converts.
+- **FakeBackend dies**: tests move to live-PG scratch schemas behind the
+  existing `test_pg_available()` probe (skip-not-fail when docker is down).
+  Local PG docker (`leankg-pg-phase0`, :5433) is mandatory per project rules.
+- Write bus (`write_bus.rs`) re-targets from datalog scripts to
+  `(sql, params)` work items.
+
+### TDD protocol (every phase)
+
+1. RED: characterization test against live-PG scratch schema asserting current
+   behavior of the target function (or parity via existing
+   `tests/pg_translate_parity_test.rs` harness while it exists).
+2. GREEN: convert call site(s) to parameterized SQL; test stays green.
+3. REFACTOR: drop the now-unused helper/script constants.
+4. Gate per wave: `cargo build --release && cargo test` green before merge of
+   that wave's commit.
+
+## 4. Phases
+
+### P0 Baseline [-]
+- [x] Worktree created, branch `feat/remove-cozo-datalog`.
+- [ ] Record baseline: `cargo build --release` + `cargo test` results.
+
+### P1 SQL seam in db layer [ ]
+- [ ] Add `SqlParam`, `SqlRow`, `query/execute/transaction/copy_import` to
+      `PostgresBackend` (trait methods with default error impls so the tree
+      compiles mid-migration).
+- [ ] Unit tests for the seam against live-PG scratch schema (TDD).
+- [ ] Keep `run_script` delegating to nothing new; both paths coexist until P3.
+
+### P2 Call-site conversion waves (fan-out subagents, one agent per wave)
+- [ ] W1 `src/db/mod.rs` helpers (46) + schema.rs + keys.rs + write_bus.rs
+- [ ] W2 `src/graph/query.rs` part A (read/query shapes)
+- [ ] W3 `src/graph/query.rs` part B (writes/aggregation/vector) +
+      inventory.rs + clustering.rs + nl_query/l1_cache if touched
+- [ ] W4 embeddings state/build/control + retrieval/pipeline.rs
+- [ ] W5 auth tokens/accounts + ontology query/sync
+- [ ] W6 mcp handler/tracking_db/main/indexer/doc_indexer/pack
+- [ ] Each wave: tests first (characterization), then convert, then gate.
+
+Wave ordering rationale: W1 converts the shared helpers everything calls;
+W2-W6 are leaf domains that can run in parallel once W1 lands.
+
+### P3 Deletion sweep [ ]
+- [ ] Delete `src/db/pg/translate.rs`, `src/db/pg/mutability.rs`,
+      `cozo_to_pg`, legacy script plumbing in `backend.rs`.
+- [ ] Shrink `value.rs`: drop `Bot`, `NamedRows::next`; rename to honest
+      names (`SqlRow` etc.).
+- [ ] Delete `src/db/fake.rs`; migrate its test users to live-PG scratch
+      schema pattern (probe-gated).
+- [ ] Trait reduced to `query/execute/transaction/copy_import/redacted_url/
+      is_read_only`.
+- [ ] Integration tests: rewrite direct `run_script` usage in the 16 test
+      files to SQL.
+- [ ] Docs sweep: update living docs (README, CLAUDE.md, docs/architecture.md,
+      erd.md, mcp-tools.md, tech-stack.md, index-embed-flow.md ...); delete
+      obsolete cozo migration planning docs; CHANGELOG history entries stay
+      verbatim (historical record).
+- [ ] Regenerate or patch UI bundle mention (`src/embed/assets/index-*.js`).
+
+### P4 Final verification [ ]
+- [ ] `grep -ri "cozo\|datalog" src/ tests/ Cargo.toml` → zero hits
+      (excluding CHANGELOG).
+- [ ] `cargo build --release` clean; `cargo clippy` no new warnings.
+- [ ] `cargo test` with local PG up: fully green; without PG: skips only.
+- [ ] Smoke: `init` + `index ./src` + one MCP tool query against :5433.
+
+## 5. Risks
+
+| Risk | Mitigation |
+|------|------------|
+| Recursive/transitive graph queries in query.rs have no trivial SQL form | Use recursive CTEs; parity-test against old path before deleting translator |
+| FakeBackend-dependent unit tests lose no-DB property | Scratch-schema + probe-skip pattern is established; docker PG is mandatory locally anyway |
+| Hidden datalog built dynamically (string interpolation) | Wave agents must grep their files for format!/push_str into scripts; flag any to orchestrator |
+| Concurrent subagent edits conflict | Waves own disjoint file sets; only shared file is backend seam (P1, done first, by orchestrator) |

--- a/docs/plan-remove-cozo-datalog-sql-migration.md
+++ b/docs/plan-remove-cozo-datalog-sql-migration.md
@@ -82,19 +82,28 @@ Decisions:
 
 ## 4. Phases
 
-### P0 Baseline [-]
-- [x] Worktree created, branch `feat/remove-cozo-datalog`.
-- [ ] Record baseline: `cargo build --release` + `cargo test` results.
+### P0 Baseline [x]
+- [x] Worktree created, branch `feat/remove-cozo-datalog` (original session).
+- [x] Record baseline: `feature/hackathon` @ `03b969c4` — `cargo test --release --lib`
+      1195 passed / 0 failed (CARGO_TARGET_DIR=/tmp/opencode/t-w8).
 
-### P1 SQL seam in db layer [ ]
-- [ ] Add `SqlParam`, `SqlRow`, `query/execute/transaction/copy_import` to
-      `PostgresBackend` (trait methods with default error impls so the tree
-      compiles mid-migration).
-- [ ] Unit tests for the seam against live-PG scratch schema (TDD).
-- [ ] Keep `run_script` delegating to nothing new; both paths coexist until P3.
+### P1 SQL seam in db layer [x]
+- [x] Add `SqlParam`, `SqlRow`, `sql_query`/`sql_query_gucs`/`sql_execute`/
+      `sql_execute_batch`/`sql_copy_import` to the backend trait with default
+      error impls (tree compiles mid-migration; FakeBackend inherits them).
+      Ported from WIP `wip/cozo-sql-seam-backup` @ `dd8018fa`, adapted to the
+      current tree (audit-ledger + dashboard trait methods landed since).
+- [x] Unit tests for the seam against live-PG scratch schema (TDD):
+      RED 7 pass / 8 fail on defaults, GREEN 15/15 after PostgresBackend impl
+      (`src/db/sql.rs` tests, probe-gated skip when PG unreachable).
+- [x] Keep `run_script` untouched; both paths coexist until P3 (the dual-path
+      parity test relies on this).
 
 ### P2 Call-site conversion waves (fan-out subagents, one agent per wave)
-- [ ] W1 `src/db/mod.rs` helpers (46) + schema.rs + keys.rs + write_bus.rs
+- [-] W1 **SPLIT for hackathon C5**: wave-1a = `keys.rs` (7 sites) +
+      `indexer/content_hash.rs` (2 sites) — DONE (see section 6). The remainder of
+      the original W1 (`db/mod.rs` helpers, schema.rs, write_bus.rs) is
+      wave-1b, still open.
 - [ ] W2 `src/graph/query.rs` part A (read/query shapes)
 - [ ] W3 `src/graph/query.rs` part B (writes/aggregation/vector) +
       inventory.rs + clustering.rs + nl_query/l1_cache if touched
@@ -138,3 +147,20 @@ W2-W6 are leaf domains that can run in parallel once W1 lands.
 | FakeBackend-dependent unit tests lose no-DB property | Scratch-schema + probe-skip pattern is established; docker PG is mandatory locally anyway |
 | Hidden datalog built dynamically (string interpolation) | Wave agents must grep their files for format!/push_str into scripts; flag any to orchestrator |
 | Concurrent subagent edits conflict | Waves own disjoint file sets; only shared file is backend seam (P1, done first, by orchestrator) |
+
+## 6. W8 execution log (hackathon C5, feature/hackathon)
+
+| Item | Status |
+|------|--------|
+| Plan adopted from dormant WIP | copied from `wip/cozo-sql-seam-backup` @ `dd8018fa`; this section logs deviations. |
+| P0 seam commit | `feat(db): SQL-first seam adoption (W8 P0)` — `src/db/sql.rs` (655 ln), trait + PostgresBackend impls in `backend.rs`. |
+| Wave-1a converted | `keys.rs`: create/list/revoke/validate -> typed trait methods (`insert_api_key`, `list_api_keys`, `mark_api_key_revoked`, `list_active_api_key_hashes`, `touch_api_key_last_used`). `content_hash.rs`: load/save -> generic seam (`sql_query` / `sql_execute_batch`), signature now takes `&dyn DbBackend` instead of `&GraphEngine`. |
+| Parity gating | `tests/pg_sql_wave1_test.rs` (5 tests, #[ignore]-gated): lifecycle, dual-path parity old-Datalog-vs-new-SQL on identical rows, multi-key listing filter, content-hash upsert roundtrip, empty-store read. Dual path possible because the translator still runs during W8. |
+| Deviation A | WIP `mod.rs` diff had replaced `pub mod schema;` with `pub mod sql;` — port keeps BOTH modules. |
+| Deviation B | WIP's `bind()` helper (Vec of refs built from temporaries) was unsound/uncompilable — dropped; binding goes through `SqlParam::to_pg()` boxed values owned by the caller frame. |
+| Deviation C | `SqlRow::text()` fixed to return `None` for `DataValue::Null`/`Bot` (WIP rendered NULL as the literal string "null", which broke every optional-column read; caught by wave-1 integration tests, locked by unit test). |
+| Deviation D | Vector binding documented as `$n::text::vector` (matches translator convention; a direct `$n::vector` cast rejects the String bind at ToSql level). JSON binds as `serde_json::Value` (postgres `with-serde_json-1`). |
+| Deviation E | `validate_key` no longer DELETE+re-inserts the row (legacy behavior wiped `name` and `created_at` on EVERY successful validation). SQL-first path updates only `last_used_at`; guarded by a lifecycle test assertion. |
+| Deviation F | COPY text format: NULL emitted as raw backslash-N marker (escaping it produced a literal two-char string); empty string stays distinct from NULL — regression-tested. |
+| Gates (wave-1a) | build --release 0 warnings - cargo test --release --lib green - fmt --check green - clippy CI gate green - pg_schema_test + pg_sql_wave1_test vs remote managed PG (LEANKG_PG_URL via repo .env; never Docker) green. |
+| Live proof | `leankg api-key create/list/revoke` against remote PG with `LEANKG_PG_SQL_LOG=1`: `leankg::pg_sql` lines carry `kind="sql"` + plain SQL and NO `cozo=` field for converted ops (old paths always emit `cozo=`). |

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -256,6 +256,58 @@ pub trait DbBackend: Send + Sync {
     ) -> Result<(), Box<dyn std::error::Error>> {
         Err(crate::db::sql::unsupported())
     }
+
+    // ---- W8 wave 1 typed queries: api_keys (parameterized SQL) ----
+    // Each method replaces one Datalog `run_script` site in keys.rs. The
+    // defaults err so a backend that skips the migration fails loudly.
+
+    /// Upsert one API key row (`:put api_keys` parity — conflict target is
+    /// the unique `key_hash`, matching the translator's pk_for_table).
+    fn insert_api_key(
+        &self,
+        _key: &crate::db::keys::ApiKey,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err("SQL-first api_keys not supported by this backend".into())
+    }
+
+    /// All key rows. Replaces the unfiltered `*api_keys[...]` read; callers
+    /// apply their own revoked/display filtering exactly as before.
+    fn list_api_keys(&self) -> Result<Vec<crate::db::keys::ApiKey>, Box<dyn std::error::Error>> {
+        Err("SQL-first api_keys not supported by this backend".into())
+    }
+
+    /// Revoke by id if not already revoked. Returns whether a row was
+    /// updated: `false` covers BOTH "no such id" and "already revoked",
+    /// matching the legacy two-step read+check behavior.
+    fn mark_api_key_revoked(
+        &self,
+        _id: &str,
+        _revoked_at: &str,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        Err("SQL-first api_keys not supported by this backend".into())
+    }
+
+    /// `(id, key_hash)` for every non-revoked key — the argon2 verification
+    /// candidate set for [`Self`]-level token validation.
+    fn list_active_api_key_hashes(
+        &self,
+    ) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
+        Err("SQL-first api_keys not supported by this backend".into())
+    }
+
+    /// Record last-use timestamp on successful validation.
+    ///
+    /// Deviation from the legacy path (documented in the plan): the old
+    /// Datalog flow DELETEd the row and re-inserted it with `name=""`,
+    /// `created_at=""` on EVERY validation, wiping the key's identity. The
+    /// SQL-first path only updates `last_used_at`.
+    fn touch_api_key_last_used(
+        &self,
+        _id: &str,
+        _last_used_at: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err("SQL-first api_keys not supported by this backend".into())
+    }
 }
 
 /// Shared handle used throughout the codebase. `Arc` so clones of
@@ -1630,6 +1682,96 @@ impl DbBackend for PostgresBackend {
         rows: &[Vec<crate::db::sql::SqlParam>],
     ) -> Result<(), Box<dyn std::error::Error>> {
         self.sql_off_runtime(|| self.sql_copy_import_sync(table, columns, rows))
+    }
+
+    // ---- W8 wave 1 typed queries: api_keys ----
+
+    fn insert_api_key(
+        &self,
+        key: &crate::db::keys::ApiKey,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.sql_execute(
+            "INSERT INTO api_keys (id, name, key_hash, created_at, last_used_at, revoked_at) \
+             VALUES ($1, $2, $3, $4, $5, $6) \
+             ON CONFLICT (key_hash) DO UPDATE SET \
+               id = EXCLUDED.id, name = EXCLUDED.name, created_at = EXCLUDED.created_at, \
+               last_used_at = EXCLUDED.last_used_at, revoked_at = EXCLUDED.revoked_at",
+            &[
+                crate::db::sql::SqlParam::Text(key.id.clone()),
+                crate::db::sql::SqlParam::Text(key.name.clone()),
+                crate::db::sql::SqlParam::Text(key.key_hash.clone()),
+                crate::db::sql::SqlParam::Text(key.created_at.clone()),
+                crate::db::sql::SqlParam::from(key.last_used_at.clone()),
+                crate::db::sql::SqlParam::from(key.revoked_at.clone()),
+            ],
+        )
+        .map(|_| ())
+    }
+
+    fn list_api_keys(&self) -> Result<Vec<crate::db::keys::ApiKey>, Box<dyn std::error::Error>> {
+        let rows = self.sql_query(
+            "SELECT id, name, key_hash, created_at, last_used_at, revoked_at FROM api_keys",
+            &[],
+        )?;
+        Ok(rows
+            .iter()
+            .map(|r| crate::db::keys::ApiKey {
+                id: r.text("id").unwrap_or_default(),
+                name: r.text("name").unwrap_or_default(),
+                key_hash: r.text("key_hash").unwrap_or_default(),
+                created_at: r.text("created_at").unwrap_or_default(),
+                last_used_at: r.text("last_used_at"),
+                revoked_at: r.text("revoked_at"),
+            })
+            .collect())
+    }
+
+    fn mark_api_key_revoked(
+        &self,
+        id: &str,
+        revoked_at: &str,
+    ) -> Result<bool, Box<dyn std::error::Error>> {
+        let n = self.sql_execute(
+            "UPDATE api_keys SET revoked_at = $2 WHERE id = $1 AND revoked_at IS NULL",
+            &[
+                crate::db::sql::SqlParam::Text(id.to_string()),
+                crate::db::sql::SqlParam::Text(revoked_at.to_string()),
+            ],
+        )?;
+        Ok(n > 0)
+    }
+
+    fn list_active_api_key_hashes(
+        &self,
+    ) -> Result<Vec<(String, String)>, Box<dyn std::error::Error>> {
+        let rows = self.sql_query(
+            "SELECT id, key_hash FROM api_keys WHERE revoked_at IS NULL",
+            &[],
+        )?;
+        Ok(rows
+            .iter()
+            .map(|r| {
+                (
+                    r.text("id").unwrap_or_default(),
+                    r.text("key_hash").unwrap_or_default(),
+                )
+            })
+            .collect())
+    }
+
+    fn touch_api_key_last_used(
+        &self,
+        id: &str,
+        last_used_at: &str,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.sql_execute(
+            "UPDATE api_keys SET last_used_at = $2 WHERE id = $1",
+            &[
+                crate::db::sql::SqlParam::Text(id.to_string()),
+                crate::db::sql::SqlParam::Text(last_used_at.to_string()),
+            ],
+        )
+        .map(|_| ())
     }
 
     /// FR-ENT-1: one multi-row INSERT for the whole batch (≤ 50 rows × 9

--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -203,6 +203,59 @@ pub trait DbBackend: Send + Sync {
     ) -> Result<crate::dashboard::UsageAggregates, Box<dyn std::error::Error>> {
         Err("usage dashboard not supported by this backend".into())
     }
+
+    // ---- SQL-first API (W8 P0 — Datalog removal seam) ----
+
+    /// Run a parameterized PostgreSQL SELECT and return owned named rows.
+    /// The default (fake / un-migrated backends) reports unsupported.
+    fn sql_query(
+        &self,
+        _sql: &str,
+        _params: &[crate::db::sql::SqlParam],
+    ) -> Result<Vec<crate::db::sql::SqlRow>, Box<dyn std::error::Error>> {
+        Err(crate::db::sql::unsupported())
+    }
+
+    /// [`Self::sql_query`] with session GUCs applied inside the read
+    /// transaction (e.g. `hnsw.ef_search` before a vector search).
+    fn sql_query_gucs(
+        &self,
+        _sql: &str,
+        _params: &[crate::db::sql::SqlParam],
+        _gucs: &[(&str, &str)],
+    ) -> Result<Vec<crate::db::sql::SqlRow>, Box<dyn std::error::Error>> {
+        Err(crate::db::sql::unsupported())
+    }
+
+    /// Run a parameterized INSERT/UPDATE/DELETE/DDL statement; returns the
+    /// affected row count.
+    fn sql_execute(
+        &self,
+        _sql: &str,
+        _params: &[crate::db::sql::SqlParam],
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        Err(crate::db::sql::unsupported())
+    }
+
+    /// Run several statements in ONE transaction — all commit or all roll
+    /// back. Replaces multi-statement `:put`/`:rm` scripts.
+    fn sql_execute_batch(
+        &self,
+        _stmts: &[(&str, Vec<crate::db::sql::SqlParam>)],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err(crate::db::sql::unsupported())
+    }
+
+    /// Bulk-load rows into `table` via PostgreSQL COPY (text format).
+    /// Replaces `import_relations` / `submit_import`.
+    fn sql_copy_import(
+        &self,
+        _table: &str,
+        _columns: &[&str],
+        _rows: &[Vec<crate::db::sql::SqlParam>],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err(crate::db::sql::unsupported())
+    }
 }
 
 /// Shared handle used throughout the codebase. `Arc` so clones of
@@ -454,6 +507,218 @@ impl std::fmt::Debug for PostgresBackend {
 }
 
 impl PostgresBackend {
+    /// Box the bind params once, then hand `&dyn ToSql` refs to the client.
+    fn sql_binds(
+        params: &[crate::db::sql::SqlParam],
+    ) -> Vec<Box<dyn postgres::types::ToSql + Sync + Send>> {
+        params.iter().map(|p| p.to_pg()).collect()
+    }
+
+    /// Pool selection for a SQL-first statement: a read-only backend never
+    /// touches the RW pool (writes fail at the Postgres layer with a clean
+    /// `read-only` error), mirroring [`Self::run_script_sync`].
+    fn checkout_for_sql(&self) -> Result<PooledClient, Box<dyn std::error::Error>> {
+        if self.read_only {
+            self.checkout_read_only()
+        } else {
+            self.checkout()
+        }
+    }
+
+    /// Emit one `leankg::pg_sql` line for a SQL-first op. Deliberately has NO
+    /// `cozo=` field — converted paths are proven Datalog-free by its absence.
+    fn log_sql_op(phase: &str, op: &str, sql: &str, rows: usize, elapsed_ms: u128) {
+        tracing::info!(
+            target: "leankg::pg_sql",
+            phase,
+            kind = "sql",
+            op,
+            rows,
+            elapsed_ms,
+            sql,
+            "pg sql_first"
+        );
+    }
+
+    /// W8 P0 sync body behind [`DbBackend::sql_query`].
+    fn sql_query_sync(
+        &self,
+        sql: &str,
+        params: &[crate::db::sql::SqlParam],
+    ) -> Result<Vec<crate::db::sql::SqlRow>, Box<dyn std::error::Error>> {
+        let binds = Self::sql_binds(params);
+        let refs: Vec<&(dyn postgres::types::ToSql + Sync)> = binds
+            .iter()
+            .map(|b| b.as_ref() as &(dyn postgres::types::ToSql + Sync))
+            .collect();
+        let mut client = self.checkout_for_sql()?;
+        let started = std::time::Instant::now();
+        let result = client.query(sql, &refs)?;
+        let rows: Vec<crate::db::sql::SqlRow> =
+            result.iter().map(crate::db::sql::row_from_pg).collect();
+        Self::log_sql_op(
+            "done",
+            "query",
+            sql,
+            rows.len(),
+            started.elapsed().as_millis(),
+        );
+        Ok(rows)
+    }
+
+    /// W8 P0 sync body behind [`DbBackend::sql_query_gucs`]: `SET LOCAL`
+    /// knobs ride the same transaction as the read and revert on commit.
+    fn sql_query_gucs_sync(
+        &self,
+        sql: &str,
+        params: &[crate::db::sql::SqlParam],
+        gucs: &[(&str, &str)],
+    ) -> Result<Vec<crate::db::sql::SqlRow>, Box<dyn std::error::Error>> {
+        let binds = Self::sql_binds(params);
+        let refs: Vec<&(dyn postgres::types::ToSql + Sync)> = binds
+            .iter()
+            .map(|b| b.as_ref() as &(dyn postgres::types::ToSql + Sync))
+            .collect();
+        let mut client = self.checkout_for_sql()?;
+        let started = std::time::Instant::now();
+        let mut tx = client.transaction()?;
+        let owned: Vec<(String, String)> = gucs
+            .iter()
+            .map(|(n, v)| ((*n).to_string(), (*v).to_string()))
+            .collect();
+        apply_gucs(&mut tx, &owned)?;
+        let result = tx.query(sql, &refs)?;
+        let rows: Vec<crate::db::sql::SqlRow> =
+            result.iter().map(crate::db::sql::row_from_pg).collect();
+        tx.commit()?;
+        Self::log_sql_op(
+            "done",
+            "query_gucs",
+            sql,
+            rows.len(),
+            started.elapsed().as_millis(),
+        );
+        Ok(rows)
+    }
+
+    /// W8 P0 sync body behind [`DbBackend::sql_execute`].
+    fn sql_execute_sync(
+        &self,
+        sql: &str,
+        params: &[crate::db::sql::SqlParam],
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        let binds = Self::sql_binds(params);
+        let refs: Vec<&(dyn postgres::types::ToSql + Sync)> = binds
+            .iter()
+            .map(|b| b.as_ref() as &(dyn postgres::types::ToSql + Sync))
+            .collect();
+        let mut client = self.checkout_for_sql()?;
+        let started = std::time::Instant::now();
+        let n = client.execute(sql, &refs)?;
+        Self::log_sql_op(
+            "done",
+            "execute",
+            sql,
+            n as usize,
+            started.elapsed().as_millis(),
+        );
+        Ok(n)
+    }
+
+    /// W8 P0 sync body behind [`DbBackend::sql_execute_batch`]: every
+    /// statement runs in ONE transaction — any failure rolls back all.
+    fn sql_execute_batch_sync(
+        &self,
+        stmts: &[(&str, Vec<crate::db::sql::SqlParam>)],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        let mut client = self.checkout_for_sql()?;
+        let started = std::time::Instant::now();
+        let mut tx = client.transaction()?;
+        for (sql, params) in stmts {
+            let binds = Self::sql_binds(params);
+            let refs: Vec<&(dyn postgres::types::ToSql + Sync)> = binds
+                .iter()
+                .map(|b| b.as_ref() as &(dyn postgres::types::ToSql + Sync))
+                .collect();
+            tx.execute(*sql, &refs)?;
+        }
+        tx.commit()?;
+        Self::log_sql_op(
+            "done",
+            "execute_batch",
+            &format!("{} stmt(s)", stmts.len()),
+            0,
+            started.elapsed().as_millis(),
+        );
+        Ok(())
+    }
+
+    /// W8 P0 sync body behind [`DbBackend::sql_copy_import`] — text-format
+    /// COPY inside a transaction. NULL is the `\N` marker so an empty string
+    /// stays distinct from SQL NULL.
+    fn sql_copy_import_sync(
+        &self,
+        table: &str,
+        columns: &[&str],
+        rows: &[Vec<crate::db::sql::SqlParam>],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        use std::io::Write;
+
+        // Table/column names come from internal callers; still quoted like
+        // every other identifier in this file.
+        let q_table = translate::quote_ident(table);
+        let q_cols = columns
+            .iter()
+            .map(|c| translate::quote_ident(c))
+            .collect::<Vec<_>>()
+            .join(", ");
+        let copy_sql = format!("COPY {q_table} ({q_cols}) FROM STDIN");
+        let mut client = self.checkout_for_sql()?;
+        let started = std::time::Instant::now();
+        let mut tx = client.transaction()?;
+        let mut writer = tx.copy_in(&copy_sql)?;
+        for row in rows {
+            let mut line = String::new();
+            for (i, val) in row.iter().enumerate() {
+                if i > 0 {
+                    line.push('\t');
+                }
+                if matches!(val, crate::db::sql::SqlParam::Null) {
+                    // Raw \N marker: push_copy_text would escape the
+                    // backslash, turning NULL into a literal "\N" string.
+                    line.push_str("\\N");
+                } else {
+                    push_copy_text(&mut line, &val.to_copy_text());
+                }
+            }
+            line.push('\n');
+            writer.write_all(line.as_bytes())?;
+        }
+        writer.finish()?;
+        tx.commit()?;
+        Self::log_sql_op(
+            "done",
+            "copy_import",
+            &copy_sql,
+            rows.len(),
+            started.elapsed().as_millis(),
+        );
+        Ok(())
+    }
+
+    /// Wrap a sync SQL-first body in the standard `block_in_place` guard
+    /// (the sync `postgres::Client` must not run on an ambient tokio worker).
+    fn sql_off_runtime<T>(
+        &self,
+        body: impl FnOnce() -> Result<T, Box<dyn std::error::Error>>,
+    ) -> Result<T, Box<dyn std::error::Error>> {
+        if tokio::runtime::Handle::try_current().is_ok() {
+            tokio::task::block_in_place(body)
+        } else {
+            body()
+        }
+    }
+
     /// Format-check the resolved Postgres URL. Precedence:
     /// `LEANKG_PG_URL` env > `db:` block in `leankg.yaml` > built-in dev
     /// default (`postgresql://postgres:postgres@localhost:5433/leankg`,
@@ -1322,6 +1587,49 @@ impl PostgresBackend {
 impl DbBackend for PostgresBackend {
     fn is_read_only(&self) -> bool {
         self.read_only
+    }
+
+    // ---- SQL-first API (W8 P0) ----
+
+    fn sql_query(
+        &self,
+        sql: &str,
+        params: &[crate::db::sql::SqlParam],
+    ) -> Result<Vec<crate::db::sql::SqlRow>, Box<dyn std::error::Error>> {
+        self.sql_off_runtime(|| self.sql_query_sync(sql, params))
+    }
+
+    fn sql_query_gucs(
+        &self,
+        sql: &str,
+        params: &[crate::db::sql::SqlParam],
+        gucs: &[(&str, &str)],
+    ) -> Result<Vec<crate::db::sql::SqlRow>, Box<dyn std::error::Error>> {
+        self.sql_off_runtime(|| self.sql_query_gucs_sync(sql, params, gucs))
+    }
+
+    fn sql_execute(
+        &self,
+        sql: &str,
+        params: &[crate::db::sql::SqlParam],
+    ) -> Result<u64, Box<dyn std::error::Error>> {
+        self.sql_off_runtime(|| self.sql_execute_sync(sql, params))
+    }
+
+    fn sql_execute_batch(
+        &self,
+        stmts: &[(&str, Vec<crate::db::sql::SqlParam>)],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.sql_off_runtime(|| self.sql_execute_batch_sync(stmts))
+    }
+
+    fn sql_copy_import(
+        &self,
+        table: &str,
+        columns: &[&str],
+        rows: &[Vec<crate::db::sql::SqlParam>],
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.sql_off_runtime(|| self.sql_copy_import_sync(table, columns, rows))
     }
 
     /// FR-ENT-1: one multi-row INSERT for the whole batch (≤ 50 rows × 9
@@ -2277,6 +2585,32 @@ fn create_scratch_schema() -> Result<String, Box<dyn std::error::Error>> {
     // Keep the admin connection alive so the schema is dropped on exit.
     std::mem::forget(client);
     Ok(name)
+}
+
+/// Test-only: a migrated scratch-schema [`PostgresBackend`] for the
+/// SQL-first seam tests (W8 P0). Process-stable per key path, same mapping
+/// contract as [`test_scratch_schema`].
+#[cfg(test)]
+pub(crate) fn test_sql_scratch_backend() -> std::sync::Arc<PostgresBackend> {
+    let schema = test_scratch_schema(std::path::Path::new("/tmp/leankg-w8-sql-seam"))
+        .expect("scratch schema for SQL seam tests");
+    let pg = PostgresBackend::from_env()
+        .expect("pg url")
+        .with_schema(&schema);
+    std::sync::Arc::new(pg)
+}
+
+/// Test-only read-only variant ([`test_sql_scratch_backend`]): every
+/// statement goes through the RO pool (`default_transaction_read_only = on`),
+/// so writes fail at the Postgres layer.
+#[cfg(test)]
+pub(crate) fn test_sql_scratch_backend_ro() -> std::sync::Arc<PostgresBackend> {
+    let schema = test_scratch_schema(std::path::Path::new("/tmp/leankg-w8-sql-seam"))
+        .expect("scratch schema for SQL seam tests");
+    let pg = PostgresBackend::from_env_read_only()
+        .expect("pg url")
+        .with_schema(&schema);
+    std::sync::Arc::new(pg)
 }
 
 /// Open a read-only backend (T6.1): `default_transaction_read_only = on` —

--- a/src/db/keys.rs
+++ b/src/db/keys.rs
@@ -5,7 +5,6 @@ use argon2::{
     Argon2,
 };
 use serde::{Deserialize, Serialize};
-use std::collections::BTreeMap;
 use uuid::Uuid;
 
 pub type KeysDb = crate::db::backend::SharedDb;
@@ -20,11 +19,22 @@ pub struct ApiKey {
     pub revoked_at: Option<String>,
 }
 
-pub struct ApiKeyStore;
+pub struct ApiKeyStore {
+    /// Optional injected backend (tests pin a scratch-schema PG backend so
+    /// the shared `public` layout is never touched). `None` = open a fresh
+    /// `init_db_pg()` per operation, exactly as before W8.
+    db: Option<KeysDb>,
+}
 
 impl ApiKeyStore {
     pub fn new() -> Result<Self, Box<dyn std::error::Error>> {
-        Ok(Self)
+        Ok(Self { db: None })
+    }
+
+    /// Inject a shared backend (W8 wave-1 test seam; production callers keep
+    /// using [`Self::new`]).
+    pub fn with_db(db: KeysDb) -> Self {
+        Self { db: Some(db) }
     }
 
     pub fn init_db(&self) -> Result<KeysDb, Box<dyn std::error::Error>> {
@@ -34,34 +44,22 @@ impl ApiKeyStore {
         crate::db::backend::init_db_pg()
     }
 
+    /// The backend for one store operation: injected handle when present,
+    /// else a fresh per-call `init_db_pg()` (legacy behavior).
+    fn db(&self) -> Result<KeysDb, Box<dyn std::error::Error>> {
+        match &self.db {
+            Some(db) => Ok(db.clone()),
+            None => self.init_db(),
+        }
+    }
+
     pub fn create_key(&self, name: &str) -> Result<(String, ApiKey), Box<dyn std::error::Error>> {
-        let db = self.init_db()?;
+        let db = self.db()?;
 
         let key = generate_api_key();
         let key_id = Uuid::new_v4().to_string();
         let key_hash = hash_api_key(&key)?;
         let created_at = chrono_timestamp();
-
-        let mut params = BTreeMap::new();
-        params.insert("id".to_string(), serde_json::json!(key_id));
-        params.insert("name".to_string(), serde_json::json!(name));
-        params.insert("key_hash".to_string(), serde_json::json!(key_hash));
-        params.insert("created_at".to_string(), serde_json::json!(created_at));
-        params.insert(
-            "last_used_at".to_string(),
-            serde_json::json!(serde_json::Value::Null),
-        );
-        params.insert(
-            "revoked_at".to_string(),
-            serde_json::json!(serde_json::Value::Null),
-        );
-
-        let insert = r#"
-        ?[id, name, key_hash, created_at, last_used_at, revoked_at] <- [[$id, $name, $key_hash, $created_at, $last_used_at, $revoked_at]]
-        :put api_keys { id, name, key_hash, created_at, last_used_at, revoked_at }
-        "#;
-
-        db.run_script(insert, params)?;
 
         let api_key = ApiKey {
             id: key_id,
@@ -71,27 +69,23 @@ impl ApiKeyStore {
             last_used_at: None,
             revoked_at: None,
         };
+        db.insert_api_key(&api_key)?;
 
         Ok((key, api_key))
     }
 
     pub fn list_keys(&self) -> Result<Vec<ApiKey>, Box<dyn std::error::Error>> {
-        let db = self.init_db()?;
+        let db = self.db()?;
 
-        let query = r#"
-        ?[id, name, key_hash, created_at, last_used_at, revoked_at] := *api_keys[id, name, key_hash, created_at, last_used_at, revoked_at]
-        "#;
-
-        let result = db.run_script(query, BTreeMap::new())?;
+        let result = db.list_api_keys()?;
 
         let mut keys: std::collections::HashMap<String, ApiKey> = std::collections::HashMap::new();
-        for row in result.rows {
-            let id = row[0].get_str().unwrap_or("").to_string();
-            let name = row[1].get_str().unwrap_or("").to_string();
-            let key_hash = String::new();
-            let created_at = row[3].get_str().unwrap_or("").to_string();
-            let last_used_at = row[4].get_str().map(String::from);
-            let revoked_at: Option<String> = row[5].get_str().map(String::from);
+        for row in result {
+            let id = row.id;
+            let name = row.name;
+            let created_at = row.created_at;
+            let last_used_at = row.last_used_at;
+            let revoked_at: Option<String> = row.revoked_at;
 
             if revoked_at.is_some() {
                 keys.remove(&id);
@@ -104,7 +98,9 @@ impl ApiKeyStore {
                     ApiKey {
                         id,
                         name,
-                        key_hash,
+                        // Never surface the argon2 hash through listings —
+                        // same display contract as the legacy path.
+                        key_hash: String::new(),
                         created_at,
                         last_used_at,
                         revoked_at,
@@ -117,98 +113,20 @@ impl ApiKeyStore {
     }
 
     pub fn revoke_key(&self, id: &str) -> Result<bool, Box<dyn std::error::Error>> {
-        let db = self.init_db()?;
-
-        let query = r#"
-        ?[id, name, key_hash, created_at, last_used_at, revoked_at] := *api_keys[id, name, key_hash, created_at, last_used_at, revoked_at], id = $id
-        "#;
-
-        let mut params = BTreeMap::new();
-        params.insert("id".to_string(), serde_json::json!(id));
-
-        let result = db.run_script(query, params)?;
-
-        if result.rows.is_empty() {
-            return Ok(false);
-        }
-
-        let row = &result.rows[0];
-
-        let revoked_at_val = row[5].get_str();
-        if revoked_at_val.is_some() {
-            return Ok(false);
-        }
-
-        let revoked_at = chrono_timestamp();
-
-        let update = r#"
-        ?[id, name, key_hash, created_at, last_used_at, revoked_at] <- [[$id, $name, $key_hash, $created_at, $last_used_at, $revoked_at]]
-        :put api_keys { id, name, key_hash, created_at, last_used_at, revoked_at }
-        "#;
-
-        let mut params = BTreeMap::new();
-        params.insert(
-            "id".to_string(),
-            serde_json::json!(row[0].get_str().unwrap_or("")),
-        );
-        params.insert(
-            "name".to_string(),
-            serde_json::json!(row[1].get_str().unwrap_or("")),
-        );
-        params.insert(
-            "key_hash".to_string(),
-            serde_json::json!(row[2].get_str().unwrap_or("")),
-        );
-        params.insert(
-            "created_at".to_string(),
-            serde_json::json!(row[3].get_str().unwrap_or("")),
-        );
-        params.insert(
-            "last_used_at".to_string(),
-            serde_json::json!(row[4].get_str().map(String::from)),
-        );
-        params.insert("revoked_at".to_string(), serde_json::json!(revoked_at));
-
-        db.run_script(update, params)?;
-
-        Ok(true)
+        let db = self.db()?;
+        db.mark_api_key_revoked(id, &chrono_timestamp())
     }
 
     pub fn validate_key(&self, key: &str) -> Result<Option<String>, Box<dyn std::error::Error>> {
-        let db = self.init_db()?;
+        let db = self.db()?;
 
-        let query = r#"
-        ?[id, key_hash] := *api_keys[id, key_hash], revoked_at = null
-        "#;
-
-        let result = db.run_script(query, BTreeMap::new())?;
-
-        for row in result.rows {
-            let key_id = row[0].get_str().unwrap_or("").to_string();
-            let stored_hash = row[1].get_str().unwrap_or("");
-            if verify_api_key(key, stored_hash) {
-                let last_used = chrono_timestamp();
-
-                let delete = format!(r#":delete api_keys where id = "{}""#, key_id);
-                let _ = db.run_script(&delete, BTreeMap::new());
-
-                let insert = r#"
-                ?[id, name, key_hash, created_at, last_used_at, revoked_at] <- [[$id, $name, $key_hash, $created_at, $last_used_at, $revoked_at]]
-                :put api_keys { id, name, key_hash, created_at, last_used_at, revoked_at }
-                "#;
-
-                let mut params = BTreeMap::new();
-                params.insert("id".to_string(), serde_json::json!(key_id.clone()));
-                params.insert("name".to_string(), serde_json::json!(""));
-                params.insert("key_hash".to_string(), serde_json::json!(stored_hash));
-                params.insert("created_at".to_string(), serde_json::json!(""));
-                params.insert("last_used_at".to_string(), serde_json::json!(last_used));
-                params.insert(
-                    "revoked_at".to_string(),
-                    serde_json::json!(serde_json::Value::Null),
-                );
-                let _ = db.run_script(insert, params);
-
+        for (key_id, stored_hash) in db.list_active_api_key_hashes()? {
+            if verify_api_key(key, &stored_hash) {
+                // W8 deviation (documented in plan §6): the legacy Datalog
+                // flow DELETEd + re-inserted the row with name="" and
+                // created_at="" here, wiping the key's identity on every
+                // validation. The SQL-first path updates only last_used_at.
+                let _ = db.touch_api_key_last_used(&key_id, &chrono_timestamp());
                 return Ok(Some(key_id));
             }
         }
@@ -249,6 +167,31 @@ fn chrono_timestamp() -> String {
         .duration_since(UNIX_EPOCH)
         .unwrap_or_default();
     format!("{}", duration.as_secs())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_then_verify_roundtrips() {
+        let key = generate_api_key();
+        let hash = hash_api_key(&key).expect("hash");
+        assert!(verify_api_key(&key, &hash), "correct key verifies");
+        assert!(!verify_api_key("wrong", &hash), "wrong key rejected");
+    }
+
+    #[test]
+    fn verify_rejects_malformed_hash() {
+        assert!(!verify_api_key("k", "not-a-argon2-hash"));
+    }
+
+    #[test]
+    fn generated_keys_have_lkkg_prefix() {
+        let k = generate_api_key();
+        assert!(k.starts_with("lkkg_"), "{k}");
+        assert!(k.len() > 20);
+    }
 }
 
 impl Default for ApiKeyStore {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -4,6 +4,7 @@ pub mod keys;
 pub mod models;
 pub mod pg;
 pub mod schema;
+pub mod sql;
 pub mod value;
 pub mod versioning;
 pub mod write_bus;
@@ -17,6 +18,8 @@ pub use backend::{init_db, init_db_pg, init_db_readonly, PostgresBackend, Shared
 pub use models::*;
 #[allow(unused_imports)]
 pub use schema::*;
+#[allow(unused_imports)]
+pub use sql::SqlParam;
 
 pub fn create_business_logic(
     db: &dyn crate::db::backend::DbBackend,

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -177,10 +177,14 @@ impl SqlRow {
         key.lookup(self)
     }
 
+    /// String view of a cell. SQL NULL (and the legacy bottom type) map to
+    /// `None` — same contract as `NamedRows::get_str` on the Datalog path,
+    /// which callers like `keys.rs` rely on to detect optional columns.
     pub fn text(&self, key: impl RowKey) -> Option<String> {
         match self.get(key) {
             Some(DataValue::Str(s)) => Some(s.clone()),
             Some(DataValue::Json(j)) => Some(j.clone()),
+            Some(DataValue::Null) | Some(DataValue::Bot) => None,
             Some(other) => Some(other.to_string()),
             None => None,
         }
@@ -394,15 +398,22 @@ mod tests {
     #[test]
     fn sql_row_accessors_by_name_and_index() {
         let row = SqlRow::new(
-            vec!["name".into(), "count".into()],
+            vec!["name".into(), "count".into(), "opt".into()],
             vec![
                 DataValue::Str("main.rs".into()),
                 DataValue::Num(Num::Int(7)),
+                DataValue::Null,
             ],
         );
         assert_eq!(row.text("name"), Some("main.rs".into()));
         assert_eq!(row.int(1), Some(7));
         assert_eq!(row.int("missing"), None);
+        // NULL cells read as None through every typed accessor — parity
+        // with the legacy `get_str` contract (regression guard: the WIP
+        // seam rendered NULL text as Some("null"), which broke keys.rs).
+        assert_eq!(row.text("opt"), None);
+        assert_eq!(row.text("missing"), None);
+        assert_eq!(row.int("opt"), None);
     }
 
     #[test]

--- a/src/db/sql.rs
+++ b/src/db/sql.rs
@@ -1,0 +1,655 @@
+//! SQL-first query seam (W8 P0 — plan `docs/plan-remove-cozo-datalog-sql-migration.md`).
+//!
+//! The Datalog dialect is being removed wave-by-wave: every query becomes
+//! plain, parameterized PostgreSQL issued through [`crate::db::backend::DbBackend`]
+//! methods (`sql_query`, `sql_query_gucs`, `sql_execute`, `sql_execute_batch`,
+//! `sql_copy_import`). This module holds the bind/result types shared by all
+//! call sites plus the pg -> cell mapping used to build results.
+//!
+//! Binding rules:
+//! - [`SqlParam::Vector`] binds as the pgvector text literal `[0.1,0.2]`;
+//!   cast at the use site (`$3::text::vector`, matching the translator convention).
+//! - NULL binds as [`SqlParam::Null`] (distinct from every other variant).
+//!
+//! Reading rules ([`row_from_pg`]): column-type-driven mapping into
+//! [`DataValue`] cells; unknown/custom types (e.g. pgvector's `vector`)
+//! fall back to their text form, vectors parsed into floats by
+//! [`parse_vector_text`].
+
+use crate::db::value::{DataValue, Num};
+use postgres::types::ToSql;
+use std::error::Error;
+
+/// A bind parameter for the SQL-first API.
+#[derive(Debug, Clone, PartialEq)]
+pub enum SqlParam {
+    Null,
+    Bool(bool),
+    Int(i64),
+    Float(f64),
+    Text(String),
+    Bytes(Vec<u8>),
+    Json(serde_json::Value),
+    /// Bound as the pgvector literal `[a,b,...]`; cast `$n::text::vector` in SQL.
+    Vector(Vec<f32>),
+}
+
+impl SqlParam {
+    /// Bind as a boxed `ToSql`. Vectors become their pgvector text form.
+    pub fn to_pg(&self) -> Box<dyn ToSql + Sync + Send> {
+        match self {
+            SqlParam::Null => Box::new(Option::<String>::None),
+            SqlParam::Bool(b) => Box::new(*b),
+            SqlParam::Int(i) => Box::new(*i),
+            SqlParam::Float(f) => Box::new(*f),
+            SqlParam::Text(s) => Box::new(s.clone()),
+            SqlParam::Bytes(b) => Box::new(b.clone()),
+            // serde_json::Value implements ToSql for json/jsonb directly
+            // (postgres `with-serde_json-1`); a String would be rejected
+            // with WrongType when the SQL casts `$n::jsonb`.
+            SqlParam::Json(j) => Box::new(j.clone()),
+            SqlParam::Vector(items) => Box::new(pgvector_literal(items)),
+        }
+    }
+
+    /// Render for the COPY text format ([`crate::db::backend`] bulk path):
+    /// NULL is the `\N` marker; metacharacters are escaped by the writer.
+    pub(crate) fn to_copy_text(&self) -> String {
+        match self {
+            SqlParam::Null => "\\N".to_string(),
+            SqlParam::Bool(b) => b.to_string(),
+            SqlParam::Int(i) => i.to_string(),
+            SqlParam::Float(f) => f.to_string(),
+            SqlParam::Text(s) => s.clone(),
+            SqlParam::Bytes(b) => {
+                let mut s = String::with_capacity(b.len() * 4);
+                for byte in b {
+                    s.push_str(&format!("\\{:03o}", byte));
+                }
+                s
+            }
+            SqlParam::Json(j) => j.to_string(),
+            SqlParam::Vector(items) => pgvector_literal(items),
+        }
+    }
+}
+
+/// pgvector text literal: `[0.1,0.2,...]`.
+pub fn pgvector_literal(items: &[f32]) -> String {
+    let mut s = String::from("[");
+    for (i, f) in items.iter().enumerate() {
+        if i > 0 {
+            s.push(',');
+        }
+        s.push_str(&format!("{f}"));
+    }
+    s.push(']');
+    s
+}
+
+macro_rules! param_from {
+    ($ty:ty, $variant:expr) => {
+        impl From<$ty> for SqlParam {
+            fn from(v: $ty) -> Self {
+                $variant(v)
+            }
+        }
+    };
+}
+param_from!(bool, SqlParam::Bool);
+param_from!(i64, SqlParam::Int);
+param_from!(f64, SqlParam::Float);
+param_from!(String, SqlParam::Text);
+param_from!(Vec<u8>, SqlParam::Bytes);
+param_from!(Vec<f32>, SqlParam::Vector);
+param_from!(serde_json::Value, SqlParam::Json);
+impl From<&str> for SqlParam {
+    fn from(v: &str) -> Self {
+        SqlParam::Text(v.to_string())
+    }
+}
+impl From<i32> for SqlParam {
+    fn from(v: i32) -> Self {
+        SqlParam::Int(v as i64)
+    }
+}
+impl From<Option<String>> for SqlParam {
+    fn from(v: Option<String>) -> Self {
+        match v {
+            Some(s) => SqlParam::Text(s),
+            None => SqlParam::Null,
+        }
+    }
+}
+impl From<DataValue> for SqlParam {
+    /// Transition shim while call sites still hold `DataValue` rows
+    /// (e.g. bulk imports). Vector-shaped lists need the column name hint
+    /// via [`data_value_to_param`]; this default maps lists to JSON.
+    fn from(v: DataValue) -> Self {
+        data_value_to_param(&v, "")
+    }
+}
+
+/// Convert a legacy `DataValue` cell to a bind parameter. `col` disambiguates
+/// vector columns (`vec` / `vector`), mirroring the historical convention.
+pub fn data_value_to_param(v: &DataValue, col: &str) -> SqlParam {
+    match v {
+        DataValue::Null | DataValue::Bot => SqlParam::Null,
+        DataValue::Bool(b) => SqlParam::Bool(*b),
+        DataValue::Num(Num::Int(i)) => SqlParam::Int(*i),
+        DataValue::Num(Num::Float(f)) => SqlParam::Float(*f),
+        DataValue::Str(s) => SqlParam::Text(s.clone()),
+        DataValue::Bytes(b) => SqlParam::Bytes(b.clone()),
+        DataValue::List(items) if col == "vec" || col == "vector" => SqlParam::Vector(
+            items
+                .iter()
+                .filter_map(|it| match it {
+                    DataValue::Num(Num::Float(f)) => Some(*f as f32),
+                    DataValue::Num(Num::Int(i)) => Some(*i as f32),
+                    _ => None,
+                })
+                .collect(),
+        ),
+        DataValue::List(items) => {
+            SqlParam::Json(serde_json::to_value(items).unwrap_or(serde_json::Value::Null))
+        }
+        DataValue::Json(j) => SqlParam::Json(
+            serde_json::from_str::<serde_json::Value>(j)
+                .unwrap_or(serde_json::Value::String(j.clone())),
+        ),
+    }
+}
+
+/// One result row: named headers plus positionally-aligned cells.
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct SqlRow {
+    pub headers: Vec<String>,
+    pub cells: Vec<DataValue>,
+}
+
+impl SqlRow {
+    pub fn new(headers: Vec<String>, cells: Vec<DataValue>) -> Self {
+        Self { headers, cells }
+    }
+
+    /// Cell by column name or ordinal.
+    pub fn get(&self, key: impl RowKey) -> Option<&DataValue> {
+        key.lookup(self)
+    }
+
+    pub fn text(&self, key: impl RowKey) -> Option<String> {
+        match self.get(key) {
+            Some(DataValue::Str(s)) => Some(s.clone()),
+            Some(DataValue::Json(j)) => Some(j.clone()),
+            Some(other) => Some(other.to_string()),
+            None => None,
+        }
+    }
+
+    pub fn int(&self, key: impl RowKey) -> Option<i64> {
+        match self.get(key) {
+            Some(DataValue::Num(Num::Int(i))) => Some(*i),
+            Some(DataValue::Num(Num::Float(f))) => Some(*f as i64),
+            _ => None,
+        }
+    }
+
+    pub fn float(&self, key: impl RowKey) -> Option<f64> {
+        match self.get(key) {
+            Some(DataValue::Num(Num::Float(f))) => Some(*f),
+            Some(DataValue::Num(Num::Int(i))) => Some(*i as f64),
+            _ => None,
+        }
+    }
+
+    pub fn boolean(&self, key: impl RowKey) -> Option<bool> {
+        match self.get(key) {
+            Some(DataValue::Bool(b)) => Some(*b),
+            _ => None,
+        }
+    }
+
+    pub fn vec_f32(&self, key: impl RowKey) -> Option<Vec<f32>> {
+        match self.get(key) {
+            Some(DataValue::List(items)) => Some(
+                items
+                    .iter()
+                    .filter_map(|it| match it {
+                        DataValue::Num(Num::Float(f)) => Some(*f as f32),
+                        DataValue::Num(Num::Int(i)) => Some(*i as f32),
+                        _ => None,
+                    })
+                    .collect(),
+            ),
+            Some(DataValue::Str(s)) => parse_vector_text(s),
+            _ => None,
+        }
+    }
+}
+
+/// Index a row by column name (`&str`) or ordinal (`usize`).
+pub trait RowKey {
+    fn lookup(self, row: &SqlRow) -> Option<&DataValue>;
+}
+impl RowKey for usize {
+    fn lookup(self, row: &SqlRow) -> Option<&DataValue> {
+        row.cells.get(self)
+    }
+}
+impl RowKey for &str {
+    fn lookup(self, row: &SqlRow) -> Option<&DataValue> {
+        row.headers
+            .iter()
+            .position(|h| h == self)
+            .and_then(|i| row.cells.get(i))
+    }
+}
+
+/// Map a borrowed pg row into an owned [`SqlRow`].
+pub fn row_from_pg(row: &postgres::Row) -> SqlRow {
+    let cols = row.columns();
+    let mut headers = Vec::with_capacity(cols.len());
+    let mut cells = Vec::with_capacity(cols.len());
+    for (i, col) in cols.iter().enumerate() {
+        headers.push(col.name().to_string());
+        cells.push(cell_from_pg(row, i));
+    }
+    SqlRow::new(headers, cells)
+}
+
+fn str_cell(v: Option<String>) -> DataValue {
+    match v {
+        Some(s) => DataValue::Str(s),
+        None => DataValue::Null,
+    }
+}
+
+// Per-type extraction. Each read goes through Option so SQL NULL maps to
+// DataValue::Null instead of erroring.
+fn cell_from_pg(row: &postgres::Row, i: usize) -> DataValue {
+    let ty = row.columns()[i].type_();
+    match ty.name() {
+        "bool" => str_opt_bool(row, i),
+        "int2" => int_cell(
+            row.try_get::<_, Option<i16>>(i)
+                .ok()
+                .flatten()
+                .map(i64::from),
+        ),
+        "int4" => int_cell(
+            row.try_get::<_, Option<i32>>(i)
+                .ok()
+                .flatten()
+                .map(i64::from),
+        ),
+        "int8" => int_cell(row.try_get::<_, Option<i64>>(i).ok().flatten()),
+        "float4" => float_cell(
+            row.try_get::<_, Option<f32>>(i)
+                .ok()
+                .flatten()
+                .map(f64::from),
+        ),
+        "float8" => float_cell(row.try_get::<_, Option<f64>>(i).ok().flatten()),
+        "bytea" => match row.try_get::<_, Option<Vec<u8>>>(i) {
+            Ok(Some(b)) => DataValue::Bytes(b),
+            _ => DataValue::Null,
+        },
+        "json" | "jsonb" => match row.try_get::<_, Option<serde_json::Value>>(i) {
+            Ok(Some(v)) => DataValue::Json(v.to_string()),
+            _ => DataValue::Null,
+        },
+        "uuid" | "void" => str_cell(row.try_get::<_, Option<String>>(i).ok().flatten()),
+        "_text" | "_varchar" | "_name" => match row.try_get::<_, Option<Vec<String>>>(i) {
+            Ok(Some(vs)) => DataValue::List(vs.into_iter().map(DataValue::Str).collect()),
+            _ => DataValue::Null,
+        },
+        "vector" => str_cell(row.try_get::<_, Option<String>>(i).ok().flatten()),
+        // text/varchar/name/citext and anything unhandled: string form.
+        _ => str_cell(row.try_get::<_, Option<String>>(i).ok().flatten()),
+    }
+}
+
+fn str_opt_bool(row: &postgres::Row, i: usize) -> DataValue {
+    match row.try_get::<_, Option<bool>>(i) {
+        Ok(Some(b)) => DataValue::Bool(b),
+        _ => DataValue::Null,
+    }
+}
+
+fn int_cell(v: Option<i64>) -> DataValue {
+    match v {
+        Some(i) => DataValue::Num(Num::Int(i)),
+        None => DataValue::Null,
+    }
+}
+
+fn float_cell(v: Option<f64>) -> DataValue {
+    match v {
+        Some(f) => DataValue::Num(Num::Float(f)),
+        None => DataValue::Null,
+    }
+}
+
+/// Parse pgvector text (`[0.1, 0.2]`) into floats.
+pub fn parse_vector_text(s: &str) -> Option<Vec<f32>> {
+    let inner = s.trim().trim_start_matches('[').trim_end_matches(']');
+    if inner.trim().is_empty() {
+        return Some(vec![]);
+    }
+    inner
+        .split(',')
+        .map(|p| p.trim().parse::<f32>().map_err(|_| ()))
+        .collect::<Result<Vec<_>, _>>()
+        .ok()
+}
+
+/// Error returned when a backend does not implement the SQL-first API.
+pub fn unsupported() -> Box<dyn Error> {
+    Box::new(std::io::Error::other(
+        "SQL-first API not implemented for this backend (live PostgreSQL required)",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::db::backend::DbBackend;
+    use crate::db::value::Num;
+
+    // ---- pure unit tests (no DB) ----
+
+    #[test]
+    fn pgvector_literal_formats_floats() {
+        assert_eq!(pgvector_literal(&[0.1, 0.25]), "[0.1,0.25]");
+        assert_eq!(pgvector_literal(&[]), "[]");
+    }
+
+    #[test]
+    fn parses_vector_text_with_spaces() {
+        assert_eq!(
+            parse_vector_text("[0.5, -1.0, 2]"),
+            Some(vec![0.5, -1.0, 2.0])
+        );
+        assert_eq!(parse_vector_text("[]"), Some(vec![]));
+        assert_eq!(parse_vector_text("not a vec"), None);
+    }
+
+    #[test]
+    fn data_value_param_maps_vector_columns() {
+        let dv = DataValue::List(vec![
+            DataValue::Num(Num::Float(1.0)),
+            DataValue::Num(Num::Float(2.0)),
+        ]);
+        assert_eq!(
+            data_value_to_param(&dv, "vec"),
+            SqlParam::Vector(vec![1.0, 2.0])
+        );
+        let dv = DataValue::List(vec![DataValue::Str("x".into())]);
+        assert!(matches!(
+            data_value_to_param(&dv, "tags"),
+            SqlParam::Json(_)
+        ));
+    }
+
+    #[test]
+    fn sql_row_accessors_by_name_and_index() {
+        let row = SqlRow::new(
+            vec!["name".into(), "count".into()],
+            vec![
+                DataValue::Str("main.rs".into()),
+                DataValue::Num(Num::Int(7)),
+            ],
+        );
+        assert_eq!(row.text("name"), Some("main.rs".into()));
+        assert_eq!(row.int(1), Some(7));
+        assert_eq!(row.int("missing"), None);
+    }
+
+    #[test]
+    fn params_convert_from_common_scalars() {
+        assert_eq!(SqlParam::from("x"), SqlParam::Text("x".into()));
+        assert_eq!(SqlParam::from(7_i32), SqlParam::Int(7));
+        assert_eq!(
+            SqlParam::from(None::<String>),
+            SqlParam::Null,
+            "Option None binds NULL"
+        );
+        assert_eq!(
+            SqlParam::from(Some("v".to_string())),
+            SqlParam::Text("v".into())
+        );
+    }
+
+    #[test]
+    fn copy_text_renders_null_marker_and_escapes_bytes() {
+        assert_eq!(SqlParam::Null.to_copy_text(), "\\N");
+        assert_eq!(SqlParam::Bytes(vec![0o011]).to_copy_text(), "\\011");
+        assert_eq!(SqlParam::Vector(vec![1.0]).to_copy_text(), "[1]");
+        assert_eq!(
+            SqlParam::Json(serde_json::json!({"a":1})).to_copy_text(),
+            "{\"a\":1}"
+        );
+    }
+
+    // ---- live-PG integration (probe-gated: skip when PG is unreachable) ----
+
+    fn live_backend() -> Option<std::sync::Arc<crate::db::backend::PostgresBackend>> {
+        if !crate::db::backend::test_pg_available() {
+            return None;
+        }
+        Some(crate::db::backend::test_sql_scratch_backend())
+    }
+
+    #[test]
+    fn query_maps_pg_types_to_cells() {
+        let Some(db) = live_backend() else { return };
+        let rows = db
+            .sql_query(
+                "SELECT 'main' AS name, 42::int AS n, 3.5::float8 AS x, true AS ok, \
+                 NULL::text AS missing, '{\"a\":1}'::jsonb AS meta",
+                &[],
+            )
+            .expect("query");
+        assert_eq!(rows.len(), 1);
+        let r = &rows[0];
+        assert_eq!(r.text("name"), Some("main".into()));
+        assert_eq!(r.int("n"), Some(42));
+        assert_eq!(r.float("x"), Some(3.5));
+        assert_eq!(r.boolean("ok"), Some(true));
+        assert_eq!(r.get("missing"), Some(&DataValue::Null));
+        let meta = r.text("meta").expect("jsonb text");
+        assert!(meta.contains("\"a\""), "jsonb raw: {meta}");
+    }
+
+    #[test]
+    fn params_roundtrip_through_table() {
+        let Some(db) = live_backend() else { return };
+        db.sql_execute_batch(&[
+            ("DROP TABLE IF EXISTS leankg_sql_seam_t", vec![]),
+            (
+                "CREATE TABLE leankg_sql_seam_t (id bigserial primary key, name text, score float8, flags jsonb, embedding vector(3))",
+                vec![],
+            ),
+        ])
+        .expect("create");
+        let n = db
+            .sql_execute(
+                "INSERT INTO leankg_sql_seam_t (name, score, flags, embedding) \
+                 VALUES ($1, $2, $3::jsonb, $4::text::vector)",
+                &[
+                    SqlParam::Text("a.rs".into()),
+                    SqlParam::Float(1.5),
+                    SqlParam::Json(serde_json::json!({"k": 1})),
+                    SqlParam::Vector(vec![0.1, 0.2, 0.3]),
+                ],
+            )
+            .expect("insert");
+        assert_eq!(n, 1);
+        let rows = db
+            .sql_query(
+                "SELECT name, score FROM leankg_sql_seam_t WHERE name = $1 AND score = $2",
+                &[SqlParam::Text("a.rs".into()), SqlParam::Float(1.5)],
+            )
+            .expect("select");
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].text("name"), Some("a.rs".into()));
+        assert_eq!(rows[0].float("score"), Some(1.5));
+    }
+
+    #[test]
+    fn execute_reports_affected_rows() {
+        let Some(db) = live_backend() else { return };
+        db.sql_execute_batch(&[
+            ("DROP TABLE IF EXISTS leankg_sql_seam_u", vec![]),
+            (
+                "CREATE TABLE leankg_sql_seam_u (id bigserial primary key, grp bigint)",
+                vec![],
+            ),
+            (
+                "INSERT INTO leankg_sql_seam_u (grp) SELECT generate_series(1, 5)",
+                vec![],
+            ),
+        ])
+        .expect("setup");
+        let n = db
+            .sql_execute(
+                "UPDATE leankg_sql_seam_u SET grp = grp + 10 WHERE grp <= $1",
+                &[SqlParam::Int(3)],
+            )
+            .expect("update");
+        assert_eq!(n, 3);
+    }
+
+    #[test]
+    fn batch_is_atomic_on_failure() {
+        let Some(db) = live_backend() else { return };
+        db.sql_execute_batch(&[
+            ("DROP TABLE IF EXISTS leankg_sql_seam_b", vec![]),
+            ("CREATE TABLE leankg_sql_seam_b (id int)", vec![]),
+        ])
+        .expect("setup");
+        let err = db
+            .sql_execute_batch(&[
+                ("INSERT INTO leankg_sql_seam_b VALUES (1)", vec![]),
+                ("INSERT INTO leankg_sql_seam_missing VALUES (2)", vec![]),
+            ])
+            .expect_err("second statement must fail");
+        let _ = err;
+        let rows = db
+            .sql_query("SELECT count(*)::bigint AS c FROM leankg_sql_seam_b", &[])
+            .expect("count");
+        // First insert rolled back with the failed transaction.
+        assert_eq!(rows[0].int("c"), Some(0), "batch must be atomic");
+    }
+
+    #[test]
+    fn gucs_apply_within_the_read_transaction() {
+        let Some(db) = live_backend() else { return };
+        let rows = db
+            .sql_query_gucs(
+                "SELECT current_setting('hnsw.ef_search') AS ef",
+                &[],
+                &[("hnsw.ef_search", "77")],
+            )
+            .expect("guc query");
+        assert_eq!(rows[0].text("ef"), Some("77".into()));
+    }
+
+    #[test]
+    fn copy_import_bulk_loads() {
+        let Some(db) = live_backend() else { return };
+        db.sql_execute_batch(&[
+            ("DROP TABLE IF EXISTS leankg_sql_seam_c", vec![]),
+            (
+                "CREATE TABLE leankg_sql_seam_c (qualified_name text, line_start bigint)",
+                vec![],
+            ),
+        ])
+        .expect("setup");
+        let rows: Vec<Vec<SqlParam>> = (0..500)
+            .map(|i| {
+                vec![
+                    SqlParam::Text(format!("src/f{i}.rs::f{i}")),
+                    SqlParam::Int(i),
+                ]
+            })
+            .collect();
+        db.sql_copy_import(
+            "leankg_sql_seam_c",
+            &["qualified_name", "line_start"],
+            &rows,
+        )
+        .expect("copy");
+        let got = db
+            .sql_query("SELECT count(*)::bigint AS c FROM leankg_sql_seam_c", &[])
+            .expect("count");
+        assert_eq!(got[0].int("c"), Some(500));
+    }
+
+    #[test]
+    fn copy_import_preserves_nulls_and_empty_strings() {
+        let Some(db) = live_backend() else { return };
+        db.sql_execute_batch(&[
+            ("DROP TABLE IF EXISTS leankg_sql_seam_n", vec![]),
+            ("CREATE TABLE leankg_sql_seam_n (a text, b text)", vec![]),
+        ])
+        .expect("setup");
+        db.sql_copy_import(
+            "leankg_sql_seam_n",
+            &["a", "b"],
+            &[
+                vec![SqlParam::Null, SqlParam::Text(String::new())],
+                vec![SqlParam::Text("x".into()), SqlParam::Null],
+            ],
+        )
+        .expect("copy");
+        let got = db
+            .sql_query(
+                "SELECT a, b FROM leankg_sql_seam_n ORDER BY b NULLS LAST, a NULLS FIRST",
+                &[],
+            )
+            .expect("read");
+        assert_eq!(got.len(), 2);
+        // Row ('x', NULL): a is text, b is SQL NULL.
+        let with_null = got
+            .iter()
+            .find(|r| r.text("a") == Some("x".into()))
+            .expect("x row");
+        assert_eq!(with_null.get("b"), Some(&DataValue::Null), "\\N is NULL");
+        // Row (NULL, ''): empty string survives, NOT collapsed to NULL.
+        let empty = got
+            .iter()
+            .find(|r| r.get("a") == Some(&DataValue::Null))
+            .expect("null-a row");
+        assert_eq!(empty.text("b"), Some(String::new()), "'' is not NULL");
+    }
+
+    #[test]
+    fn read_only_backend_rejects_writes_at_pg_layer() {
+        let Some(_db) = live_backend() else { return };
+        let ro = crate::db::backend::test_sql_scratch_backend_ro();
+        let err = ro
+            .sql_execute("CREATE TABLE leankg_sql_seam_ro_should_not_exist ()", &[])
+            .expect_err("read-only session must reject writes");
+        // postgres::Error's Debug carries the full server message; Display
+        // alone may truncate to "db error".
+        let rendered = format!("{err:?}");
+        assert!(
+            rendered.to_lowercase().contains("read-only"),
+            "unexpected error: {rendered}"
+        );
+        let rows = ro
+            .sql_query("SELECT 1::bigint AS one", &[])
+            .expect("ro read");
+        assert_eq!(rows[0].int("one"), Some(1));
+    }
+
+    #[test]
+    fn fake_backend_reports_unsupported_clearly() {
+        let fake = crate::db::fake::FakeBackend::for_path(std::path::Path::new("/tmp/x"));
+        let err = fake
+            .sql_query("SELECT 1", &[])
+            .expect_err("fake has no SQL engine");
+        assert!(err.to_string().contains("SQL"), "{err}");
+    }
+}

--- a/src/indexer/content_hash.rs
+++ b/src/indexer/content_hash.rs
@@ -10,8 +10,9 @@
 //! All fields are length-prefixed (u64 LE) so a boundary shift (e.g.
 //! `path="a", repo="bc"` vs `path="ab", repo="c"`) can never collide.
 //!
-//! The content-hash store is a Cozo relation (`index_hashes`) that survives
-//! across runs. This module is **standalone**: wiring into the index walk
+//! The content-hash store is the `index_hashes` PG table (W8 wave 1: read
+//! and written as parameterized SQL through the [`crate::db::sql`] seam,
+//! no Datalog). This module is **standalone**: wiring into the index walk
 //! (`src/indexer/mod.rs`) is deferred until the P0 session merges, per plan —
 //! today it ships the pure key derivation + store CRUD + a unit-tested
 //! "should re-index?" predicate so the walk hook is a two-line call later.
@@ -59,48 +60,55 @@ pub struct IndexHashRow {
     pub hash: String,
 }
 
-/// Read persisted hashes from Cozo. Returns `Ok(Vec)` (possibly empty) when
+/// Read persisted hashes. Returns `Ok(Vec)` (possibly empty) when
 /// the relation does not exist yet — the caller treats that as "index all".
+///
+/// W8 wave 1: issued as parameterized SQL through the [`crate::db::sql`]
+/// seam on the backend trait (was: a Datalog `run_raw_query` script).
 pub fn load_hashes(
-    db: &crate::graph::GraphEngine,
+    db: &dyn crate::db::backend::DbBackend,
 ) -> Result<Vec<IndexHashRow>, Box<dyn std::error::Error + Send + Sync>> {
-    // The `<-` read form (`?[path, hash] <- index_hashes[...]`) is invalid
-    // cozo — use the canonical `:=` rule form (inventory CH1).
-    db.run_raw_query(
-        "?[path, hash] := *index_hashes[path, hash]",
-        std::collections::BTreeMap::new(),
-    )
-    .map(|rows| {
-        rows.rows
-            .iter()
-            .map(|row| IndexHashRow {
-                path: row[0].get_str().unwrap_or("").to_string(),
-                hash: row[1].get_str().unwrap_or("").to_string(),
-            })
-            .collect()
-    })
+    let rows = db
+        .sql_query("SELECT path, hash FROM index_hashes", &[])
+        .map_err(|e| {
+            Box::new(std::io::Error::other(e.to_string()))
+                as Box<dyn std::error::Error + Send + Sync>
+        })?;
+    Ok(rows
+        .iter()
+        .map(|row| IndexHashRow {
+            path: row.text("path").unwrap_or_default(),
+            hash: row.text("hash").unwrap_or_default(),
+        })
+        .collect())
 }
 
-/// Persist the new hash set (upsert semantics: `put` overwrites by `path`).
+/// Persist the new hash set (upsert semantics: overwrite by `path`).
+///
+/// W8 wave 1: one atomic parameterized batch through the
+/// [`crate::db::sql`] seam — `ON CONFLICT (path) DO UPDATE` replaces the
+/// per-row Datalog `:put` scripts (which also were not atomic across rows).
 pub fn save_hashes(
-    db: &crate::graph::GraphEngine,
+    db: &dyn crate::db::backend::DbBackend,
     rows: &[IndexHashRow],
 ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-    // Cozo `:put` on a 2-column relation keyed by `path` gives upsert.
-    // The `:put table {cols} <- $args` short form is NOT valid cozo — the
-    // rule form `?[cols] <- [[...]] :put table {cols => key}` is canonical
-    // (inventory CH2; the translator maps it to INSERT ... ON CONFLICT).
-    for row in rows {
-        let params = std::collections::BTreeMap::from([
-            ("path".to_string(), row.path.clone().into()),
-            ("hash".to_string(), row.hash.clone().into()),
-        ]);
-        db.run_raw_query(
-            r#"?[path, hash] <- [[$path, $hash]] :put index_hashes {path => hash}"#,
-            params,
-        )?;
-    }
-    Ok(())
+    let stmts: Vec<(&str, Vec<crate::db::sql::SqlParam>)> = rows
+        .iter()
+        .map(|r| {
+            (
+                "INSERT INTO index_hashes (path, hash) VALUES ($1, $2) \
+                 ON CONFLICT (path) DO UPDATE SET hash = $2",
+                vec![
+                    crate::db::sql::SqlParam::Text(r.path.clone()),
+                    crate::db::sql::SqlParam::Text(r.hash.clone()),
+                ],
+            )
+        })
+        .collect();
+    db.sql_execute_batch(&stmts)
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+            Box::new(std::io::Error::other(e.to_string()))
+        })
 }
 
 /// Build the per-file hash set for a directory walk (content read from disk).

--- a/tests/pg_sql_wave1_test.rs
+++ b/tests/pg_sql_wave1_test.rs
@@ -1,0 +1,294 @@
+//! W8 wave-1 parity + behavior tests: api_keys and content-hash paths
+//! converted from Datalog `run_script` scripts to parameterized SQL through
+//! the [`leankg::db::sql`] seam (plan:
+//! docs/plan-remove-cozo-datalog-sql-migration.md).
+//!
+//! Pattern: tests/pg_schema_test.rs — each test builds a scratch schema in
+//! the target Postgres (LEANKG_PG_URL; remote managed PG supported through
+//! the crate TLS connector) and is #[ignore]-gated so the default
+//! `cargo test` run skips it.
+//!
+//! Run against the provisioned remote PG:
+//!   set -a; source .env; set +a
+//!   cargo test --release --test pg_sql_wave1_test -- --ignored --test-threads=1
+//!
+//! Dual-path parity: the Datalog translator is still present during W8, so
+//! writes/reads made through the NEW SQL seam are cross-checked with the
+//! OLD `run_script` path against the SAME rows.
+
+use leankg::db::backend::{pg_connect, PostgresBackend, SharedDb};
+use leankg::db::keys::{ApiKey, ApiKeyStore};
+use std::sync::Arc;
+
+fn pg_url() -> String {
+    std::env::var("LEANKG_PG_URL")
+        .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost:5433/leankg".to_string())
+}
+
+/// Scratch schema + backend pinned to it (per-test isolation; dropped at end
+/// of scope via the leaked admin connection pattern used by pg_schema_test).
+struct Scratch {
+    db: SharedDb,
+}
+
+impl Scratch {
+    fn new(tag: &str) -> Scratch {
+        let base = pg_url();
+        static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let name = format!(
+            "leankg_w8test_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        let mut admin = pg_connect(&base)
+            .unwrap_or_else(|e| panic!("[{tag}] cannot connect to {}: {e}", "<pg>"));
+        admin
+            .batch_execute(&format!("DROP SCHEMA IF EXISTS {name} CASCADE"))
+            .unwrap();
+        admin
+            .batch_execute(&format!("CREATE SCHEMA {name}"))
+            .unwrap();
+        admin
+            .batch_execute(&format!("SET search_path TO {name}, public"))
+            .unwrap();
+        leankg::db::pg::migrations::run_migrations(&mut admin).unwrap();
+        // Leak the admin connection so the scratch schema outlives this call
+        // for the duration of the test process (same trick as lib tests);
+        // schema is namespaced per-pid so CI reruns never collide.
+        std::mem::forget(admin);
+
+        let sep = if base.contains('?') { '&' } else { '?' };
+        let url = format!("{base}{sep}options=-csearch_path%3D{name}%2Cpublic");
+        let db: SharedDb = Arc::new(PostgresBackend {
+            pg_url: url,
+            schema: Some(name.clone()),
+            pool: Arc::new(leankg::db::backend::ClientPool::new(2)),
+            ro_pool: Arc::new(leankg::db::backend::ClientPool::new(2)),
+            read_only: false,
+            write_bus: None,
+        });
+        Scratch { db }
+    }
+}
+
+#[allow(dead_code)]
+impl Scratch {
+    fn raw(&self, sql: &str) -> Vec<leankg::db::sql::SqlRow> {
+        self.db.sql_query(sql, &[]).expect("raw sql")
+    }
+}
+
+fn sorted_ids(keys: &[ApiKey]) -> Vec<String> {
+    let mut v: Vec<String> = keys.iter().map(|k| k.id.clone()).collect();
+    v.sort();
+    v
+}
+
+#[test]
+#[ignore = "requires live Postgres (LEANKG_PG_URL); run with --ignored"]
+fn api_key_lifecycle_via_sql_seam() {
+    let s = Scratch::new("lifecycle");
+    let store = ApiKeyStore::with_db(s.db.clone());
+
+    // CREATE
+    let (secret, created) = store.create_key("w8-lifecycle").expect("create");
+    assert!(!secret.is_empty());
+    assert_eq!(created.name, "w8-lifecycle");
+
+    // LIST: hash is blanked for display, name preserved
+    let keys = store.list_keys().expect("list");
+    assert_eq!(keys.len(), 1);
+    assert_eq!(keys[0].id, created.id);
+    assert_eq!(keys[0].name, "w8-lifecycle");
+    assert_eq!(keys[0].key_hash, "", "hash must not surface in listings");
+
+    // VALIDATE: correct key resolves to its id
+    let got = store.validate_key(&secret).expect("validate");
+    assert_eq!(got.as_deref(), Some(created.id.as_str()));
+
+    // VALIDATE side effects: last_used recorded; identity PRESERVED
+    // (deviation guard — the legacy path wiped name/created_at here).
+    let rows = s.raw(&format!(
+        "SELECT name, created_at, last_used_at FROM api_keys WHERE id = '{}'",
+        created.id
+    ));
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].text("name").as_deref(), Some("w8-lifecycle"));
+    assert_eq!(
+        rows[0].text("created_at").as_deref(),
+        Some(created.created_at.as_str())
+    );
+    assert!(rows[0].text("last_used_at").is_some(), "last_used recorded");
+
+    // VALIDATE: wrong key rejected
+    let bad = store.validate_key("lkkg_bogus_key_0000").expect("validate");
+    assert_eq!(bad, None);
+
+    // REVOKE
+    assert!(store.revoke_key(&created.id).expect("revoke"));
+    assert!(
+        !store.revoke_key(&created.id).expect("revoke twice"),
+        "second revoke must report false"
+    );
+    let after = store.validate_key(&secret).expect("validate revoked");
+    assert_eq!(after, None, "revoked key must not validate");
+    let listed = store.list_keys().expect("list after revoke");
+    assert!(listed.is_empty(), "revoked keys are excluded from listings");
+}
+
+#[test]
+#[ignore = "requires live Postgres (LEANKG_PG_URL); run with --ignored"]
+fn api_key_dual_path_parity_old_datalog_vs_new_sql() {
+    let s = Scratch::new("parity");
+    let store = ApiKeyStore::with_db(s.db.clone());
+
+    // Write A: NEW typed method.
+    let (_sec_a, ka) = store.create_key("via-sql").expect("create sql");
+    // Write B: OLD Datalog :put through run_script (translator still alive
+    // during W8 — this IS the pre-conversion reference path).
+    let legacy_id = "legacy-key-id";
+    let script = r#"?[id, name, key_hash, created_at, last_used_at, revoked_at] <- [[$id, $name, $key_hash, $created_at, $last_used_at, $revoked_at]]
+        :put api_keys { id, name, key_hash, created_at, last_used_at, revoked_at }"#;
+    let params: std::collections::BTreeMap<String, serde_json::Value> =
+        std::collections::BTreeMap::from([
+            ("id".into(), serde_json::json!(legacy_id)),
+            ("name".into(), serde_json::json!("legacy")),
+            (
+                "key_hash".into(),
+                serde_json::json!("$argon2id$v=19$m=19456,t=2,p=1$deadbeef$cafebabe"),
+            ),
+            ("created_at".into(), serde_json::json!("1700000000")),
+            ("last_used_at".into(), serde_json::Value::Null),
+            ("revoked_at".into(), serde_json::Value::Null),
+        ]);
+    s.db.run_script(script, params).expect("legacy put");
+
+    // Cross-read: OLD read path sees BOTH writes identically to NEW read path.
+    let old_view = s
+        .db
+        .run_script(
+            "?[id, name, key_hash, created_at, last_used_at, revoked_at] := *api_keys[id, name, key_hash, created_at, last_used_at, revoked_at]",
+            std::collections::BTreeMap::new(),
+        )
+        .expect("datalog read");
+    let new_view: Vec<ApiKey> = s.db.list_api_keys().expect("sql read");
+    assert_eq!(old_view.rows.len(), 2, "{old_view:?}");
+    assert_eq!(new_view.len(), 2);
+
+    let old_rows: Vec<(String, String)> = old_view
+        .rows
+        .iter()
+        .map(|r| {
+            (
+                r[0].get_str().unwrap_or("").to_string(),
+                r[2].get_str().unwrap_or("").to_string(),
+            )
+        })
+        .collect();
+    let new_rows: Vec<(String, String)> = new_view
+        .iter()
+        .map(|k| (k.id.clone(), k.key_hash.clone()))
+        .collect();
+    let mut o = old_rows;
+    o.sort();
+    let mut n = new_rows;
+    n.sort();
+    assert_eq!(o, n, "(id, key_hash) tuples must match across both paths");
+
+    // Revoke through the NEW path, verify through the OLD path.
+    assert!(store.revoke_key(legacy_id).expect("revoke"));
+    let still_there =
+        s.db.run_script(
+            "?[id, revoked_at] := *api_keys[id, revoked_at], id = $id",
+            std::collections::BTreeMap::from([("id".into(), serde_json::json!(legacy_id))]),
+        )
+        .expect("read back");
+    assert_eq!(still_there.rows.len(), 1);
+    assert_eq!(
+        still_there.rows[0][1].get_str().map(String::from).is_some(),
+        true,
+        "revoked_at must now be set"
+    );
+
+    let _ = ka;
+}
+
+#[test]
+#[ignore = "requires live Postgres (LEANKG_PG_URL); run with --ignored"]
+fn api_keys_multiple_and_listing_filter() {
+    let s = Scratch::new("multi");
+    let store = ApiKeyStore::with_db(s.db.clone());
+    let mut ids = Vec::new();
+    for i in 0..4 {
+        let (_, k) = store.create_key(&format!("key-{i}")).expect("create");
+        ids.push(k.id);
+    }
+    // Revoke two.
+    assert!(store.revoke_key(&ids[0]).unwrap());
+    assert!(store.revoke_key(&ids[2]).unwrap());
+    let listed = store.list_keys().unwrap();
+    let mut want: Vec<String> = vec![ids[1].clone(), ids[3].clone()];
+    want.sort();
+    let got = sorted_ids(&listed);
+    assert_eq!(got, want);
+}
+
+#[test]
+#[ignore = "requires live Postgres (LEANKG_PG_URL); run with --ignored"]
+fn content_hashes_roundtrip_upsert_through_seam() {
+    use leankg::indexer::content_hash::{load_hashes, save_hashes, IndexHashRow};
+
+    let s = Scratch::new("hashes");
+    let rows = vec![
+        IndexHashRow {
+            path: "src/a.rs".into(),
+            hash: "aaa".into(),
+        },
+        IndexHashRow {
+            path: "src/b.rs".into(),
+            hash: "bbb".into(),
+        },
+    ];
+    save_hashes(&*s.db, &rows).expect("save");
+
+    // Upsert: same path, new hash; plus one brand-new path.
+    let updated = vec![
+        IndexHashRow {
+            path: "src/a.rs".into(),
+            hash: "aaa2".into(),
+        },
+        IndexHashRow {
+            path: "src/c.rs".into(),
+            hash: "ccc".into(),
+        },
+    ];
+    save_hashes(&*s.db, &updated).expect("resave");
+
+    let loaded = load_hashes(&*s.db).expect("load");
+    let mut got: Vec<(String, String)> = loaded
+        .iter()
+        .map(|r| (r.path.clone(), r.hash.clone()))
+        .collect();
+    got.sort();
+    assert_eq!(
+        got,
+        vec![
+            ("src/a.rs".into(), "aaa2".into()), // overwritten, not duplicated
+            ("src/b.rs".into(), "bbb".into()),
+            ("src/c.rs".into(), "ccc".into()),
+        ]
+    );
+
+    // Empty save is a no-op that must NOT wipe existing rows.
+    save_hashes(&*s.db, &[]).expect("empty save");
+    assert_eq!(load_hashes(&*s.db).unwrap().len(), 3);
+}
+
+#[test]
+#[ignore = "requires live Postgres (LEANKG_PG_URL); run with --ignored"]
+fn content_hash_load_empty_when_relation_empty() {
+    use leankg::indexer::content_hash::load_hashes;
+    let s = Scratch::new("hashes-empty");
+    let loaded = load_hashes(&*s.db).expect("load on empty table");
+    assert!(loaded.is_empty());
+}


### PR DESCRIPTION
**W8 Datalog removal begins** (plan adopted from dormant cozo-removal WIP):
- P1 SQL seam: src/db/sql.rs (SqlParam/SqlRow, sql_query/sql_execute_batch/COPY import) ported + TDD'd; run_script dual-path parity preserved
- Wave-1a: db/keys.rs (7 sites) + indexer/content_hash.rs (2 sites) converted to typed parameterized methods
- Bugs caught: SqlRow NULL→Some("null") rendering; legacy validate_key DELETE+reinsert data loss (now last_used_at update only)
- Live proof: converted ops emit kind="sql" with zero cozo= lines

Gates: lib **1213✅** · pg_schema 6✅ · parity 11✅ · fmt/clippy clean. Next waves: db/mod.rs helpers ×46 → translate.rs/fake.rs deletion.