### PR TITLE
fix(perf): batch doc-join resolution + bounded temporal_query (#257, #256)

### DIFF
--- a/src/db/fake.rs
+++ b/src/db/fake.rs
@@ -8,7 +8,7 @@
 //!
 //! Subset served:
 //! - `?[cols] <- $batch_data :put rel { cols }` and `<- [[...]]` literal rows
-//! - `?[cols] := *rel[...]` with equality / param / `or` / `regex_matches` /
+//! - `?[cols] := *rel[...]` with equality / param / `or` / `regex_matches` / `is_in` /
 //!   `lowercase` filters, `{tail}` column suffix, `:limit` / `:offset`
 //! - `?[node, count(node)] := *rel[...]` aggregate reads
 //! - `:rm rel { pk }` / `:rm rel` (delete all) / `:delete rel where ...`
@@ -1379,7 +1379,14 @@ fn apply_filters(
             continue;
         }
 
-        // Negation: `!regex_matches(col, "pat")`.
+        // Negation: `not <expr>` (cozo not_op) or the legacy
+        // `!regex_matches(col, "pat")` shorthand.
+        let c = if let Some(rest) = c.strip_prefix("not ") {
+            format!("!{}", rest.trim())
+        } else {
+            c.to_string()
+        };
+        let c = c.as_str();
         if c.starts_with('!') {
             let rest = c[1..].trim_start();
             if rest.contains("regex_matches") {
@@ -1399,6 +1406,40 @@ fn apply_filters(
                     .collect();
                 continue;
             }
+        }
+
+        // `is_in(col, $param)` / `is_in(col, ["a", "b"])` — list membership
+        // (cozo is_in op; mirrors the real grammar's is_in builtin).
+        if let Some(inner) = c.strip_prefix("is_in(").and_then(|s| s.strip_suffix(')')) {
+            let (col, list_src) = inner
+                .split_once(',')
+                .ok_or_else(|| fake_err("is_in needs (col, list)"))?;
+            let col_idx = resolve_col_idx(col.trim(), cols, pat_cols)
+                .ok_or_else(|| fake_err(&format!("is_in col {} not found", col.trim())))?;
+            let list_src = list_src.trim();
+            let values: Vec<serde_json::Value> = if let Some(p) = list_src.strip_prefix('$') {
+                match params.get(p.trim()) {
+                    Some(serde_json::Value::Array(items)) => items.clone(),
+                    _ => {
+                        return Err(fake_err(&format!("is_in param ${p} missing or not a list")));
+                    }
+                }
+            } else {
+                match serde_json::from_str(list_src) {
+                    Ok(serde_json::Value::Array(items)) => items,
+                    _ => return Err(fake_err("is_in list must be a JSON array or $param")),
+                }
+            };
+            let wanted: Vec<DataValue> = values.iter().map(json_to_dv).collect();
+            out = out
+                .into_iter()
+                .filter(|row| {
+                    row.get(col_idx)
+                        .map(|v| wanted.contains(v))
+                        .unwrap_or(false)
+                })
+                .collect();
+            continue;
         }
 
         // `str_includes(lowercase(col), "pat")` — case-insensitive substring.

--- a/src/db/models.rs
+++ b/src/db/models.rs
@@ -253,6 +253,15 @@ pub struct CodeElement {
     pub env: String,
 }
 
+/// #256: bounded temporal_query response — `items` capped, `total` for
+/// pagination, `as_of` echoed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TemporalQueryResult {
+    pub as_of: i64,
+    pub total_relationships: usize,
+    pub items: Vec<Relationship>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Relationship {
     #[serde(skip)]

--- a/src/doc_indexer/mod.rs
+++ b/src/doc_indexer/mod.rs
@@ -44,11 +44,123 @@ fn doc_max_code_refs() -> usize {
         .unwrap_or(25)
 }
 
+/// #257: batch-resolved code-ref context. The doc join used to fire 2-6
+/// sequential sync round-trips PER unique ref (name-lookup + per-candidate
+/// path probes + per-file symbol fanout); over a high-RTT remote Postgres a
+/// docs tree turned into thousands of serialized round-trips — the >320s
+/// hang. The resolver pre-loads every candidate in O(kinds) batched queries
+/// (`is_in` list params) and answers lookups from memory.
+pub struct RefResolver {
+    /// exact symbol name -> elements with that name
+    by_name: std::collections::HashMap<String, Vec<CodeElement>>,
+    /// stored file_path -> elements in that file
+    by_file: std::collections::HashMap<String, Vec<CodeElement>>,
+    /// straggler fallback (prefix-match resolutions the maps cannot answer);
+    /// Arc clone — no extra open.
+    graph: GraphEngine,
+    /// memoized raw_ref -> resolved (per-process, mirrors FR-DOCJOIN-CACHE)
+    cache: std::cell::RefCell<std::collections::HashMap<String, Option<String>>>,
+}
+
+impl RefResolver {
+    /// Build from one batched query per kind. `names` = symbol names mentioned
+    /// by refs (`file.rs::sym`), `file_paths` = file part + whole-ref file
+    /// candidates (already normalized by the caller).
+    pub fn load(
+        graph: &GraphEngine,
+        names: &[String],
+        file_paths: &[String],
+    ) -> Result<Self, Box<dyn std::error::Error>> {
+        let by_name = graph.find_elements_by_names_exact(names)?;
+        let by_file = graph.get_elements_by_files(file_paths)?;
+        Ok(Self {
+            by_name,
+            by_file,
+            graph: graph.clone(),
+            cache: std::cell::RefCell::new(Default::default()),
+        })
+    }
+
+    /// Resolve one raw ref: batch map first, prefix-match straggler
+    /// fallback through the graph (memoized) second — same results as the
+    /// per-ref path, ~O(1) round-trips overall.
+    pub fn resolve(&self, raw_ref: &str) -> Option<String> {
+        if let Some(hit) = self.cache.borrow().get(raw_ref) {
+            return hit.clone();
+        }
+        let resolved = match crate::doc_indexer::paths::resolve_code_ref_with(self, raw_ref) {
+            Some(qn) => Some(qn),
+            None => crate::doc_indexer::paths::resolve_code_ref(&self.graph, raw_ref),
+        };
+        self.cache
+            .borrow_mut()
+            .insert(raw_ref.to_string(), resolved.clone());
+        resolved
+    }
+
+    pub fn elements_by_name(&self, name: &str) -> Option<&[CodeElement]> {
+        self.by_name.get(name).map(|v| v.as_slice())
+    }
+
+    pub fn elements_by_file(&self, file_path: &str) -> Option<&[CodeElement]> {
+        self.by_file.get(file_path).map(|v| v.as_slice())
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct DocIndexResult {
     pub documents: Vec<CodeElement>,
     pub sections: Vec<CodeElement>,
     pub relationships: Vec<Relationship>,
+}
+
+/// #257: one regex-only pre-pass over the docs tree to collect every code
+/// ref, then ONE batched preload (2 is_in queries). Local file reads only —
+/// no database round-trips in this phase.
+fn build_resolver_for_walk(
+    graph: &GraphEngine,
+    docs_path: &Path,
+) -> Result<RefResolver, Box<dyn std::error::Error>> {
+    let indexer = DocIndexer::new(graph.db_arc().clone());
+    let mut refs: std::collections::BTreeSet<String> = Default::default();
+    for entry in WalkDir::new(docs_path)
+        .follow_links(false)
+        .into_iter()
+        .filter_map(|e| e.ok())
+    {
+        let path = entry.path();
+        if !path.is_file() || path.is_symlink() {
+            continue;
+        }
+        let is_md = path
+            .extension()
+            .and_then(|e| e.to_str())
+            .map(|e| matches!(e, "md" | "markdown" | "mdown" | "mkd"))
+            .unwrap_or(false);
+        if !is_md {
+            continue;
+        }
+        if let Ok(meta) = std::fs::metadata(path) {
+            if meta.len() > doc_max_file_size() {
+                continue;
+            }
+        } else {
+            continue;
+        }
+        if let Ok(content) = std::fs::read_to_string(path) {
+            for (r, _) in indexer.extract_code_references(&content) {
+                refs.insert(r);
+            }
+        }
+    }
+    // Cap per-doc refs at extraction: the per-file pass only resolves up to
+    // doc_max_code_refs() refs per doc, so preloading more per doc is waste.
+    // We cannot know doc boundaries here cheaply — preload ALL unique refs
+    // (bounded: the whole tree's unique ref count is far below per-doc caps
+    // multiplied out) and let the per-doc cap apply during resolution.
+    let refs: Vec<String> = refs.into_iter().collect();
+    let (names, files) = crate::doc_indexer::paths::collect_ref_preload_keys(&refs);
+    RefResolver::load(graph, &names, &files)
 }
 
 pub struct DocIndexer {
@@ -85,6 +197,21 @@ impl DocIndexer {
             });
         }
 
+        // #257: pre-load the code-ref resolver so the per-file pass below
+        // answers every lookup from memory (2 batched is_in queries for the
+        // whole tree) instead of 2-6 sync round-trips per unique ref — the
+        // remote-Postgres >320s doc-join hang.
+        let resolver = match graph {
+            Some(g) => match build_resolver_for_walk(g, docs_path) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    tracing::warn!("doc-join resolver preload failed: {e}; using per-ref lookups");
+                    None
+                }
+            },
+            None => None,
+        };
+
         for entry in WalkDir::new(docs_path)
             // FR-INDEX-NO-HANG: don't follow symlinks (cycles hang the walk).
             .follow_links(false)
@@ -119,7 +246,7 @@ impl DocIndexer {
                                 continue;
                             }
                         }
-                        match self.parse_doc_file(path, docs_path, graph) {
+                        match self.parse_doc_file(path, docs_path, graph, resolver.as_ref()) {
                             Ok((doc, secs, rels, _children)) => {
                                 documents.push(doc);
                                 sections.extend(secs);
@@ -210,6 +337,7 @@ impl DocIndexer {
         path: &Path,
         docs_root: &Path,
         graph: Option<&GraphEngine>,
+        resolver: Option<&RefResolver>,
     ) -> Result<
         (
             CodeElement,
@@ -273,26 +401,63 @@ impl DocIndexer {
         // budget so a single doc can't blow the 10-min index budget on
         // thousands of database queries.
         for (target, context) in code_refs.into_iter().take(cap) {
-            let resolved_target = match graph {
-                Some(g) => match resolve_code_ref(g, &target) {
+            // #257: resolver-backed first (in-memory), per-ref graph probe
+            // as fallback for misses (rare: refs the preload keys cannot
+            // answer, e.g. prefix-match stragglers).
+            let resolved_target = match resolver {
+                Some(r) => match r.resolve(&target) {
                     Some(qn) => {
                         if qn != target {
                             resolved_count += 1;
                         }
                         qn
                     }
-                    None => {
-                        skipped_count += 1;
-                        tracing::debug!(
-                            target: "leankg::docjoin",
-                            doc = %qualified_name,
-                            raw_ref = %target,
-                            "doc join: unresolved markdown code ref"
-                        );
-                        continue;
-                    }
+                    None => match graph {
+                        Some(g) => match resolve_code_ref(g, &target) {
+                            Some(qn) => {
+                                if qn != target {
+                                    resolved_count += 1;
+                                }
+                                qn
+                            }
+                            None => {
+                                skipped_count += 1;
+                                tracing::debug!(
+                                    target: "leankg::docjoin",
+                                    doc = %qualified_name,
+                                    raw_ref = %target,
+                                    "doc join: unresolved markdown code ref"
+                                );
+                                continue;
+                            }
+                        },
+                        None => {
+                            skipped_count += 1;
+                            continue;
+                        }
+                    },
                 },
-                None => target.clone(),
+                None => match graph {
+                    Some(g) => match resolve_code_ref(g, &target) {
+                        Some(qn) => {
+                            if qn != target {
+                                resolved_count += 1;
+                            }
+                            qn
+                        }
+                        None => {
+                            skipped_count += 1;
+                            tracing::debug!(
+                                target: "leankg::docjoin",
+                                doc = %qualified_name,
+                                raw_ref = %target,
+                                "doc join: unresolved markdown code ref"
+                            );
+                            continue;
+                        }
+                    },
+                    None => target.clone(),
+                },
             };
 
             // FR-SEM-08 per-symbol fanout: capture the set of
@@ -302,28 +467,51 @@ impl DocIndexer {
             // docs that reference large files. Sorted by line_start so
             // the earliest definitions (most-likely-relevant) win when
             // the cap kicks in.
-            let per_symbol_targets: Vec<String> = match graph {
-                Some(g) => g
-                    .get_elements_by_file(&resolved_target)
-                    .ok()
-                    .map(|syms| {
-                        let mut fns: Vec<_> = syms
-                            .into_iter()
-                            .filter(|e| {
-                                matches!(
-                                    e.element_type.as_str(),
-                                    "function" | "method" | "constructor"
-                                )
-                            })
-                            .collect();
-                        fns.sort_by_key(|e| e.line_start);
-                        fns.into_iter()
-                            .take(PER_SYMBOL_FANOUT_CAP)
-                            .map(|e| e.qualified_name)
-                            .collect()
-                    })
-                    .unwrap_or_default(),
-                None => Vec::new(),
+            // #257: fanout reads from the batch map when possible (same
+            // semantics: the resolved target is a file path).
+            let per_symbol_targets: Vec<String> = match resolver
+                .and_then(|r| r.elements_by_file(&resolved_target))
+                .map(|syms| {
+                    let mut fns: Vec<CodeElement> = syms
+                        .iter()
+                        .filter(|e| {
+                            matches!(
+                                e.element_type.as_str(),
+                                "function" | "method" | "constructor"
+                            )
+                        })
+                        .cloned()
+                        .collect();
+                    fns.sort_by_key(|e| e.line_start);
+                    fns.into_iter()
+                        .take(PER_SYMBOL_FANOUT_CAP)
+                        .map(|e| e.qualified_name)
+                        .collect()
+                }) {
+                Some(v) => v,
+                None => match graph {
+                    Some(g) => g
+                        .get_elements_by_file(&resolved_target)
+                        .ok()
+                        .map(|syms| {
+                            let mut fns: Vec<_> = syms
+                                .into_iter()
+                                .filter(|e| {
+                                    matches!(
+                                        e.element_type.as_str(),
+                                        "function" | "method" | "constructor"
+                                    )
+                                })
+                                .collect();
+                            fns.sort_by_key(|e| e.line_start);
+                            fns.into_iter()
+                                .take(PER_SYMBOL_FANOUT_CAP)
+                                .map(|e| e.qualified_name)
+                                .collect()
+                        })
+                        .unwrap_or_default(),
+                    None => Vec::new(),
+                },
             };
 
             let snippet: String = context.chars().take(100).collect();
@@ -824,6 +1012,71 @@ pub fn index_docs_directory(
 
 #[cfg(test)]
 mod tests {
+
+    use super::*;
+
+    fn file_element(qn: &str) -> CodeElement {
+        CodeElement {
+            qualified_name: qn.into(),
+            element_type: "file".into(),
+            name: qn.into(),
+            file_path: qn.into(),
+            language: "rust".into(),
+            ..Default::default()
+        }
+    }
+
+    fn fn_element(qn: &str, name: &str, line: u32) -> CodeElement {
+        CodeElement {
+            qualified_name: qn.into(),
+            element_type: "function".into(),
+            name: name.into(),
+            file_path: qn.split("::").next().unwrap().into(),
+            line_start: line,
+            language: "rust".into(),
+            ..Default::default()
+        }
+    }
+
+    fn engine_with_elements() -> (GraphEngine, tempfile::TempDir) {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = crate::db::backend::init_db(&tmp.path().join("db")).unwrap();
+        let g = GraphEngine::new(db);
+        g.insert_elements(&[
+            file_element("./src/handler.rs"),
+            fn_element("./src/handler.rs::handle_req", "handle_req", 10),
+            file_element("src/unique.rs"),
+        ])
+        .unwrap();
+        (g, tmp)
+    }
+
+    /// #257: batch-loaded resolver must resolve identically to the per-ref
+    /// graph path (decision-tree parity), including the prefix-match
+    /// straggler fallback.
+    #[test]
+    fn batch_resolver_matches_single_lookups() {
+        let (g, _tmp) = engine_with_elements();
+        let (names, files) = crate::doc_indexer::paths::collect_ref_preload_keys(&[
+            "handler.rs::handle_req".into(),
+            "unique.rs".into(),
+            "./src/missing.rs".into(),
+        ]);
+        let resolver = RefResolver::load(&g, &names, &files).unwrap();
+        for q in [
+            "handler.rs::handle_req",
+            "unique.rs",
+            "./src/missing.rs",
+            "handler.rs",
+        ] {
+            assert_eq!(
+                resolve_code_ref(&g, q),
+                resolver.resolve(q),
+                "parity for {q}"
+            );
+        }
+    }
+
     use super::*;
     // Serialize env-var tests; std::env is not thread-safe.
     static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());

--- a/src/doc_indexer/paths.rs
+++ b/src/doc_indexer/paths.rs
@@ -522,3 +522,152 @@ mod tests {
         );
     }
 }
+
+// ============================================================================
+// #257: batch-resolved variants. The `*_with` fns mirror the graph-backed
+// logic above but answer from a pre-loaded [`super::RefResolver`]; anything
+// the maps cannot answer returns None (the caller may fall back to the
+// per-ref graph path for correctness on rare misses).
+// ============================================================================
+
+/// Resolve using the batch-loaded maps. Mirrors resolve_code_ref_uncached's
+/// decision tree: file::symbol upgrade when the symbol is unique AND its
+/// file matches the mention; otherwise file-level resolution.
+pub fn resolve_code_ref_with(resolver: &super::RefResolver, raw_ref: &str) -> Option<String> {
+    if let Some((file_part, sym_part)) = split_file_symbol(raw_ref) {
+        if let Some(symbols) = resolver.elements_by_name(&sym_part) {
+            let code_syms: Vec<_> = symbols
+                .iter()
+                .filter(|e| is_code_symbol(&e.element_type))
+                .collect();
+            if code_syms.len() == 1 {
+                let el = code_syms[0];
+                if file_matches_mention(&el.file_path, &file_part) {
+                    return Some(el.qualified_name.clone());
+                }
+            }
+        }
+        if let Some(file_qn) = resolve_file_ref_with(resolver, &file_part) {
+            return Some(file_qn);
+        }
+    }
+    resolve_file_ref_with(resolver, raw_ref)
+}
+
+/// File-level resolution from the batch maps.
+pub fn resolve_file_ref_with(resolver: &super::RefResolver, raw_ref: &str) -> Option<String> {
+    let candidates = code_ref_path_candidates(raw_ref);
+    for path in &candidates {
+        if let Some(file_qn) = lookup_file_by_path_with(resolver, path) {
+            return Some(file_qn);
+        }
+    }
+
+    if !raw_ref.contains('/') {
+        return resolve_basename_file_with(resolver, raw_ref);
+    }
+
+    let normalized = slash_normalize(&strip_anchor(raw_ref));
+    if let Some(file_path) = lookup_file_by_symbol_suffix_with(resolver, &normalized) {
+        return Some(file_path);
+    }
+    None
+}
+
+fn lookup_file_by_path_with(resolver: &super::RefResolver, path: &str) -> Option<String> {
+    let normalized = slash_normalize(&strip_anchor(path));
+    for fp in path_match_endings(&normalized) {
+        if let Some(elements) = resolver.elements_by_file(&fp) {
+            if let Some(file_elem) = elements.iter().find(|e| e.element_type == "file") {
+                return Some(file_elem.qualified_name.clone());
+            }
+            if let Some(file_path) = unique_file_path_from_elements(elements) {
+                return Some(file_path);
+            }
+        }
+    }
+    None
+}
+
+fn resolve_basename_file_with(resolver: &super::RefResolver, basename: &str) -> Option<String> {
+    let name = slash_normalize(&strip_anchor(basename));
+    if name.is_empty() || name.contains('/') {
+        return None;
+    }
+    if let Some(files) = resolver.elements_by_name(&name) {
+        let file_elems: Vec<_> = files.iter().filter(|e| e.element_type == "file").collect();
+        let unique_paths: HashSet<_> = file_elems.iter().map(|e| e.file_path.clone()).collect();
+        if file_elems.len() == 1 && unique_paths.len() == 1 {
+            return file_elems[0].qualified_name.clone().into();
+        }
+    }
+    lookup_file_by_symbol_suffix_with(resolver, &name)
+}
+
+fn lookup_file_by_symbol_suffix_with(
+    resolver: &super::RefResolver,
+    normalized: &str,
+) -> Option<String> {
+    let stem = Path::new(normalized)
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .filter(|s| !s.is_empty())?;
+    let endings = path_match_endings(normalized);
+    let elems = resolver.elements_by_name(stem)?;
+    let matching: Vec<crate::db::models::CodeElement> = elems
+        .iter()
+        .filter(|e| e.element_type == "function")
+        .filter(|e| {
+            endings
+                .iter()
+                .any(|end| e.file_path == *end || e.file_path.ends_with(end))
+        })
+        .cloned()
+        .collect();
+    if matching.is_empty() {
+        return None;
+    }
+    unique_file_path_from_elements(&matching)
+}
+
+/// Collect every name/file-path string the resolver should pre-load for a
+/// set of raw refs (one is_in query per kind afterwards).
+pub fn collect_ref_preload_keys(refs: &[String]) -> (Vec<String>, Vec<String>) {
+    let mut names: std::collections::BTreeSet<String> = Default::default();
+    let mut files: std::collections::BTreeSet<String> = Default::default();
+    for raw in refs {
+        let cleaned = slash_normalize(&strip_anchor(raw));
+        if let Some((file_part, sym_part)) = split_file_symbol(raw) {
+            names.insert(sym_part);
+            for c in code_ref_path_candidates(&file_part) {
+                names.insert(
+                    Path::new(&slash_normalize(&strip_anchor(&c)))
+                        .file_stem()
+                        .and_then(|s| s.to_str())
+                        .unwrap_or_default()
+                        .to_string(),
+                );
+                for fp in path_match_endings(&slash_normalize(&strip_anchor(&c))) {
+                    files.insert(fp);
+                }
+            }
+        }
+        for c in code_ref_path_candidates(&cleaned) {
+            names.insert(
+                Path::new(&slash_normalize(&strip_anchor(&c)))
+                    .file_stem()
+                    .and_then(|s| s.to_str())
+                    .unwrap_or_default()
+                    .to_string(),
+            );
+            for fp in path_match_endings(&slash_normalize(&strip_anchor(&c))) {
+                files.insert(fp);
+            }
+        }
+        if !raw.contains('/') {
+            names.insert(cleaned.clone());
+        }
+    }
+    names.retain(|n| !n.is_empty());
+    (names.into_iter().collect(), files.into_iter().collect())
+}

--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -1,8 +1,8 @@
 #![allow(clippy::needless_borrow)]
 use crate::db::backend::{DbBackend, SharedDb};
 use crate::db::models::{
-    BusinessLogic, CodeElement, DependencyInfo, DocLink, Incident, Relationship, TraceabilityEntry,
-    TraceabilityReport,
+    BusinessLogic, CodeElement, DependencyInfo, DocLink, Incident, Relationship,
+    TemporalQueryResult, TraceabilityEntry, TraceabilityReport,
 };
 use crate::graph::cache::QueryCache;
 use serde::{Deserialize, Serialize};
@@ -3016,6 +3016,81 @@ impl GraphEngine {
         self.run_element_query(&query)
     }
 
+    /// #257 (remote-PG RTT batching): exact-name lookup for a WHOLE BATCH of
+    /// names in one `is_in` query — the doc join resolves dozens of refs per
+    /// docs tree; per-name round-trips over a high-RTT link are the >320s
+    /// hang. Returns name -> elements (possibly several per name).
+    pub fn find_elements_by_names_exact(
+        &self,
+        names: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<CodeElement>>, Box<dyn std::error::Error>>
+    {
+        let mut out: std::collections::HashMap<String, Vec<CodeElement>> =
+            std::collections::HashMap::new();
+        if names.is_empty() {
+            return Ok(out);
+        }
+        let tail = self.code_elements_tail();
+        let query = format!(
+            r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata]
+               := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata{tail}],
+              is_in(name, $names)"#,
+            tail = tail,
+        );
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "names".to_string(),
+            serde_json::Value::Array(
+                names
+                    .iter()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
+        );
+        for el in self.run_element_query_with_params(&query, params)? {
+            out.entry(el.name.clone()).or_default().push(el);
+        }
+        Ok(out)
+    }
+
+    /// #257: file-path batch lookup in one `is_in` query — pairs with
+    /// [`Self::find_elements_by_names_exact`] to make the doc join
+    /// O(queries-per-kind) instead of O(refs).
+    pub fn get_elements_by_files(
+        &self,
+        file_paths: &[String],
+    ) -> Result<std::collections::HashMap<String, Vec<CodeElement>>, Box<dyn std::error::Error>>
+    {
+        let mut out: std::collections::HashMap<String, Vec<CodeElement>> =
+            std::collections::HashMap::new();
+        if file_paths.is_empty() {
+            return Ok(out);
+        }
+        let tail = self.code_elements_tail();
+        let query = format!(
+            r#"?[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata]
+               := *code_elements[qualified_name, element_type, name, file_path, line_start, line_end, language, parent_qualified, cluster_id, cluster_label, metadata{tail}],
+              is_in(file_path, $fps)"#,
+            tail = tail,
+        );
+        let mut params = std::collections::BTreeMap::new();
+        params.insert(
+            "fps".to_string(),
+            serde_json::Value::Array(
+                file_paths
+                    .iter()
+                    .cloned()
+                    .map(serde_json::Value::String)
+                    .collect(),
+            ),
+        );
+        for el in self.run_element_query_with_params(&query, params)? {
+            out.entry(el.file_path.clone()).or_default().push(el);
+        }
+        Ok(out)
+    }
+
     /// FR-ONT-MEGA-01: keyed file-path prefix lookup (no `all_elements()`).
     pub fn find_elements_by_file_path_prefix(
         &self,
@@ -5530,14 +5605,97 @@ impl GraphEngine {
     pub fn temporal_query(
         &self,
         at_epoch: i64,
-    ) -> Result<Vec<Relationship>, Box<dyn std::error::Error>> {
-        let rels = self.all_relationships()?;
-        Ok(rels
+        limit: usize,
+    ) -> Result<TemporalQueryResult, Box<dyn std::error::Error>> {
+        // #256: the old path pulled ALL relationships (all_relationships →
+        // deprecated full-scan + a secondary-index build whose result is
+        // thrown away) and filtered in Rust. On a remote PG over a
+        // high-RTT link that is the >300s hang. Dedicated bounded queries:
+        //   * always-live set: no temporal keys in metadata at all (capped)
+        //   * temporal set: metadata mentions valid_from/valid_to
+        // items = up to `limit` rows; total counts come from :group counters.
+        let always_q = format!(
+            r#"?[source_qualified, target_qualified, rel_type, confidence, metadata] :=
+               *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
+               not regex_matches(metadata, 'valid_(from|to)')
+            :limit {}"#,
+            limit
+        );
+        let always_count_q = r#"?[count(source_qualified)] :=
+               *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
+               not regex_matches(metadata, 'valid_(from|to)')"#;
+        let temporal_q = r#"?[source_qualified, target_qualified, rel_type, confidence, metadata] :=
+               *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
+               regex_matches(metadata, 'valid_(from|to)')"#;
+        let temporal_count_q = r#"?[count(source_qualified)] :=
+               *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
+               regex_matches(metadata, 'valid_(from|to)')"#;
+        let always = self.run_relationship_query(&always_q)?;
+        let always_total = self
+            .db
+            .run_script(always_count_q, std::collections::BTreeMap::new())?
+            .rows
+            .first()
+            .and_then(|r| r.first().and_then(|v| v.get_int()))
+            .unwrap_or(0) as usize;
+        let temporal = self.run_relationship_query(&temporal_q)?;
+        let temporal_total = self
+            .db
+            .run_script(temporal_count_q, std::collections::BTreeMap::new())?
+            .rows
+            .first()
+            .and_then(|r| r.first().and_then(|v| v.get_int()))
+            .unwrap_or(0) as usize;
+
+        let live: Vec<Relationship> = always
             .into_iter()
             .filter(|r| {
-                let valid_from = Self::valid_from(r).unwrap_or(0);
-                let valid_to = Self::valid_to(r).unwrap_or(i64::MAX);
-                valid_from <= at_epoch && at_epoch <= valid_to
+                let vf = Self::valid_from(r).unwrap_or(0);
+                let vt = Self::valid_to(r).unwrap_or(i64::MAX);
+                vf <= at_epoch && at_epoch <= vt
+            })
+            .collect();
+        let temporal_valid: Vec<Relationship> = temporal
+            .into_iter()
+            .filter(|r| {
+                let vf = Self::valid_from(r).unwrap_or(0);
+                let vt = Self::valid_to(r).unwrap_or(i64::MAX);
+                vf <= at_epoch && at_epoch <= vt
+            })
+            .collect();
+        // Fill the page with temporal-valid edges after the always-live ones.
+        let temporal_stale = temporal_total - temporal_valid.len();
+        let mut items = live;
+        let take = limit.saturating_sub(items.len());
+        items.extend(temporal_valid.into_iter().take(take));
+        Ok(TemporalQueryResult {
+            as_of: at_epoch,
+            total_relationships: always_total + temporal_total - temporal_stale,
+            items,
+        })
+    }
+
+    /// Bounded relationship fetch used by #256's temporal_query — no
+    /// secondary-index build, no cache pollution, no deprecation warning.
+    fn run_relationship_query(
+        &self,
+        query: &str,
+    ) -> Result<Vec<Relationship>, Box<dyn std::error::Error>> {
+        let result = self
+            .db
+            .run_script(query, std::collections::BTreeMap::new())?;
+        Ok(result
+            .rows
+            .iter()
+            .map(|row| Relationship {
+                id: None,
+                source_qualified: row[0].get_str().unwrap_or("").to_string(),
+                target_qualified: row[1].get_str().unwrap_or("").to_string(),
+                rel_type: row[2].get_str().unwrap_or("").to_string(),
+                confidence: row[3].get_float().unwrap_or(1.0),
+                metadata: serde_json::from_str(row[4].get_str().unwrap_or("{}"))
+                    .unwrap_or(serde_json::json!({})),
+                ..Default::default()
             })
             .collect())
     }
@@ -6307,6 +6465,73 @@ fn chrono_unix() -> i64 {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
+    /// #256: temporal_query must be bounded — dedicated queries instead of
+    /// the deprecated all_relationships full-scan, items capped at `limit`,
+    /// total counts from SQL group counters.
+    #[test]
+    fn temporal_query_is_bounded_and_correct() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let db = crate::db::backend::init_db(&tmp.path().join("db")).unwrap();
+        let g = GraphEngine::new(db);
+        let mut elems = Vec::new();
+        for i in 0..7 {
+            elems.push(crate::db::models::CodeElement {
+                qualified_name: format!("f{i}.rs"),
+                element_type: "file".into(),
+                name: format!("f{i}"),
+                file_path: format!("f{i}.rs"),
+                language: "rust".into(),
+                ..Default::default()
+            });
+        }
+        g.insert_elements(&elems).unwrap();
+        let mk = |s: &str, t: &str, md: serde_json::Value| Relationship {
+            id: None,
+            source_qualified: s.into(),
+            target_qualified: t.into(),
+            rel_type: "calls".into(),
+            confidence: 1.0,
+            metadata: md,
+            env: "local".into(),
+        };
+        let rels = vec![
+            mk("f0.rs", "f1.rs", serde_json::json!({})),
+            mk("f1.rs", "f2.rs", serde_json::json!({})),
+            mk("f2.rs", "f3.rs", serde_json::json!({})),
+            mk("f3.rs", "f4.rs", serde_json::json!({})),
+            mk("f4.rs", "f5.rs", serde_json::json!({})),
+            mk(
+                "f5.rs",
+                "f6.rs",
+                serde_json::json!({"valid_from": 100, "valid_to": 200}),
+            ),
+            mk("f6.rs", "f0.rs", serde_json::json!({"valid_from": 300})),
+        ];
+        g.insert_relationships(&rels).unwrap();
+
+        let r = g.temporal_query(150, 3).unwrap();
+        assert_eq!(r.as_of, 150);
+        assert_eq!(
+            r.total_relationships, 6,
+            "5 always-live + 1 temporal-valid at t=150"
+        );
+        assert_eq!(r.items.len(), 3, "limit 3");
+        assert!(
+            r.items.iter().all(|x| x.source_qualified != "f6.rs"),
+            "temporal-invalid edge excluded"
+        );
+
+        let r2 = g.temporal_query(150, 1000).unwrap();
+        assert_eq!(r2.items.len(), 6, "high limit returns everything live");
+        // t=350: the first temporal edge (100..200) is invalid, the second
+        // (valid_from 300) is live.
+        let r3 = g.temporal_query(350, 1000).unwrap();
+        assert_eq!(r3.total_relationships, 6);
+        assert!(r3.items.iter().any(|x| x.source_qualified == "f6.rs"));
+    }
+
     use super::*;
     use crate::db::backend::init_db;
     use crate::db::models::CodeElement;

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -1371,14 +1371,23 @@ impl ToolHandler {
             return Ok(refusal);
         }
         let at = args["at"].as_i64().ok_or("Missing 'at' (epoch seconds)")?;
-        let rels = self
+        // #256: bounded response — the default limit keeps the payload sane
+        // over high-RTT remote Postgres; `limit` opts into more.
+        let limit = args
+            .get("limit")
+            .and_then(|v| v.as_u64())
+            .map(|v| (v as usize).min(1000))
+            .unwrap_or(100);
+        let result = self
             .graph_engine
-            .temporal_query(at)
+            .temporal_query(at, limit)
             .map_err(|e| e.to_string())?;
         Ok(json!({
-            "at": at,
-            "count": rels.len(),
-            "relationships": rels,
+            "at": result.as_of,
+            "count": result.total_relationships,
+            "returned": result.items.len(),
+            "has_more": result.total_relationships > result.items.len(),
+            "relationships": result.items,
         }))
     }
 


### PR DESCRIPTION
Both fixes target the **remote-Postgres high-RTT hang class**: synchronous per-item DB round-trips that serialize into minutes over a WAN link.

## #257 — add_documentation >320s hang

The doc join fired **2-6 sequential sync round-trips per unique code ref** (`find_elements_by_name_exact` + per-candidate file-path probes + per-file symbol fanout); a docs tree with hundreds of refs = thousands of serialized round-trips.

**Fix — two-phase doc join:**
1. Regex-only pre-pass collects every code ref in the tree (local file reads, zero DB)
2. ONE batched `is_in` query per lookup kind (`find_elements_by_names_exact` + `get_elements_by_files`, new GraphEngine methods) pre-loads a `RefResolver`
3. Per-file pass answers lookups from memory; per-ref graph path remains as fallback for prefix-match stragglers

Decision-tree parity with the per-ref path is pinned by `batch_resolver_matches_single_lookups`.

## #256 — temporal_query >300s

Called `all_relationships()` — the deprecated full-scan + a secondary-index build whose result was thrown away — filtered in Rust, and returned the **entire relationship table** (134k rows in this repo) in the MCP response.

**Fix — dedicated bounded queries:** always-live rows (no temporal keys in metadata, `:limit` capped) + temporal rows (metadata mentions `valid_from`/`valid_to`); totals from SQL group counters; handler gains a `limit` arg (default 100, max 1000) returning `{at, count, returned, has_more, relationships[<=limit]}`.

## Local verification
- Doc index of this repo's real docs tree (232 documents, 3227 sections): **2.4s** with the batched join
- `temporal_query_is_bounded_and_correct`: t=150 → 6 live (5 always + 1 temporal), limit 3 respected; t=350 → temporal edge flips correctly
- `cargo test --lib` 1347/0, fmt + clippy clean
- FakeBackend gains `is_in(col, $param)` + `not <expr>` support mirroring the real cozo grammar