### PR TITLE
fix(graph): cozo-safe single-quoted regex literals in relationship sweep

### DIFF
--- a/src/db/fake.rs
+++ b/src/db/fake.rs
@@ -978,8 +978,50 @@ fn is_string_literal(s: &str) -> bool {
     s.starts_with('"') || s.starts_with('\'')
 }
 
+/// Decode a cozo string literal per the pest grammar (cozoscript.pest):
+/// both quote styles share the same escape set — \' \" \\ \/ \b \f \n
+/// \r \t and \uXXXX. Keeping this faithful matters: unit tests pin
+/// FakeBackend semantics, and real cozo REJECTS any other backslash
+/// sequence outright (e.g. `\.` is a parse error, not a literal dot).
 fn unescape_str(s: &str) -> String {
-    s.trim_matches('"').trim_matches('\'').to_string()
+    let (quote, inner) = match s.chars().next() {
+        Some('"') if s.ends_with('"') && s.len() >= 2 => ('"', &s[1..s.len() - 1]),
+        Some('\'') if s.ends_with('\'') && s.len() >= 2 => ('\'', &s[1..s.len() - 1]),
+        _ => return s.to_string(),
+    };
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c != '\\' {
+            out.push(c);
+            continue;
+        }
+        match chars.next() {
+            Some(e @ ('\'' | '"' | '\\' | '/')) => out.push(e),
+            Some('b') => out.push('\u{0008}'),
+            Some('f') => out.push('\u{000C}'),
+            Some('n') => out.push('\n'),
+            Some('r') => out.push('\r'),
+            Some('t') => out.push('\t'),
+            Some('u') => {
+                let hex: String = chars.by_ref().take(4).collect();
+                if let Some(cp) = u32::from_str_radix(&hex, 16).ok().and_then(char::from_u32) {
+                    out.push(cp);
+                }
+            }
+            other => {
+                // Real cozo is a parse error here; the fake mirrors the
+                // rejection by emitting the sequence verbatim (callers see
+                // a no-match rather than a silent reinterpretation).
+                out.push('\\');
+                if let Some(e) = other {
+                    out.push(e);
+                }
+            }
+        }
+    }
+    let _ = quote;
+    out
 }
 
 fn parse_head(q: &str) -> Result<Vec<String>, Box<dyn std::error::Error>> {

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -2309,14 +2309,19 @@ impl GraphEngine {
         // "/xa/by".
         for f in file_paths {
             let pattern = format!("^{}", regex::escape(f));
+            // Cozo 0.7.6 rejects \" inside double-quoted string literals
+            // (pest grammar), so interpolate as a SINGLE-quoted literal with
+            // \' escaping — file paths containing quotes or backslashes must
+            // not make the whole script unparseable.
+            let literal = pattern.replace('\\', "\\\\").replace('\'', "\\'");
             let script = format!(
                 r#"
             ?[source_qualified, target_qualified, rel_type, confidence, metadata, env] :=
                 *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
-                regex_matches(source_qualified, "{}")
+                regex_matches(source_qualified, '{}')
             :rm relationships {{source_qualified, target_qualified, rel_type, confidence, metadata, env}}
         "#,
-                pattern.replace('"', "\\")
+                literal
             );
             self.db.run_script(&script, Default::default())?;
         }
@@ -6388,6 +6393,47 @@ mod tests {
     /// must match relationships by FILE PREFIX (source_qualified starts
     /// with the file path), not exact-match on the raw path — swept
     /// files' relationships were previously left orphaned.
+    /// Cozo 0.7.6 rejects \" inside double-quoted literals — paths with
+    /// quote characters must still be matchable (single-quoted literal
+    /// with \' escaping).
+    #[test]
+    fn remove_relationships_by_files_bulk_handles_quotes_in_paths() {
+        let (engine, _tmp) = make_test_engine();
+        let tricky = "/a/we\"ird'named.rs";
+        engine
+            .insert_relationships(&[
+                Relationship {
+                    id: None,
+                    source_qualified: format!("{tricky}::f"),
+                    target_qualified: "/b/x.rs::g".into(),
+                    rel_type: "imports".into(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({}),
+                    env: "local".into(),
+                },
+                Relationship {
+                    id: None,
+                    source_qualified: "/c/keep.rs::h".into(),
+                    target_qualified: "/b/y.rs::g".into(),
+                    rel_type: "imports".into(),
+                    confidence: 1.0,
+                    metadata: serde_json::json!({}),
+                    env: "local".into(),
+                },
+            ])
+            .unwrap();
+        engine
+            .remove_relationships_by_files_bulk(&[tricky.to_string()])
+            .expect("script must parse despite quotes in the path");
+        let (remaining, _total) = engine.get_relationships_paginated(10, 0).unwrap();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "only /c/keep.rs relationship should remain: {remaining:?}"
+        );
+        assert_eq!(remaining[0].source_qualified, "/c/keep.rs::h");
+    }
+
     #[test]
     fn remove_relationships_by_files_bulk_matches_by_file_prefix() {
         let (engine, _tmp) = make_test_engine();


### PR DESCRIPTION
Closes the last cozo-grammar trap in `remove_relationships_by_files_bulk` (#321-adjacent hardening, same class as #307's hydration quote-escape).

**Bug:** the anchored regex was interpolated into a **double-quoted** cozo literal with `.replace('"', '\\')` — but cozo 0.7.6's pest grammar rejects `\\"` inside double-quoted literals entirely (only `\\\\ \/ \b \f \n \r \t \uXXXX` are valid). Any swept file path containing a double quote made the whole `:rm` script unparseable → the sweep silently failed and orphaned relationships survived.

**Fix:** single-quoted literals with `\'` escaping (same scheme `datavalue_literal_cozo` already emits), with backslash doubled (`\\\\`) because single-quoted literals decode `\\\\` → `\\` — a regex needing `\\.` must be written `\\\\.`.

**FakeBackend faithfulness:** `unescape_str` now decodes the real cozo escape set for both quote styles instead of trim-only, so unit tests exercise the grammar semantics real cozo delivers.

**Tests:**
- new `remove_relationships_by_files_bulk_handles_quotes_in_paths` — a path containing both `"` and `'` is swept correctly
- existing prefix-match regression still green
- live-verified against a real sqlite DB: quote-bearing relationship inserted and swept by the new literal form (previously a parse error)

Local: `cargo test --lib` 1346/0, fmt + clippy clean.