### PR TITLE
perf(retrieval): cache ONNX provider + shared rerank stage per process (#292)

### DIFF
--- a/src/retrieval/pipeline.rs
+++ b/src/retrieval/pipeline.rs
@@ -23,7 +23,7 @@ pub struct SemanticRetrievalPipeline {
     /// Active model's vectors relation (`embedding_vectors` for the default
     /// BGE model; `embedding_vectors_<model_id>` otherwise) — the ANN target.
     active_vectors_relation: String,
-    rerank_stage: RerankStage,
+    rerank_stage: std::sync::Arc<RerankStage>,
     db: SharedDb,
     /// Most recent query embedding from [`Self::retrieve`], stashed so
     /// downstream stages (e.g. ontology-guided composite scoring in
@@ -220,7 +220,8 @@ impl SemanticRetrievalPipeline {
         provider: Arc<dyn EmbedProvider>,
         vectors_relation: String,
     ) -> Result<Self, Box<dyn std::error::Error>> {
-        let rerank_stage = RerankStage::try_new();
+        let rerank_stage: std::sync::Arc<RerankStage> =
+            crate::retrieval::rerank::shared_rerank_stage().clone();
         Ok(Self {
             provider,
             active_vectors_relation: vectors_relation,
@@ -248,13 +249,40 @@ impl SemanticRetrievalPipeline {
             })?,
             None => crate::embeddings::registry::resolve_active_model()?,
         };
-        let provider = create_provider_for_entry(&entry)?;
+        // Process-global provider cache keyed by model id (#292): loading
+        // the ONNX session per request made every router query pay a
+        // multi-second init. The provider is Send+Sync and stateless w.r.t.
+        // projects — the DB handle stays per-request (passed in), so no
+        // cross-project leakage is possible. The vectors relation is
+        // derived from the same entry, so it is always consistent with the
+        // cached provider.
+        static PROVIDER_CACHE: std::sync::OnceLock<
+            std::sync::Mutex<std::collections::HashMap<String, Arc<dyn EmbedProvider>>>,
+        > = std::sync::OnceLock::new();
+        let cache = PROVIDER_CACHE.get_or_init(|| std::sync::Mutex::new(Default::default()));
+        let provider = {
+            let mut guard = cache.lock().unwrap_or_else(|e| e.into_inner());
+            match guard.get(&entry.model_id) {
+                Some(p) => p.clone(),
+                None => {
+                    let p = create_provider_for_entry(&entry)?;
+                    guard.insert(entry.model_id.clone(), p.clone());
+                    p
+                }
+            }
+        };
         let active_vectors_relation = entry.vectors_relation();
         Self::with_provider(db, provider, active_vectors_relation)
     }
 
     pub fn provider(&self) -> &dyn EmbedProvider {
         self.provider.as_ref()
+    }
+
+    /// Arc handle to the cached provider (for identity assertions in tests
+    /// and diagnostics).
+    pub fn provider_arc(&self) -> &Arc<dyn EmbedProvider> {
+        &self.provider
     }
 
     pub fn reranker_active(&self) -> bool {
@@ -470,6 +498,27 @@ fn truncate(s: &str, max_chars: usize) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Regression (#292): for_model must reuse the cached provider for the
+    /// same model id instead of loading a fresh ONNX session per request.
+    /// Two pipelines for the same model point at one provider instance
+    /// (cheap Arc clone), while a different db handle per call keeps the
+    /// pipeline per-project.
+    #[cfg(feature = "embeddings")]
+    #[test]
+    fn for_model_reuses_cached_provider_for_same_model() {
+        let db1: SharedDb = Arc::new(crate::db::fake::FakeBackend::new());
+        let db2: SharedDb = Arc::new(crate::db::fake::FakeBackend::new());
+        let p1 = SemanticRetrievalPipeline::for_model(db1, None).expect("pipeline 1");
+        let p2 = SemanticRetrievalPipeline::for_model(db2, None).expect("pipeline 2");
+        // Same provider instance (Arc::ptr_eq on the trait object).
+        assert!(
+            Arc::ptr_eq(p1.provider_arc(), p2.provider_arc(),),
+            "same model must share one cached provider"
+        );
+        // Different db handles (per-project isolation preserved).
+        assert!(!std::sync::Arc::ptr_eq(&p1.db, &p2.db));
+    }
 
     #[test]
     fn worktree_filter_matches_q2_patterns() {

--- a/src/retrieval/rerank.rs
+++ b/src/retrieval/rerank.rs
@@ -9,8 +9,21 @@ use crate::embeddings::{models::Reranker, RerankScore, RerankerStatus};
 /// Wraps an optional `Reranker`. Constructed once at pipeline startup; if
 /// construction fails, `inner` stays None and every `rerank` call returns
 /// `RerankerStatus::Fallback` with the input order unchanged.
+#[derive(Clone)]
 pub struct RerankStage {
-    inner: Option<Reranker>,
+    inner: std::sync::Arc<Option<Reranker>>,
+}
+
+/// Process-global shared cross-encoder stage. Loading `Reranker::new()`
+/// downloads/loads the ONNX cross-encoder — doing that per request made
+/// every router query pay a multi-second init (#292). One instance is
+/// shared by every pipeline in the process; `RerankStage::rerank` is
+/// `&self` and the inner fastembed reranker is internally synchronized.
+pub fn shared_rerank_stage() -> std::sync::Arc<RerankStage> {
+    static SHARED: std::sync::OnceLock<std::sync::Arc<RerankStage>> = std::sync::OnceLock::new();
+    SHARED
+        .get_or_init(|| std::sync::Arc::new(RerankStage::try_new()))
+        .clone()
 }
 
 impl RerankStage {
@@ -18,13 +31,17 @@ impl RerankStage {
     /// works, just without Stage 3.
     pub fn try_new() -> Self {
         match Reranker::new() {
-            Ok(r) => Self { inner: Some(r) },
+            Ok(r) => Self {
+                inner: std::sync::Arc::new(Some(r)),
+            },
             Err(e) => {
                 tracing::warn!(
                     "reranker load failed; pipeline will run in ANN-only fallback mode: {}",
                     e
                 );
-                Self { inner: None }
+                Self {
+                    inner: std::sync::Arc::new(None),
+                }
             }
         }
     }
@@ -43,7 +60,7 @@ impl RerankStage {
         documents: Vec<String>,
     ) -> (Vec<RerankScore>, RerankerStatus) {
         let n = documents.len();
-        let Some(reranker) = &self.inner else {
+        let Some(reranker) = &*self.inner else {
             return (ann_order(n), RerankerStatus::Fallback);
         };
         match reranker.rerank(query, documents) {


### PR DESCRIPTION
Fixes #292 — router `get` queries paid a multi-second ONNX session load per request (~16s vs <100ms direct `search_code` in the leankg-vs-rg benchmark, `benchmark/grep_vs_leankg/report.md`).

**Changes:**
- `for_model`: process-global provider cache keyed by model id. The ONNX embedder (`DirectEmbedder` session) is loaded once per model and the `Arc<dyn EmbedProvider>` is cloned per request. The DB handle remains per-request (passed in), so there is no cross-project leakage.
- `RerankStage`: one shared cross-encoder instance per process (`shared_rerank_stage()`); `RerankStage` now holds `Arc<Option<Reranker>>` and derives `Clone`.

**Regression test:** `for_model_reuses_cached_provider_for_same_model` (embeddings-gated) — two pipelines for the same model must share one provider instance (`Arc::ptr_eq`) while keeping separate DB handles.

**Known pre-existing:** 5 failures in the `--features embeddings` build, reproduced identical on a clean tree before this change (unrelated modules: sqlite import test fixture, offsite/inventory/handler ONNX fixtures). Will file as its own issue — CI's default-features Test Suite is green.

Local: `cargo test --lib` 1337/0; fmt + clippy clean.