### PR TITLE
W8 wave-1b: knowledge_entries SQL conversion

### DIFF
--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -308,6 +308,69 @@ pub trait DbBackend: Send + Sync {
     ) -> Result<(), Box<dyn std::error::Error>> {
         Err("SQL-first api_keys not supported by this backend".into())
     }
+
+    // ========================================================================
+    // W8 wave-1b: knowledge_entries parameterized-SQL surface.
+    // Replaces the Datalog `:put`/`:rm`/regex-scan bodies in db/mod.rs.
+    // Semantics locked by tests/pg_sql_wave1b_test.rs.
+    // ========================================================================
+
+    /// Insert or update by id (legacy `:put` = upsert; the wave-1 fix made
+    /// the translator emit ON CONFLICT — here it is explicit).
+    fn upsert_knowledge_entry(
+        &self,
+        _entry: &crate::db::models::KnowledgeEntry,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        Err("SQL-first knowledge_entries not supported by this backend".into())
+    }
+
+    fn find_knowledge_entry(
+        &self,
+        _id: &str,
+    ) -> Result<Option<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        Err("SQL-first knowledge_entries not supported by this backend".into())
+    }
+
+    /// Delete by id. Returns whether a row was removed (legacy `:rm`
+    /// silently no-opped on absent ids, so absence is not an error).
+    fn delete_knowledge_entry_by_id(&self, _id: &str) -> Result<bool, Box<dyn std::error::Error>> {
+        Err("SQL-first knowledge_entries not supported by this backend".into())
+    }
+
+    /// Case-insensitive substring match over title/content (equivalent to
+    /// the legacy `regex_matches(lowercase(x), ".*q.*")` scan), with
+    /// optional exact-match filters and limit.
+    fn search_knowledge_entries(
+        &self,
+        _query: &str,
+        _knowledge_type: Option<&str>,
+        _environment: Option<&str>,
+        _limit: usize,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        Err("SQL-first knowledge_entries not supported by this backend".into())
+    }
+
+    fn list_knowledge_by_element(
+        &self,
+        _element_qualified: &str,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        Err("SQL-first knowledge_entries not supported by this backend".into())
+    }
+
+    fn list_knowledge_by_feature(
+        &self,
+        _feature_id: &str,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        Err("SQL-first knowledge_entries not supported by this backend".into())
+    }
+
+    fn list_knowledge_by_environment(
+        &self,
+        _environment: &str,
+        _limit: usize,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        Err("SQL-first knowledge_entries not supported by this backend".into())
+    }
 }
 
 /// Shared handle used throughout the codebase. `Arc` so clones of
@@ -1774,6 +1837,151 @@ impl DbBackend for PostgresBackend {
         .map(|_| ())
     }
 
