### PR TITLE
fix(db): sqlite import bracket nesting, doctor probes, 3-tool surface

### DIFF
--- a/src/db/sqlite_backend.rs
+++ b/src/db/sqlite_backend.rs
@@ -1111,6 +1111,49 @@ impl SqliteBackend {
     }
 }
 
+/// Map a Cozo `code_elements` row to a `CodeElement`. `with_env` selects the
+/// trailing `env` column (parity with PG's `code_element_from_row_env`).
+fn cozo_row_to_code_element(
+    row: &[crate::db::value::DataValue],
+    with_env: bool,
+) -> crate::db::models::CodeElement {
+    let g = |i: usize| {
+        row.get(i)
+            .and_then(|v| match v {
+                crate::db::value::DataValue::Str(s) => Some(s.to_string()),
+                _ => None,
+            })
+            .unwrap_or_default()
+    };
+    let n = |i: usize| {
+        row.get(i)
+            .and_then(|v| match v {
+                crate::db::value::DataValue::Num(crate::db::value::Num::Int(x)) => Some(*x as u32),
+                _ => None,
+            })
+            .unwrap_or(0)
+    };
+    let env_last = if with_env {
+        g(row.len().saturating_sub(1))
+    } else {
+        String::new()
+    };
+    crate::db::models::CodeElement {
+        qualified_name: g(0),
+        element_type: g(1),
+        name: g(2),
+        file_path: g(3),
+        line_start: n(4),
+        line_end: n(5),
+        language: g(6),
+        parent_qualified: (!g(7).is_empty()).then(|| g(7)),
+        cluster_id: (!g(8).is_empty()).then(|| g(8)),
+        cluster_label: (!g(9).is_empty()).then(|| g(9)),
+        metadata: serde_json::from_str(&g(10)).unwrap_or(serde_json::json!({})),
+        env: env_last,
+    }
+}
+
 impl DbBackend for SqliteBackend {
     fn run_script(
         &self,
@@ -1152,7 +1195,13 @@ impl DbBackend for SqliteBackend {
                 continue;
             }
             let cols = rows.headers.join(", ");
-            let mut script = format!("?[{cols}] <- [[");
+            // Rows arrive pre-bracketed (`[v1, v2, ...]`), so the data
+            // literal is `[ [row], [row], ... ]` — ONE bracket layer of
+            // wrapping. Emitting `[[` here produced `[[[row]]]`, and the
+            // Constant fixed rule then read arity from the wrong nesting
+            // level ("Fixed rule head arity mismatch") on every call —
+            // embed's vector import was its first real caller.
+            let mut script = format!("?[{cols}] <- [");
             for (i, row) in rows.rows.iter().enumerate() {
                 if i > 0 {
                     script.push_str(", ");
@@ -1160,7 +1209,7 @@ impl DbBackend for SqliteBackend {
                 let vals: Vec<String> = row.iter().map(datavalue_literal_cozo).collect();
                 script.push_str(&format!("[{}]", vals.join(", ")));
             }
-            script.push_str(format!("]] :insert {relation}").as_str());
+            script.push_str(format!("] :insert {relation}").as_str());
             run_script(&self.db, &script, Default::default())?;
         }
         Ok(())
@@ -1337,6 +1386,70 @@ impl DbBackend for SqliteBackend {
                 })
             })
             .collect())
