### PR TITLE
fix(tests): make the --features embeddings test build green (#302)

### DIFF
--- a/benchmark/grep_vs_leankg/report.md
+++ b/benchmark/grep_vs_leankg/report.md
@@ -63,3 +63,11 @@
 - Remaining merge queue: #298 → #301 → #303 → #304 → #305 (independent; #305 diagnostics-only, merge first if you want crash evidence).
 - After merging #301 + #304: re-index + re-embed this repo, then re-run the benchmark — first clean-corpus validation of embeddings (#291) and the latency delta for #292 are both captured then.
 - Stash handoff: `stash@{0}` (b3402076) = another session's graft-docs WIP; restore on `docs/graft-vs-leankg-analysis`.
+
+## Post-merge delta (main @ 063bccdb, all 5 fix PRs merged, 2026-09-08)
+- Latency: router query 6.07s cold → 2.48s warm (was 14-31s per query pre-#301). #301 confirmed; residual is fuse_l2 + hydration, not model load.
+- Exact-symbol: rung=exact, real `create_hnsw_index`, vendor absent (#298 + #290 closed).
+- Vendor excludes: 578 files collected (was 581); `predefinedPosition` search no longer returns vis-network rows (#291/#304).
+- Ranking: `mcp_status` router query — fr_zcp02_* test fns no longer dominate (#303/#307).
+- Embeddings on clean corpus: re-embed 12,984/12,984 vectors post-re-index — first clean validation.
+- Remaining open: #286 (crash — #305 hook live, no reproduction since), #300-followups (PRD AC wording), #302 (embeddings CI job), #308-followups (relationship-sweep gap noted in review), #309-followups (audit export/verify PG-only).

--- a/src/db/fake.rs
+++ b/src/db/fake.rs
@@ -930,15 +930,27 @@ fn parse_join_block(body: &str, primary: &str) -> Option<(String, Vec<PatCol>, S
 /// `*rel[qualified_name, element_type, ...]` -> (rel, pattern cols).
 fn parse_relation_block(body: &str) -> Result<(String, Vec<PatCol>), Box<dyn std::error::Error>> {
     let body = body.trim();
-    let (rel, rest) = body
-        .strip_prefix('*')
-        .and_then(|r| {
-            let (rel, rest) = r.split_once('[')?;
-            Some((rel.to_string(), rest))
-        })
-        .ok_or_else(|| fake_err("rule body must start with *relation[...]"))?;
-
-    let inner = rest.split_once(']').map(|(i, _)| i).unwrap_or(rest);
+    // Accept BOTH binding forms: positional `*rel[a, b]` and attribute
+    // `*rel{a, b}` — raw cozo accepts only the latter for some shapes and
+    // embeddings-gated scripts use the attribute form, so the fake must
+    // parse it too (attribute cols end at `}`; filters follow outside).
+    let (rel, inner) = if let Some(rest) = body.strip_prefix('*') {
+        if let Some((rel, rest)) = rest.split_once('[') {
+            let inner = rest.split_once(']').map(|(i, _)| i).unwrap_or(rest);
+            (rel.to_string(), inner.to_string())
+        } else if let Some((rel, rest)) = rest.split_once('{') {
+            let inner = rest
+                .split_once('}')
+                .map(|(i, _)| i)
+                .unwrap_or(rest)
+                .to_string();
+            (rel.to_string(), inner)
+        } else {
+            return Err(fake_err("rule body must start with *relation[...]"));
+        }
+    } else {
+        return Err(fake_err("rule body must start with *relation[...]"));
+    };
     let mut pat_cols = Vec::new();
     // Split on commas, but keep `{tail}` and `...` markers.
     for part in inner.split(',') {

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -5414,7 +5414,7 @@ mod tests {
         assert_eq!(v["rejected_reason"], "below-confidence-floor");
         let fb = semantic_low_confidence("cart", true);
         assert_eq!(fb["rejected_reason"], "reranker-fallback");
-        assert!(fb["hint"].as_str().unwrap().contains("search_code"));
+        assert!(fb["hint"].as_str().unwrap().contains("leankg_context"));
     }
 
     #[test]


### PR DESCRIPTION
Closes #302 (4 of the 5 failures; the 5th, import_relations_upserts_duplicate_keys, was fixed in #308's round).

**Root causes:**
- `FakeBackend`'s script parser only accepted positional `*rel[a,b]` — embeddings-gated scripts use the attribute form `*rel{a,b}` (required by raw cozo). `parse_relation_block` now accepts both, scoping attribute cols to the closing `}` so trailing filters still parse.
- `low_confidence_payload_is_empty_page` asserted a hint containing `search_code` — stale since the 3-tool rename moved the suggestion to `leankg_context`.

**Note:** default-features CI never compiled these tests; an embeddings-feature CI job (cacheable ONNX) would prevent this class of rot.

Local: `cargo test --lib` 1343/0, `--features embeddings` 1527/0, fmt + clippy clean.