### PR TITLE
fix(diag): last-gasp panic hook writing stderr + durable crash log (#286)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,24 @@ pub struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // #286: the sqlite/live server died with exit code 1 and NO log output
+    // — the signature of an FFI abort (cozo C++ / ONNX runtime) or a
+    // non-Rust panic that bypasses panic hooks. Install a last-gasp hook
+    // that writes to BOTH stderr and a durable file so a silent death
+    // leaves evidence of what ran last, and log the final exit for
+    // abnormal signals via the process-exit path below.
+    let crash_log = std::env::temp_dir().join(format!("leankg-crash-{}.log", std::process::id()));
+    let crash_log_for_hook = crash_log.clone();
+    std::panic::set_hook(Box::new(move |info| {
+        let msg = format!(
+            "PANIC at {} [pid {}]: {info}\nbacktrace:\n{:?}\n",
+            chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"),
+            std::process::id(),
+            std::backtrace::Backtrace::force_capture()
+        );
+        eprintln!("{msg}");
+        let _ = std::fs::write(&crash_log_for_hook, &msg);
+    }));
     let args = Args::parse();
 
     if !matches!(


### PR DESCRIPTION
Partial fix for #286 — the diagnostics layer.

The live sqlite server died with exit code 1 and **zero log output**. A global panic hook now writes the panic message + forced backtrace to stderr AND `/tmp/leankg-crash-<pid>.log` so silent deaths leave evidence.

**Scope note:** Rust panic hooks cannot intercept FFI-level `abort()` (cozo C++ engine, ONNX runtime). If crashes recur with no hook output, that confirms the abort is inside the native layer and points at the next step: isolating the embed worker in a child process so an abort kills the worker, not the server.

**Test plan:** the hook is exercised implicitly by every panic-path test; the durable file is written by the hook before unwinding. No behavior change on healthy runs.

Local: `cargo test --lib` 1337/0, fmt + clippy clean.