### PR TITLE
fix(ci): semantic-release bumps the npm wrapper — auto release PRs pass the parity gate

### DIFF
--- a/.github/actions/semver-release/action.js
+++ b/.github/actions/semver-release/action.js
@@ -165,6 +165,7 @@ function createPr() {
     bumpCargoToml(next),
     bumpCargoLock(next),
     bumpManifest(next),
+    bumpNpmWrapper(next),
     prependChangelog(next, prev),
   ].some(Boolean);
 
@@ -173,7 +174,7 @@ function createPr() {
     return;
   }
 
-  run(`git add Cargo.toml Cargo.lock manifest.json CHANGELOG.md`);
+  run(`git add Cargo.toml Cargo.lock manifest.json CHANGELOG.md npm/leankg/package.json`);
   run(`git -c user.name='leankg-release[bot]' -c user.email='noreply@github.com' commit -m 'release: v${next}'`);
 
   run(`git push origin ${branch}`);
@@ -226,6 +227,18 @@ function bumpManifest(v) {
   fs.writeFileSync(f, JSON.stringify(m, null, 2) + '\n');
   return true;
 }
+function bumpNpmWrapper(v) {
+  // FR-PLG-6: the npm wrapper must never lag the crate — bump it here so
+  // the auto-generated release PR passes the npm-parity gate.
+  const f = 'npm/leankg/package.json';
+  if (!fs.existsSync(f)) return false;
+  const m = JSON.parse(fs.readFileSync(f, 'utf8'));
+  if (m.version === v) return false;
+  m.version = v;
+  fs.writeFileSync(f, JSON.stringify(m, null, 2) + '\n');
+  return true;
+}
+
 function prependChangelog(v, prev) {
   const f = 'CHANGELOG.md';
   const src = fs.readFileSync(f, 'utf8');


### PR DESCRIPTION
#338 (the auto-generated v0.28.1 release PR) failed **npm/crate Version Parity**: the action bumps Cargo.toml/lock/manifest/CHANGELOG but not `npm/leankg/package.json` — the exact gap FR-PLG-6's guard exists for ("npm wrapper must never lag the crate").

`bumpNpmWrapper(v)` joins the change set (and `git add`), so every future auto-generated release PR is parity-clean at open time. The open #338 branch was patched directly with the wrapper sync.

Simulated + syntax-checked (`node --check`).