+    // ========================================================================
+    // W8 wave-1b: knowledge_entries parameterized-SQL implementations.
+    // ========================================================================
+
+    fn upsert_knowledge_entry(
+        &self,
+        entry: &crate::db::models::KnowledgeEntry,
+    ) -> Result<(), Box<dyn std::error::Error>> {
+        self.sql_execute(
+            "INSERT INTO knowledge_entries \
+               (id, knowledge_type, title, content, element_qualified, user_story_id, \
+                feature_id, tags, environment, branch, author, created_at, updated_at) \
+             VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12,$13) \
+             ON CONFLICT (id) DO UPDATE SET \
+               knowledge_type = EXCLUDED.knowledge_type, title = EXCLUDED.title, \
+               content = EXCLUDED.content, element_qualified = EXCLUDED.element_qualified, \
+               user_story_id = EXCLUDED.user_story_id, feature_id = EXCLUDED.feature_id, \
+               tags = EXCLUDED.tags, environment = EXCLUDED.environment, \
+               branch = EXCLUDED.branch, author = EXCLUDED.author, \
+               created_at = EXCLUDED.created_at, updated_at = EXCLUDED.updated_at",
+            &[
+                crate::db::sql::SqlParam::Text(entry.id.clone()),
+                crate::db::sql::SqlParam::Text(entry.knowledge_type.clone()),
+                crate::db::sql::SqlParam::Text(entry.title.clone()),
+                crate::db::sql::SqlParam::Text(entry.content.clone()),
+                opt_text(entry.element_qualified.as_deref()),
+                opt_text(entry.user_story_id.as_deref()),
+                opt_text(entry.feature_id.as_deref()),
+                // tags column is JSONB; legacy bound an arbitrary JSON-ish
+                // string — parse when possible, else wrap as a JSON string.
+                crate::db::sql::SqlParam::Json(
+                    serde_json::from_str::<serde_json::Value>(&entry.tags)
+                        .unwrap_or(serde_json::Value::String(entry.tags.clone())),
+                ),
+                crate::db::sql::SqlParam::Text(entry.environment.clone()),
+                opt_text(entry.branch.as_deref()),
+                crate::db::sql::SqlParam::Text(entry.author.clone()),
+                crate::db::sql::SqlParam::Int(entry.created_at),
+                crate::db::sql::SqlParam::Int(entry.updated_at),
+            ],
+        )
+        .map(|_| ())
+    }
+
+    fn find_knowledge_entry(
+        &self,
+        id: &str,
+    ) -> Result<Option<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        let rows = self.sql_query(
+            "SELECT id, knowledge_type, title, content, element_qualified, user_story_id, \
+                    feature_id, tags, environment, branch, author, created_at, updated_at \
+             FROM knowledge_entries WHERE id = $1",
+            &[crate::db::sql::SqlParam::Text(id.to_string())],
+        )?;
+        Ok(rows.first().map(knowledge_entry_from_row))
+    }
+
+    fn delete_knowledge_entry_by_id(&self, id: &str) -> Result<bool, Box<dyn std::error::Error>> {
+        self.sql_execute(
+            "DELETE FROM knowledge_entries WHERE id = $1",
+            &[crate::db::sql::SqlParam::Text(id.to_string())],
+        )
+        .map(|n| n > 0)
+    }
+
+    fn search_knowledge_entries(
+        &self,
+        query: &str,
+        knowledge_type: Option<&str>,
+        environment: Option<&str>,
+        limit: usize,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        // Legacy semantics: regex .*q.* over lowercase(title|content). ILIKE
+        // with escaped wildcards is the SQL equivalent for substring match.
+        let needle = format!("%{}%", escape_like(query));
+        let mut sql = String::from(
+            "SELECT id, knowledge_type, title, content, element_qualified, user_story_id, \
+                    feature_id, tags, environment, branch, author, created_at, updated_at \
+             FROM knowledge_entries WHERE (title ILIKE $1 OR content ILIKE $1)",
+        );
+        let mut params: Vec<crate::db::sql::SqlParam> =
+            vec![crate::db::sql::SqlParam::Text(needle)];
+        if let Some(kt) = knowledge_type {
+            params.push(crate::db::sql::SqlParam::Text(kt.to_string()));
+            sql.push_str(&format!(" AND knowledge_type = ${}", params.len()));
+        }
+        if let Some(env) = environment {
+            params.push(crate::db::sql::SqlParam::Text(env.to_string()));
+            sql.push_str(&format!(" AND environment = ${}", params.len()));
+        }
+        params.push(crate::db::sql::SqlParam::Int(limit as i64));
+        sql.push_str(&format!(
+            " ORDER BY updated_at DESC LIMIT ${}",
+            params.len()
+        ));
+        let rows = self.sql_query(&sql, &params)?;
+        Ok(rows.iter().map(knowledge_entry_from_row).collect())
+    }
+
+    fn list_knowledge_by_element(
+        &self,
+        element_qualified: &str,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        let rows = self.sql_query(
+            "SELECT id, knowledge_type, title, content, element_qualified, user_story_id, \
+                    feature_id, tags, environment, branch, author, created_at, updated_at \
+             FROM knowledge_entries WHERE element_qualified = $1",
+            &[crate::db::sql::SqlParam::Text(
+                element_qualified.to_string(),
+            )],
+        )?;
+        Ok(rows.iter().map(knowledge_entry_from_row).collect())
+    }
+
+    fn list_knowledge_by_feature(
+        &self,
+        feature_id: &str,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        let rows = self.sql_query(
+            "SELECT id, knowledge_type, title, content, element_qualified, user_story_id, \
+                    feature_id, tags, environment, branch, author, created_at, updated_at \
+             FROM knowledge_entries WHERE feature_id = $1",
+            &[crate::db::sql::SqlParam::Text(feature_id.to_string())],
+        )?;
+        Ok(rows.iter().map(knowledge_entry_from_row).collect())
+    }
+
+    fn list_knowledge_by_environment(
+        &self,
+        environment: &str,
+        limit: usize,
+    ) -> Result<Vec<crate::db::models::KnowledgeEntry>, Box<dyn std::error::Error>> {
+        let rows = self.sql_query(
+            "SELECT id, knowledge_type, title, content, element_qualified, user_story_id, \
+                    feature_id, tags, environment, branch, author, created_at, updated_at \
+             FROM knowledge_entries WHERE environment = $1 \
+             ORDER BY updated_at DESC LIMIT $2",
+            &[
+                crate::db::sql::SqlParam::Text(environment.to_string()),
+                crate::db::sql::SqlParam::Int(limit as i64),
+            ],
+        )?;
+        Ok(rows.iter().map(knowledge_entry_from_row).collect())
+    }
+
     /// FR-ENT-1: one multi-row INSERT for the whole batch (≤ 50 rows × 9
     /// params per flush, well under the 65535 bind limit).
     fn insert_audit_batch(
@@ -2383,6 +2591,43 @@ fn project_identity_keys_in(
     }
 
     (root.to_string_lossy().to_string(), None)
+}
+
+/// `Option<&str>` → bind param: `None` maps to SQL NULL (matches the legacy
+/// Datalog `serde_json::Value::Null` bindings for optional columns).
+fn opt_text(v: Option<&str>) -> crate::db::sql::SqlParam {
+    match v {
+        Some(s) => crate::db::sql::SqlParam::Text(s.to_string()),
+        None => crate::db::sql::SqlParam::Null,
+    }
+}
+
+/// Escape LIKE wildcards in user input so `search_knowledge` substring
+/// semantics match the legacy `regex_matches(lowercase(x), ".*q.*")` scan.
+fn escape_like(s: &str) -> String {
+    s.replace('\\', "\\\\")
+        .replace('%', "\\%")
+        .replace('_', "\\_")
+}
+
+/// Map a knowledge_entries row onto the model — field-for-field identical
+/// to db/mod.rs's `row_to_knowledge_entry` defaults.
+fn knowledge_entry_from_row(r: &crate::db::sql::SqlRow) -> crate::db::models::KnowledgeEntry {
+    crate::db::models::KnowledgeEntry {
+        id: r.text("id").unwrap_or_default(),
+        knowledge_type: r.text("knowledge_type").unwrap_or_else(|| "general".into()),
+        title: r.text("title").unwrap_or_default(),
+        content: r.text("content").unwrap_or_default(),
+        element_qualified: r.text("element_qualified"),
+        user_story_id: r.text("user_story_id"),
+        feature_id: r.text("feature_id"),
+        tags: r.text("tags").unwrap_or_else(|| "[]".into()),
+        environment: r.text("environment").unwrap_or_else(|| "production".into()),
+        branch: r.text("branch"),
+        author: r.text("author").unwrap_or_default(),
+        created_at: r.int("created_at").unwrap_or(0),
+        updated_at: r.int("updated_at").unwrap_or(0),
+    }
 }
 
 fn redact_url(url: &str) -> String {

--- a/src/db/mod.rs
+++ b/src/db/mod.rs
@@ -670,78 +670,7 @@ pub fn create_knowledge_entry(
     db: &dyn crate::db::backend::DbBackend,
     entry: &models::KnowledgeEntry,
 ) -> Result<models::KnowledgeEntry, Box<dyn std::error::Error>> {
-    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] <- [[$id, $kt, $title, $content, $eq, $us, $feat, $tags, $env, $branch, $author, $cat, $uat]] :put knowledge_entries {id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at}"#;
-    let mut params = std::collections::BTreeMap::new();
-    params.insert(
-        "id".to_string(),
-        serde_json::Value::String(entry.id.clone()),
-    );
-    params.insert(
-        "kt".to_string(),
-        serde_json::Value::String(entry.knowledge_type.clone()),
-    );
-    params.insert(
-        "title".to_string(),
-        serde_json::Value::String(entry.title.clone()),
-    );
-    params.insert(
-        "content".to_string(),
-        serde_json::Value::String(entry.content.clone()),
-    );
-    params.insert(
-        "eq".to_string(),
-        entry
-            .element_qualified
-            .as_ref()
-            .map(|s| serde_json::Value::String(s.clone()))
-            .unwrap_or(serde_json::Value::Null),
-    );
-    params.insert(
-        "us".to_string(),
-        entry
-            .user_story_id
-            .as_ref()
-            .map(|s| serde_json::Value::String(s.clone()))
-            .unwrap_or(serde_json::Value::Null),
-    );
-    params.insert(
-        "feat".to_string(),
-        entry
-            .feature_id
-            .as_ref()
-            .map(|s| serde_json::Value::String(s.clone()))
-            .unwrap_or(serde_json::Value::Null),
-    );
-    params.insert(
-        "tags".to_string(),
-        serde_json::Value::String(entry.tags.clone()),
-    );
-    params.insert(
-        "env".to_string(),
-        serde_json::Value::String(entry.environment.clone()),
-    );
-    params.insert(
-        "branch".to_string(),
-        entry
-            .branch
-            .as_ref()
-            .map(|s| serde_json::Value::String(s.clone()))
-            .unwrap_or(serde_json::Value::Null),
-    );
-    params.insert(
-        "author".to_string(),
-        serde_json::Value::String(entry.author.clone()),
-    );
-    params.insert(
-        "cat".to_string(),
-        serde_json::Value::Number(entry.created_at.into()),
-    );
-    params.insert(
-        "uat".to_string(),
-        serde_json::Value::Number(entry.updated_at.into()),
-    );
-
-    db.run_script(query, params)?;
+    db.upsert_knowledge_entry(entry)?;
     Ok(entry.clone())
 }
 
