### PR TITLE
fix(indexer): stale-element sweep — remove elements for files that dropped out of the collection set (#308)

### DIFF
--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -3616,6 +3616,27 @@ impl GraphEngine {
             .unwrap_or(0) as usize)
     }
 
+    /// All distinct file_paths currently in code_elements (#308 stale-element
+    /// sweep input: the incremental sync diffs this set against the
+    /// collection set and bulk-removes anything the collector no longer
+    /// returns — e.g. files excluded by a new default, or deleted between
+    /// git-diff windows).
+    pub fn list_indexed_file_paths(&self) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+        let tail = self.code_elements_tail();
+        let query = format!(
+            r#"files[f] := *code_elements[n, a, b, f, c, d, e, g, h, i, j{tail}]
+?[f] := files[f]"#
+        );
+        let result = self
+            .db
+            .run_script(&query, std::collections::BTreeMap::new())?;
+        Ok(result
+            .rows
+            .iter()
+            .filter_map(|r| r.first().and_then(|v| v.get_str().map(String::from)))
+            .collect())
+    }
+
     pub fn count_files(&self) -> Result<usize, Box<dyn std::error::Error>> {
         let tail = self.code_elements_tail();
         let query = format!(

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -421,10 +421,16 @@ pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Er
         let ext_lower = ext.to_lowercase();
         let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
-        let is_valid_file = config_files.contains(&file_name)
-            || (path.to_string_lossy().contains("/res/") && ext == "xml")
-            || extensions.contains(&ext_lower.as_str())
-            || is_cicd_yaml_file(path);
+        // #291: minified/vendor bundles (vis-network.min.js et al.) are
+        // indexed and embedded otherwise — thousands of 1-2 char
+        // identifiers dominate ANN hits and pollute the vector space.
+        let is_minified = is_minified_asset(path);
+
+        let is_valid_file = !is_minified
+            && (config_files.contains(&file_name)
+                || (path.to_string_lossy().contains("/res/") && ext == "xml")
+                || extensions.contains(&ext_lower.as_str())
+                || is_cicd_yaml_file(path));
 
         if is_valid_file {
             files.push(path.to_string_lossy().to_string());
@@ -432,6 +438,18 @@ pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Er
     }
 
     Ok(files)
+}
+
+/// #291: minified/vendor bundles (`.min.js`, generated asset copies) are
+/// excluded from indexing — their 1-2 char identifiers pollute the ANN
+/// vector space and outrank real code.
+fn is_minified_asset(path: &Path) -> bool {
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if file_name.contains(".min.") {
+        return true;
+    }
+    let s = path.to_string_lossy();
+    s.contains("/src/embed/")
 }
 
 fn is_default_ignored_entry(root: &Path, path: &Path) -> bool {
@@ -2884,6 +2902,34 @@ mod tests {
     }
 
     #[test]
+    /// Regression (#291): minified/vendor bundles must be skipped at
+    /// collection time — vis-network.min.js was indexed and embedded, and
+    /// its 1-2 char identifiers dominated ANN hits (see
+    /// benchmark/grep_vs_leankg).
+    #[test]
+    fn test_minified_and_embed_assets_are_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let cases = [
+            ("src/embed/vis-network.min.js", true),
+            ("ui-v2/public/vis-network.min.js", true),
+            ("ui/dist/app.min.js", true),
+            ("src/mcp/tools.rs", false),
+            ("ui-v2/src/main.ts", false),
+        ];
+        for (rel, want_skip) in cases {
+            let abs = root.join(&rel);
+            if let Some(parent) = abs.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&abs, "var a=1;").unwrap();
+            let got = is_minified_asset(&abs);
+            assert_eq!(got, want_skip, "path {rel}: skip={want_skip}");
+            let _ = root.join(&rel);
+        }
+        let _ = &root;
+    }
+
     fn test_default_index_ignored_dirs_covers_common_build_dirs() {
         // Regression guard: the default exclude set must keep growing to cover
         // common monorepo build outputs, otherwise the indexer drags in

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -2930,6 +2930,7 @@ mod tests {
         let _ = &root;
     }
 
+    #[test]
     fn test_default_index_ignored_dirs_covers_common_build_dirs() {
         // Regression guard: the default exclude set must keep growing to cover
         // common monorepo build outputs, otherwise the indexer drags in

--- a/src/indexer/mod.rs
+++ b/src/indexer/mod.rs
@@ -421,10 +421,16 @@ pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Er
         let ext_lower = ext.to_lowercase();
         let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
 
-        let is_valid_file = config_files.contains(&file_name)
-            || (path.to_string_lossy().contains("/res/") && ext == "xml")
-            || extensions.contains(&ext_lower.as_str())
-            || is_cicd_yaml_file(path);
+        // #291: minified/vendor bundles (vis-network.min.js et al.) are
+        // indexed and embedded otherwise — thousands of 1-2 char
+        // identifiers dominate ANN hits and pollute the vector space.
+        let is_minified = is_minified_asset(path);
+
+        let is_valid_file = !is_minified
+            && (config_files.contains(&file_name)
+                || (path.to_string_lossy().contains("/res/") && ext == "xml")
+                || extensions.contains(&ext_lower.as_str())
+                || is_cicd_yaml_file(path));
 
         if is_valid_file {
             files.push(path.to_string_lossy().to_string());
@@ -432,6 +438,18 @@ pub fn find_files_sync(root: &str) -> Result<Vec<String>, Box<dyn std::error::Er
     }
 
     Ok(files)
+}
+
+/// #291: minified/vendor bundles (`.min.js`, generated asset copies) are
+/// excluded from indexing — their 1-2 char identifiers pollute the ANN
+/// vector space and outrank real code.
+fn is_minified_asset(path: &Path) -> bool {
+    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+    if file_name.contains(".min.") {
+        return true;
+    }
+    let s = path.to_string_lossy();
+    s.contains("/src/embed/")
 }
 
 fn is_default_ignored_entry(root: &Path, path: &Path) -> bool {
@@ -1923,6 +1941,39 @@ pub async fn incremental_index_sync(
         }
     }
 
+    // #308 stale-element sweep: the bulk-rm above only covers files touched
+    // by the git diff. Files that dropped out of the COLLECTION set (e.g. a
+    // new default exclude, or a file deleted outside a git window) keep
+    // their elements forever. Diff the indexed set against a fresh walk and
+    // remove anything the collector no longer returns.
+    match graph.list_indexed_file_paths() {
+        Ok(indexed_paths) => {
+            let collected: std::collections::HashSet<String> = match find_files_sync(root_path) {
+                Ok(f) => f.into_iter().collect(),
+                Err(e) => {
+                    tracing::warn!("stale-element sweep skipped: find_files failed: {e}");
+                    Default::default()
+                }
+            };
+            let stale: Vec<String> = indexed_paths
+                .into_iter()
+                .filter(|p| !collected.contains(p))
+                .collect();
+            if !stale.is_empty() {
+                tracing::info!(
+                    "stale-element sweep: removing {} orphaned files",
+                    stale.len()
+                );
+                if let Err(e) = graph.remove_elements_by_files_bulk(&stale) {
+                    tracing::warn!("stale-element sweep bulk remove failed: {}", e);
+                }
+                if let Err(e) = graph.remove_relationships_by_files_bulk(&stale) {
+                    tracing::warn!("stale-element sweep relationship rm failed: {}", e);
+                }
+            }
+        }
+        Err(e) => tracing::warn!("stale-element sweep skipped: list indexed paths failed: {e}"),
+    }
     // Inventory refresh: scans every code_elements + relationships row, so
     // do it ONCE at the end of the batch rather than per file.
     if let Err(e) = crate::graph::inventory::refresh_index_inventory(graph, "code_index") {
@@ -2884,6 +2935,34 @@ mod tests {
     }
 
     #[test]
+    /// Regression (#291): minified/vendor bundles must be skipped at
+    /// collection time — vis-network.min.js was indexed and embedded, and
+    /// its 1-2 char identifiers dominated ANN hits (see
+    /// benchmark/grep_vs_leankg).
+    #[test]
+    fn test_minified_and_embed_assets_are_skipped() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let root = tmp.path().to_path_buf();
+        let cases = [
+            ("src/embed/vis-network.min.js", true),
+            ("ui-v2/public/vis-network.min.js", true),
+            ("ui/dist/app.min.js", true),
+            ("src/mcp/tools.rs", false),
+            ("ui-v2/src/main.ts", false),
+        ];
+        for (rel, want_skip) in cases {
+            let abs = root.join(&rel);
+            if let Some(parent) = abs.parent() {
+                std::fs::create_dir_all(parent).unwrap();
+            }
+            std::fs::write(&abs, "var a=1;").unwrap();
+            let got = is_minified_asset(&abs);
+            assert_eq!(got, want_skip, "path {rel}: skip={want_skip}");
+            let _ = root.join(&rel);
+        }
+        let _ = &root;
+    }
+
     fn test_default_index_ignored_dirs_covers_common_build_dirs() {
         // Regression guard: the default exclude set must keep growing to cover
         // common monorepo build outputs, otherwise the indexer drags in


### PR DESCRIPTION
Fixes #308.

The incremental sync's bulk-rm only covered git-diff-touched files. Files that fell out of the collection set (e.g. #291's minified-asset rule) kept their elements forever: re-indexing this repo after #291 dropped vis-network.min.js from collection but its elements survived, so `search_code` kept returning vendor rows on existing projects.

**Changes:**
- `GraphEngine::list_indexed_file_paths()` — distinct file_paths over code_elements
- `incremental_index_sync`: after the bulk-rm, diff indexed paths against a fresh `find_files_sync` walk and bulk-remove orphans (elements + relationships); both arms log-and-continue on failure
- Stacks on #304's excludes (this branch includes them — merge #304 or this supersedes it for the indexer)

Local: `cargo test --lib` 1338/0, fmt + clippy clean.