### PR TITLE
fix(db): knowledge CRUD on sqlite — correct format args, implement search

### DIFF
--- a/src/db/sqlite_backend.rs
+++ b/src/db/sqlite_backend.rs
@@ -1177,9 +1177,9 @@ impl DbBackend for SqliteBackend {
             r#"?[id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at] <-
                 [["{}", "{}", "{}", "{}", "{}", "{}", "{}", "{}", "{}", "{}", "{}", {}, {}]] :put knowledge_entries {{id, knowledge_type, title, content, element_qualified, user_story_id, feature_id, tags, environment, branch, author, created_at, updated_at}}"#,
             entry.id,
-            entry.id,
             entry.knowledge_type,
             entry.title.replace('"', "\\\""),
+            entry.content.replace('"', "\\\""),
             entry.element_qualified.as_deref().unwrap_or(""),
             entry.user_story_id.as_deref().unwrap_or(""),
             entry.feature_id.as_deref().unwrap_or(""),


### PR DESCRIPTION
## Bug
`add_knowledge` on SQLite succeeded (status: created) but `search_knowledge` returned 0 hits.

## Root cause
The `upsert_knowledge_entry` Cozo Datalog had a duplicate `entry.id` arg (shifting all subsequent values by one column) and was missing `entry.content`.

## Fix
- Removed duplicate `entry.id` from format args
- Added missing `entry.content`
- Implemented `search_knowledge_entries` and `list_knowledge_by_element` via Cozo Datalog `regex_matches` (previously defaulted to 'SQL-first not supported')

## Verification
- add → search → verify all 4 columns correct → restart persistence — all PASS
- 1333 lib tests green