### PR TITLE
fix(ci): scale-harness tools/list assertion matches the 3-tool surface

### DIFF
--- a/scripts/scale_harness.sh
+++ b/scripts/scale_harness.sh
@@ -182,8 +182,11 @@ lines=[l[6:] for l in raw.splitlines() if l.startswith('data: ')]
 print(lines[-1] if lines else '{}')"; }
 
 TOOLS=$(curl -s -m 10 -X POST "$MCP" "${HDR[@]}" -d '{"jsonrpc":"2.0","id":1,"method":"tools/list"}' | sse_json \
-  | python3 -c "import json,sys; print(len(json.load(sys.stdin).get('result',{}).get('tools',[])))" 2>/dev/null)
-[ "${TOOLS:-0}" -eq 1 ] && ok "one-tool registry live at scale" || bad "tools/list returned '$TOOLS'"
+  | python3 -c "import json,sys; print(','.join(sorted(t['name'] for t in json.load(sys.stdin).get('result',{}).get('tools',[]))))" 2>/dev/null)
+# #283 3-tool surface: read-only mode hides the write set + `set`, exposing
+# exactly {get, status}. leankg_context stays callable via tools/call (the
+# verb queries below) even though it is not listed.
+[ "${TOOLS:-}" = "get,status" ] && ok "read-only tool registry live at scale (get,status)" || bad "tools/list returned '${TOOLS:-<none>}', expected 'get,status'"
 
 SEARCH=$(curl -s -m 10 -X POST "$MCP" "${HDR[@]}" -d '{"jsonrpc":"2.0","id":2,"method":"tools/call","params":{"name":"leankg_context","arguments":{"verb":"search_code","query":"op_0","project":"'"$FIXTURE"'"}}}' | sse_json \
   | python3 -c "import json,sys,re; d=json.load(sys.stdin); t=d.get('result',{}).get('content',[{}])[0].get('text','') if 'error' not in d else 'ERR'; m=re.search(r'count: (\d+)',t); print(m.group(1) if m else t[:60])" 2>/dev/null)


### PR DESCRIPTION
**Root cause of the failing perf-gate on main** (every push since #283): the scale harness still asserts `tools/list` returns exactly **1** tool — written for the pre-`leankg_context`→3-tool transition surface. Since #283's 3-tool surface (set/get/status), **read-only mode exposes exactly `{get, status}`** (the write set and `set` are hidden by `is_ro_hidden_tool`), so the gate fails with `FAIL tools/list returned '2'` while all 12 other checks pass — 8+ consecutive red runs on main.

**Fix:** assert the current contract by NAME, not count: `get,status` — precise against future surface changes and self-documenting. `leankg_context` remains callable via `tools/call` (the verb-envelope checks already prove it; none of them changed).

**Local verification:**
- Live RO server (sqlite, `--read-only`): `tools/list` == `['get','status']`
- Full `scripts/scale_harness.sh` run against pgvector/pg16 scratch DB: **13 passed, 0 failed** (index 3329 elements, nested discovery, noise skip, incremental reindex, mega-mode refusal, RSS bounded)