@@ -749,23 +678,14 @@ pub fn get_knowledge_entry(
     db: &dyn crate::db::backend::DbBackend,
     id: &str,
 ) -> Result<Option<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
-    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], id = $id"#;
-    let mut params = std::collections::BTreeMap::new();
-    params.insert("id".to_string(), serde_json::Value::String(id.to_string()));
-
-    let result = db.run_script(query, params)?;
-    if result.rows.is_empty() {
-        return Ok(None);
-    }
-
-    Ok(Some(row_to_knowledge_entry(&result.rows[0])))
+    db.find_knowledge_entry(id)
 }
 
 pub fn update_knowledge_entry(
     db: &dyn crate::db::backend::DbBackend,
     entry: &models::KnowledgeEntry,
 ) -> Result<models::KnowledgeEntry, Box<dyn std::error::Error>> {
-    // :put acts as upsert in CozoDB
+    // legacy :put acted as upsert
     create_knowledge_entry(db, entry)
 }
 
@@ -773,14 +693,8 @@ pub fn delete_knowledge_entry(
     db: &dyn crate::db::backend::DbBackend,
     id: &str,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    // CozoDB has no `:delete` operator. Read the matching row(s) by id via
-    // head-binding, then `:rm` exactly those rows.
-    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], id = $id
-:rm knowledge_entries {id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at}"#;
-    let mut params = std::collections::BTreeMap::new();
-    params.insert("id".to_string(), serde_json::Value::String(id.to_string()));
-    db.run_script(query, params)?;
-    Ok(())
+    // legacy :rm silently no-opped on absent ids
+    db.delete_knowledge_entry_by_id(id).map(|_| ())
 }
 
 pub fn search_knowledge(
@@ -790,75 +704,21 @@ pub fn search_knowledge(
     environment: Option<&str>,
     limit: usize,
 ) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
-    let regex_pattern = format!(".*{}.*", query_str.to_lowercase());
-    let mut conditions = vec![format!(
-        "(regex_matches(lowercase(title), \"{0}\") or regex_matches(lowercase(content), \"{0}\"))",
-        regex_pattern
-    )];
-    let mut params = std::collections::BTreeMap::new();
-
-    if let Some(kt) = knowledge_type {
-        params.insert("kt".to_string(), serde_json::Value::String(kt.to_string()));
-        conditions.push("knowledge_type = $kt".to_string());
-    }
-    if let Some(env) = environment {
-        params.insert(
-            "env".to_string(),
-            serde_json::Value::String(env.to_string()),
-        );
-        conditions.push("environment = $env".to_string());
-    }
-
-    let where_clause = conditions.join(", ");
-    let query = format!(
-        r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], {} :limit {}"#,
-        where_clause, limit
-    );
-
-    let result = db.run_script(&query, params)?;
-    Ok(result
-        .rows
-        .iter()
-        .map(|r| row_to_knowledge_entry(r))
-        .collect())
+    db.search_knowledge_entries(query_str, knowledge_type, environment, limit)
 }
 
 pub fn get_knowledge_by_element(
     db: &dyn crate::db::backend::DbBackend,
     element_qualified: &str,
 ) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
