### PR TITLE
fix(audit): dispatch audit export/verify to sqlite backend (#309 follow-up)

### DIFF
--- a/src/db/backend.rs
+++ b/src/db/backend.rs
@@ -3505,6 +3505,12 @@ pub fn init_db_readonly_strict(
 pub fn init_db_readonly_audit(
     db_path: &std::path::Path,
 ) -> Result<SharedDb, Box<dyn std::error::Error>> {
+    // #309 follow-up: sqlite projects store the audit ledger in their own
+    // .leankg/leankg.db — dispatch there before hitting the PG path.
+    if crate::db::backend::sqlite_backend_requested() {
+        let db = crate::db::sqlite_backend::open_shared(db_path, true)?;
+        return Ok(db);
+    }
     init_db_readonly_probed(db_path, "audit_log", "audit ledger")
 }
 

--- a/src/db/sqlite_backend.rs
+++ b/src/db/sqlite_backend.rs
@@ -1346,7 +1346,80 @@ impl DbBackend for SqliteBackend {
             .and_then(|r| r.get(1).and_then(|v| v.get_str().map(String::from))))
     }
 
+    /// FR-ENT-1: windowed ledger read for `leankg audit export|verify` on
+    /// sqlite (#309 follow-up). ts is stored as unix-nanos INTEGER; since/
+    /// until filters compare the same way.
+    fn query_audit(
+        &self,
+        since: Option<std::time::SystemTime>,
+        until: Option<std::time::SystemTime>,
+    ) -> Result<Vec<crate::audit::AuditEntry>, Box<dyn std::error::Error>> {
+        let mut clauses = Vec::new();
+        if let Some(t) = since {
+            let nanos = t
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as i64)
+                .unwrap_or(0);
+            clauses.push(format!("ts >= {}", nanos));
+        }
+        if let Some(t) = until {
+            let nanos = t
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos() as i64)
+                .unwrap_or(i64::MAX);
+            clauses.push(format!("ts <= {}", nanos));
+        }
+        let filter = if clauses.is_empty() {
+            String::new()
+        } else {
+            format!(", {}", clauses.join(", "))
+        };
+        let script = format!(
+            r#"?[id, ts, actor, agent_client, tool, project, args_hash, result_status, prev_hash, entry_hash] :=
+               *audit_log{{id, ts, actor, agent_client, tool, project, args_hash, result_status, prev_hash, entry_hash}}{}
+            :sort id"#,
+            filter
+        );
+        let rows = run_script(&self.db, &script, Default::default())?;
+        Ok(rows
+            .rows
+            .iter()
+            .filter_map(|row| {
+                let id = row.first().and_then(|v| match v {
+                    crate::db::value::DataValue::Num(crate::db::value::Num::Int(i)) => Some(*i),
+                    _ => None,
+                })?;
+                let g = |i: usize| {
+                    row.get(i)
+                        .and_then(|v| match v {
+                            crate::db::value::DataValue::Str(s) => Some(s.to_string()),
+                            _ => None,
+                        })
+                        .unwrap_or_default()
+                };
+                let ts_nanos = row.get(1).and_then(|v| match v {
+                    crate::db::value::DataValue::Num(crate::db::value::Num::Int(i)) => Some(*i),
+                    _ => None,
+                })?;
+                Some(crate::audit::AuditEntry {
+                    id,
+                    ts: std::time::UNIX_EPOCH
+                        + std::time::Duration::from_nanos(ts_nanos.max(0) as u64),
+                    actor: g(2),
+                    agent_client: g(3),
+                    tool: g(4),
+                    project: (!g(5).is_empty()).then(|| g(5)),
+                    args_hash: g(6),
+                    result_status: g(7),
+                    prev_hash: g(8),
+                    entry_hash: g(9),
+                })
+            })
+            .collect())
+    }
+
     // Knowledge CRUD on Cozo relations — same Datalog the pre-v0.20 codebase
+    // ran natively; SQLite storage just persists it to the .db file.    // Knowledge CRUD on Cozo relations — same Datalog the pre-v0.20 codebase
     // ran natively; SQLite storage just persists it to the .db file.
     fn upsert_knowledge_entry(
         &self,


### PR DESCRIPTION
Completes the FR-ENT-1 audit story on sqlite (recording landed in #312):

- `SqliteBackend::query_audit` — windowed ledger read (since/until as unix-nanos filters, `*audit_log{...}` attribute form, sorted by id) so `leankg audit export` and `audit verify` work on sqlite projects
- `init_db_readonly_audit` dispatches to sqlite's `open_shared(ro)` before the PG probe path when the session is sqlite-backed

Previously both commands failed at open time on sqlite projects (PG-only `init_db_readonly_probed`).

Local: `cargo test --lib` 1344/0, fmt + clippy clean.