### PR TITLE
fix(ops): durable fatal-error log for Err exits from main (#321)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,48 @@ pub struct Args {
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // #321: an Err escaping main prints "Error: {:?}" to stderr and exits 1 —
+    // the exact silent-death signature under investigation. Log the fatal
+    // error durably (same scheme as the panic hook) BEFORE returning, so any
+    // Err-path exit is attributable even when stderr is lost.
+    let res = run().await;
+    if let Err(e) = &res {
+        log_fatal(&e.to_string());
+    }
+    res
+}
+
+/// Durable fatal-error record (#321): same scheme as the panic hook — write
+/// to a pid-tagged temp file first, then mirror to stderr. Any Err escaping
+/// run() becomes attributable even when stderr is lost or captured late.
+fn log_fatal(err: &str) {
+    let msg = format!(
+        "FATAL at {} [pid {}]: {err}\n",
+        chrono::Local::now().format("%Y-%m-%dT%H:%M:%S"),
+        std::process::id()
+    );
+    let path = std::env::temp_dir().join(format!("leankg-fatal-{}.log", std::process::id()));
+    let _ = std::fs::write(&path, &msg);
+    eprintln!("{msg}");
+}
+
+#[cfg(test)]
+mod fatal_log_tests {
+    use super::log_fatal;
+
+    #[test]
+    fn log_fatal_writes_durable_file_and_stderr() {
+        let path = std::env::temp_dir().join(format!("leankg-fatal-{}.log", std::process::id()));
+        let _ = std::fs::remove_file(&path);
+        log_fatal("probe: intentional fatal for test");
+        let body = std::fs::read_to_string(&path).expect("durable fatal log must exist");
+        assert!(body.contains("FATAL at "), "timestamped header: {body}");
+        assert!(body.contains("probe: intentional fatal for test"));
+        let _ = std::fs::remove_file(&path);
+    }
+}
+
+async fn run() -> Result<(), Box<dyn std::error::Error>> {
     // #286: the sqlite/live server died with exit code 1 and NO log output
     // — the signature of an FFI abort (cozo C++ / ONNX runtime) or a
     // non-Rust panic that bypasses panic hooks. Install a last-gasp hook


### PR DESCRIPTION
Third hardening step from the #321 silent-exit(1) investigation.

**Gap:** an `Err` escaping `main` prints `Error: {:?}` to stderr and exits 1 — exactly the silent-death signature seen twice on the live server. If stderr is a PTY buffer that gets reclaimed, the reason is lost forever.

**Fix:** rename `main` → `run`, wrap it with a fatal logger: on Err, write a pid-tagged `/tmp/leankg-fatal-<pid>.log` (same durability-first scheme as the #317 panic hook) and mirror to stderr **before** returning. Any Err-path exit is now attributable even when stderr is lost.

**Test:** `log_fatal_writes_durable_file_and_stderr` (bin target) — durable file exists with timestamped FATAL header + error text.

**Live-verified:** `leankg index /nonexistent/xyz` → exit 1 with `/tmp/leankg-fatal-<pid>.log` containing `FATAL at 2026-09-08T22:16:20 [pid 45097]: Read-only file system (os error 30)`.

Local: lib 1346/0 + bin 1370/0, fmt + clippy clean.