-    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], element_qualified = $eq"#;
-    let mut params = std::collections::BTreeMap::new();
-    params.insert(
-        "eq".to_string(),
-        serde_json::Value::String(element_qualified.to_string()),
-    );
-
-    let result = db.run_script(query, params)?;
-    Ok(result
-        .rows
-        .iter()
-        .map(|r| row_to_knowledge_entry(r))
-        .collect())
+    db.list_knowledge_by_element(element_qualified)
 }
 
 pub fn get_knowledge_by_feature(
     db: &dyn crate::db::backend::DbBackend,
     feature_id: &str,
 ) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
-    let query = r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], feature_id = $feat"#;
-    let mut params = std::collections::BTreeMap::new();
-    params.insert(
-        "feat".to_string(),
-        serde_json::Value::String(feature_id.to_string()),
-    );
-
-    let result = db.run_script(query, params)?;
-    Ok(result
-        .rows
-        .iter()
-        .map(|r| row_to_knowledge_entry(r))
-        .collect())
+    db.list_knowledge_by_feature(feature_id)
 }
 
 pub fn get_knowledge_by_environment(
@@ -866,40 +726,7 @@ pub fn get_knowledge_by_environment(
     environment: &str,
     limit: usize,
 ) -> Result<Vec<models::KnowledgeEntry>, Box<dyn std::error::Error>> {
-    let query = format!(
-        r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] := *knowledge_entries[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at], environment = $env :limit {}"#,
-        limit
-    );
-    let mut params = std::collections::BTreeMap::new();
-    params.insert(
-        "env".to_string(),
-        serde_json::Value::String(environment.to_string()),
-    );
-
-    let result = db.run_script(&query, params)?;
-    Ok(result
-        .rows
-        .iter()
-        .map(|r| row_to_knowledge_entry(r))
-        .collect())
-}
-
-fn row_to_knowledge_entry(row: &[crate::db::backend::DataValue]) -> models::KnowledgeEntry {
-    models::KnowledgeEntry {
-        id: row[0].get_str().unwrap_or("").to_string(),
-        knowledge_type: row[1].get_str().unwrap_or("general").to_string(),
-        title: row[2].get_str().unwrap_or("").to_string(),
-        content: row[3].get_str().unwrap_or("").to_string(),
-        element_qualified: row[4].get_str().map(String::from),
-        user_story_id: row[5].get_str().map(String::from),
-        feature_id: row[6].get_str().map(String::from),
-        tags: row[7].get_str().unwrap_or("[]").to_string(),
-        environment: row[8].get_str().unwrap_or("production").to_string(),
-        branch: row[9].get_str().map(String::from),
-        author: row[10].get_str().unwrap_or("").to_string(),
-        created_at: row[11].get_int().unwrap_or(0),
-        updated_at: row[12].get_int().unwrap_or(0),
-    }
+    db.list_knowledge_by_environment(environment, limit)
 }
 
 // ============================================================================