+    }
+
+    /// Keyed lookup by `qualified_name` (Datalog port of the W8 wave-2
+    /// SQL-first read) — keeps the L3 ANN hydration path working on SQLite.
+    fn find_element_by_key(
+        &self,
+        qualified_name: &str,
+    ) -> Result<Option<crate::db::models::CodeElement>, Box<dyn std::error::Error>> {
+        let script = format!(
+            r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata] :=
+               *code_elements{{qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata}},
+               qualified_name = "{}""#,
+            qualified_name.replace(['"', '\\'], "")
+        );
+        let rows = run_script(&self.db, &script, Default::default())?;
+        Ok(rows
+            .rows
+            .first()
+            .map(|r| cozo_row_to_code_element(r, false)))
+    }
+
+    /// First row whose `name` matches exactly (legacy 11-col projection).
+    fn find_element_by_name_col(
+        &self,
+        name: &str,
+    ) -> Result<Option<crate::db::models::CodeElement>, Box<dyn std::error::Error>> {
+        let script = format!(
+            r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata] :=
+               *code_elements{{qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata}},
+               name = "{}"
+             :limit 1"#,
+            name.replace(['"', '\\'], "")
+        );
+        let rows = run_script(&self.db, &script, Default::default())?;
+        Ok(rows
+            .rows
+            .first()
+            .map(|r| cozo_row_to_code_element(r, false)))
+    }
+
+    /// Keyed hydration for a set of ANN hits (FR-SEM-07). `env` IS selected.
+    fn elements_by_qualified_names(
+        &self,
+        qualified_names: &[String],
+    ) -> Result<Vec<crate::db::models::CodeElement>, Box<dyn std::error::Error>> {
+        let esc = |s: &str| s.replace('\\', "\\\\").replace('"', "\\\"");
+        let mut out = Vec::with_capacity(qualified_names.len());
+        for chunk in qualified_names.chunks(500) {
+            let parts: Vec<String> = chunk
+                .iter()
+                .map(|qn| format!(r#"["{}", "{}"]"#, esc(qn), esc(qn)))
+                .collect();
+            let script = format!(
+                r#"want[qn, qn2] <- [[{}]]
+                   ?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env] :=
+                      want[qn, qn2],
+                      *code_elements{{qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata, env}},
+                      qualified_name = qn"#,
+                parts.join(", ")
+            );
+            let rows = run_script(&self.db, &script, Default::default())?;
+            out.extend(rows.rows.iter().map(|r| cozo_row_to_code_element(r, true)));
+        }
+        Ok(out)
     }
 
     fn search_knowledge_entries(

--- a/src/doctor/deep.rs
+++ b/src/doctor/deep.rs
@@ -279,7 +279,7 @@ impl BackendProbes {
 
 impl DeepProbes for BackendProbes {
     fn ping_ms(&self) -> Result<u64, String> {
-        const PROBE: &str = "?[id] := *migrations[id] :limit 1";
+        const PROBE: &str = "?[id] := *migrations{id} :limit 1";
         // Warm-up round trip: excludes lazy connect + TLS handshake from
         // the timed measurement so remote deployments report true
         // steady-state query latency, not one-time session setup.
@@ -294,15 +294,15 @@ impl DeepProbes for BackendProbes {
     }
 
     fn applied_migrations(&self) -> Result<Vec<String>, String> {
-        self.strings("?[id] := *migrations[id]")
+        self.strings("?[id] := *migrations{id}")
     }
 
     fn indexed_files(&self) -> Result<Vec<String>, String> {
-        self.strings("?[file_path] := *code_elements[file_path]")
+        self.strings("?[file_path] := *code_elements{file_path}")
     }
 
     fn qualified_names(&self) -> Result<Vec<String>, String> {
-        self.strings("?[qualified_name] := *code_elements[qualified_name]")
+        self.strings("?[qualified_name] := *code_elements{qualified_name}")
     }
 
     fn relationship_edges(&self) -> Result<Vec<(String, String, String)>, String> {
@@ -311,7 +311,7 @@ impl DeepProbes for BackendProbes {
             .run_script(
                 &format!(
                     "?[source_qualified, target_qualified, rel_type] := \
-                     *relationships[source_qualified, target_qualified, rel_type] :limit {ORPHAN_SAMPLE_LIMIT}"
+                     *relationships{{source_qualified, target_qualified, rel_type}} :limit {ORPHAN_SAMPLE_LIMIT}"
                 ),
                 BTreeMap::new(),
             )
@@ -329,7 +329,7 @@ impl DeepProbes for BackendProbes {
     }
 
     fn embedded_names(&self) -> Result<Option<Vec<String>>, String> {
-        match self.strings("?[qualified_name] := *embedding_state[qualified_name]") {
+        match self.strings("?[qualified_name] := *embedding_state{qualified_name}") {
             Ok(names) => Ok(Some(names)),
             Err(e) if table_absent(&e) => Ok(None),
             Err(e) => Err(e),

--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -1726,7 +1726,7 @@ pub(crate) fn count_vectors(
     // is handled by the translator, but COUNT is far cheaper here.
     let vectors_rel = active_vectors_relation()?;
     let result = db.run_script(
-        &format!("?[count(qn)] := *{vectors_rel}[qn]"),
+        &format!("?[count(qualified_name)] := *{vectors_rel}{{qualified_name}}"),
         Default::default(),
     )?;
     Ok(result
@@ -2006,7 +2006,7 @@ pub fn spawn_background_embed(
                             .db()
                             .run_script(
                                 &format!(
-                                    "?[qualified_name] := *{}[qualified_name]",
+                                    "?[qualified_name] := *{}{{qualified_name}}",
                                     active_vectors_relation().unwrap_or_default()
                                 ),
                                 std::collections::BTreeMap::new(),

--- a/src/embeddings/control.rs
+++ b/src/embeddings/control.rs
@@ -170,7 +170,7 @@ pub fn count_embedding_vectors(
 ) -> Result<usize, Box<dyn std::error::Error>> {
     let vectors_rel = crate::embeddings::registry::resolve_active_model()?.vectors_relation();
     let result = db.run_script(
-        &format!("?[qualified_name] := *{vectors_rel}[qualified_name]"),
+        &format!("?[qualified_name] := *{vectors_rel}{{qualified_name}}"),
         Default::default(),
     )?;
     Ok(result.rows.len())

--- a/src/mcp/tools.rs
+++ b/src/mcp/tools.rs
@@ -121,22 +121,52 @@ pub fn resolve_3tool(
     let mut inner = arguments.clone();
     let capability = match tool_name {
         TOOL_SET => {
-            let a = action_or_verb(&inner).unwrap_or_else(|| "mcp_index".to_string());
-            inner.remove("action");
+            let act = inner
+                .get("action")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let vrb = inner
+                .get("verb")
+                .and_then(|v| v.as_str())
+                .map(str::to_string);
+            let friendly = |a: &str| matches!(a, "index" | "incremental" | "attach" | "embed");
+            // Routing key: `action` when it names a capability or friendly
+            // alias; otherwise `verb` — which leaves `action` intact as the
+            // capability's own payload (control capabilities consume an
+            // `action` sub-command of their own: on|off|status).
+            let route = match (&act, &vrb) {
+                (Some(a), _) if is_valid_verb(a) || friendly(a) => a.clone(),
+                (_, Some(v)) if is_valid_verb(v) => v.clone(),
+                (Some(a), _) => a.clone(), // unknown → nearest-suggestion error
+                (None, Some(v)) => v.clone(),
+                (None, None) => "mcp_index".to_string(),
+            };
+            let routed_via_action = act.as_deref() == Some(route.as_str());
             inner.remove("verb");
-            if is_valid_verb(&a) {
-                a
-            } else if a == "index" || a == "incremental" || a == "attach" || a == "embed" {
-                match a.as_str() {
-                    "index" | "attach" | "incremental" => "mcp_index".to_string(),
-                    "embed" => "embed_control".to_string(),
-                    _ => a,
+            if routed_via_action {
+                inner.remove("action");
+            }
+            if route == "embed" {
+                // Friendly alias = arm the background builder (CLI
+                // `leankg embed` parity).
+                inner.insert("action".into(), serde_json::json!("on"));
+                "embed_control".to_string()
+            } else if is_valid_verb(&route) {
+                if (route == "embed_control" || route == "ontology_control")
+                    && !inner.contains_key("action")
+                {
+                    // No sub-command given: default to the read-only one,
+                    // never an implicit arm.
+                    inner.insert("action".into(), serde_json::json!("status"));
                 }
+                route
+            } else if friendly(&route) {
+                "mcp_index".to_string() // index | incremental | attach
             } else {
-                let nearest = nearest_verb_name(&a);
+                let nearest = nearest_verb_name(&route);
                 return Err(crate::errors::render(
                     crate::errors::UNKNOWN_TOOL.code,
-                    &format!("unknown set action '{a}'"),
+                    &format!("unknown set action '{route}'"),
                     &format!("use action \"{nearest}\" (nearest capability) or list actions in the set tool description"),
                 ));
             }
@@ -695,11 +725,33 @@ mod tests {
         assert_eq!(cap, "mcp_index");
         assert!(!inner.contains_key("action"));
 
-        // `set` friendly actions normalize to capabilities.
+        // `set` friendly actions normalize to capabilities; the friendly
+        // `embed` alias carries its sub-command through as the payload
+        // `action` so the background builder actually arms (regression:
+        // routing used to strip `action` and embed_control silently fell
+        // back to a status read).
         let mut args = Args::new();
         args.insert("action".into(), serde_json::json!("embed"));
-        let (cap, _) = resolve_3tool("set", &args).unwrap();
+        let (cap, inner) = resolve_3tool("set", &args).unwrap();
         assert_eq!(cap, "embed_control");
+        assert_eq!(inner["action"], "on");
+
+        // Direct control verbs keep their payload action intact: routing
+        // key via `verb`, sub-command via `action`.
+        let mut args = Args::new();
+        args.insert("verb".into(), serde_json::json!("embed_control"));
+        args.insert("action".into(), serde_json::json!("off"));
+        let (cap, inner) = resolve_3tool("set", &args).unwrap();
+        assert_eq!(cap, "embed_control");
+        assert_eq!(inner["action"], "off");
+
+        // Direct control verb without payload action defaults to `status`
+        // (read-only), never to an implicit arm.
+        let mut args = Args::new();
+        args.insert("verb".into(), serde_json::json!("embed_control"));
+        let (cap, inner) = resolve_3tool("set", &args).unwrap();
+        assert_eq!(cap, "embed_control");
+        assert_eq!(inner["action"], "status");
     }
 
     #[test]


### PR DESCRIPTION
## Changes
- `import_relations`: single bracket layer for Cozo :insert (was `[[[row]]]` — arity mismatch)
- `doctor --deep` probes: `*relation{col}` Cozo syntax fix
- `embeddings count_vectors`: proper column name
- 3-tool registry: set/get/status with per-tool action namespaces
- `cozo_row_to_code_element` helper for row→CodeElement mapping

## Verification
- 1333 lib tests green; clippy clean; fmt clean
- 9699 server restarted on SQLite with 3-tool surface