### PR TITLE
fix(ci): semantic-release event race — separate concurrency groups, release mode only for release/* PR merges

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -34,7 +34,7 @@ permissions:
 
 # One release flow at a time; cancel duplicate runs racing on the same ref.
 concurrency:
-  group: semantic-release-${{ github.ref }}
+  group: semantic-release-${{ github.event_name }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:
@@ -47,7 +47,9 @@ jobs:
     if: >-
       github.event_name == 'push' ||
       github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request' && github.event.pull_request.merged == true)
+      (github.event_name == 'pull_request' &&
+       github.event.pull_request.merged == true &&
+       startsWith(github.event.pull_request.head.ref, 'release/'))
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Second half of the semantic-release pipeline fix (#336 hardened the bump functions; this fixes the workflow's event handling).

**Observed live:** merging #336 fired `push(main)` and `pull_request(closed)` at the same instant — both mapped to concurrency group `semantic-release-refs/heads/main`, so the two runs cancelled each other: the release-mode run (which for a regular fix merge has nothing to do) won and the create-pr run was marked `cancelled` — another red X on the pipeline.

**Fix:**
- concurrency group includes the **event name**: the two runs no longer cancel each other
- the `pull_request(closed, merged)` entry point only runs **release mode for `release/*` head branches** — merging a regular PR no longer wakes the publisher at all

Also includes the state from #336 (idempotent bump functions — `bumpCargoToml` no longer throws on already-at-target; create-pr skips commit when nothing changed).

YAML validated; local gates green.