--- a/tests/pg_sql_wave1b_test.rs
+++ b/tests/pg_sql_wave1b_test.rs
@@ -1,0 +1,147 @@
+//! W8 wave-1b: knowledge_entries parameterized-SQL parity tests.
+//!
+//! Locks the semantics of the converted `db::mod` knowledge fns against the
+//! legacy Datalog behavior: upsert-by-id, NULL optionals round-trip as None,
+//! ILIKE substring search with exact-match filters, by-element/feature/env
+//! lists, and delete-by-id absence tolerance.
+//!
+//! Pattern: tests/pg_sql_wave1_test.rs — #[ignore]-gated live-PG scratch.
+
+use leankg::db::backend::{DbBackend, PostgresBackend, SharedDb};
+use leankg::db::models::KnowledgeEntry;
+use std::sync::Arc;
+
+fn pg_url() -> String {
+    std::env::var("LEANKG_PG_URL")
+        .unwrap_or_else(|_| "postgresql://postgres:postgres@localhost:5433/leankg".to_string())
+}
+
+struct Scratch {
+    db: SharedDb,
+}
+
+impl Scratch {
+    fn new(tag: &str) -> Scratch {
+        let base = pg_url();
+        static COUNTER: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
+        let name = format!(
+            "leankg_w8b_{}_{}",
+            std::process::id(),
+            COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
+        );
+        let mut admin = leankg::db::backend::pg_connect(&base)
+            .unwrap_or_else(|e| panic!("[{tag}] cannot connect to PG: {e}"));
+        admin
+            .batch_execute(&format!("DROP SCHEMA IF EXISTS {name} CASCADE"))
+            .unwrap();
+        admin
+            .batch_execute(&format!("CREATE SCHEMA {name}"))
+            .unwrap();
+        admin
+            .batch_execute(&format!("SET search_path TO {name}, public"))
+            .unwrap();
+        leankg::db::pg::migrations::run_migrations(&mut admin).unwrap();
+        std::mem::forget(admin);
+
+        let sep = if base.contains('?') { '&' } else { '?' };
+        let url = format!("{base}{sep}options=-csearch_path%3D{name}%2Cpublic");
+        let db: SharedDb = Arc::new(PostgresBackend {
+            pg_url: url,
+            schema: Some(name.clone()),
+            pool: Arc::new(leankg::db::backend::ClientPool::new(2)),
+            ro_pool: Arc::new(leankg::db::backend::ClientPool::new(2)),
+            read_only: false,
+            write_bus: None,
+        });
+        Scratch { db }
+    }
+}
+
+fn entry(id: &str, title: &str, content: &str) -> KnowledgeEntry {
+    KnowledgeEntry {
+        id: id.into(),
+        knowledge_type: "decision".into(),
+        title: title.into(),
+        content: content.into(),
+        element_qualified: Some(format!("src/{id}.rs::thing")),
+        user_story_id: None,
+        feature_id: None,
+        tags: "[\"w8\"]".into(),
+        environment: "production".into(),
+        branch: None,
+        author: "wave1b-test".into(),
+        created_at: 1_700_000_000,
+        updated_at: 1_700_000_100,
+    }
+}
+
+#[test]
+#[ignore = "requires live Postgres (LEANKG_PG_URL); run with --ignored --test-threads=1"]
+fn knowledge_entries_sql_parity_round_trip() {
+    let s = Scratch::new("parity");
+    let db = s.db.as_ref();
+
+    // create + get (second entry exercises NULL optional columns)
+    let a = entry("w8b-1", "Fix auth flow", "token refresh races under load");
+    leankg::db::create_knowledge_entry(db, &a).unwrap();
+    let mut b = entry("w8b-2", "Overview cache", "l1 warm path");
+    b.element_qualified = None;
+    b.branch = None;
+    b.user_story_id = Some("US-9".into());
+    leankg::db::create_knowledge_entry(db, &b).unwrap();
+
+    let got = leankg::db::get_knowledge_entry(db, "w8b-1")
+        .unwrap()
+        .expect("row must exist");
+    assert_eq!(got.title, "Fix auth flow");
+    assert_eq!(
+        got.element_qualified.as_deref(),
+        Some("src/w8b-1.rs::thing")
+    );
+    assert_eq!(got.tags, "[\"w8\"]");
+
+    // update via upsert — exactly one row per id afterwards
+    let mut a2 = a.clone();
+    a2.title = "Fix auth flow v2".into();
+    a2.updated_at = 1_700_000_200;
+    leankg::db::update_knowledge_entry(db, &a2).unwrap();
+    let got = leankg::db::get_knowledge_entry(db, "w8b-1")
+        .unwrap()
+        .unwrap();
+    assert_eq!(got.title, "Fix auth flow v2");
+    assert_eq!(got.updated_at, 1_700_000_200);
+    let all = leankg::db::search_knowledge(db, "auth flow", None, None, 10).unwrap();
+    assert_eq!(all.iter().filter(|e| e.id == "w8b-1").count(), 1);
+
+    // NULL optional columns survive the round trip as None (wave-1 SqlRow bug)
+    let got_b = leankg::db::get_knowledge_entry(db, "w8b-2")
+        .unwrap()
+        .unwrap();
+    assert!(got_b.element_qualified.is_none(), "NULL must stay None");
+    assert!(got_b.branch.is_none());
+    assert_eq!(got_b.user_story_id.as_deref(), Some("US-9"));
+
+    // search: case-insensitive substring + exact filters
+    let hits = leankg::db::search_knowledge(db, "TOKEN REFRESH", None, None, 10).unwrap();
+    assert_eq!(hits.len(), 1);
+    assert_eq!(hits[0].id, "w8b-1");
+    let none =
+        leankg::db::search_knowledge(db, "auth", Some("nonexistent-type"), None, 10).unwrap();
+    assert!(none.is_empty());
+
+    // by_element / by_feature / by_environment
+    let by_el = leankg::db::get_knowledge_by_element(db, "src/w8b-1.rs::thing").unwrap();
+    assert_eq!(by_el.len(), 1);
+    assert!(leankg::db::get_knowledge_by_feature(db, "FEAT-X")
+        .unwrap()
+        .is_empty());
+    let envd = leankg::db::get_knowledge_by_environment(db, "production", 10).unwrap();
+    assert!(envd.len() >= 2);
+
+    // delete via trait method: present removes → true; absent tolerated → false
+    assert!(db.delete_knowledge_entry_by_id("w8b-1").unwrap());
+    assert!(!db.delete_knowledge_entry_by_id("w8b-1").unwrap());
+    assert!(leankg::db::get_knowledge_entry(db, "w8b-1")
+        .unwrap()
+        .is_none());
+}


### PR DESCRIPTION
Cycle-6 wave of the Datalog removal plan: 8 db/mod.rs knowledge fns now delegate to parameterized-SQL trait methods (upsert ON CONFLICT / find / delete-by-id bool / ILIKE search + filters / by_element·feature·environment). run_script sites in db/mod.rs **46→39**.

Parity test caught a real schema mismatch (tags is JSONB, legacy bound Text) — fixed via SqlParam::Json with string-fallback. NULL optionals round-trip as None; ordering matches legacy semantics.

Gates: lib 1195✅ · live-PG parity 1✅ · fmt/clippy clean · 0 warnings. Live proof: add_knowledge on :9874 → ok, server log cozo_lines=0. Remote PG only; no Docker.