### PR TITLE
fix(db): temporal_query uses !regex_matches — parses on both sqlite and PG backends

### DIFF
--- a/src/graph/query.rs
+++ b/src/graph/query.rs
@@ -5617,13 +5617,13 @@ impl GraphEngine {
         let always_q = format!(
             r#"?[source_qualified, target_qualified, rel_type, confidence, metadata] :=
                *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
-               not regex_matches(metadata, 'valid_(from|to)')
+               !regex_matches(metadata, 'valid_(from|to)')
             :limit {}"#,
             limit
         );
         let always_count_q = r#"?[count(source_qualified)] :=
                *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
-               not regex_matches(metadata, 'valid_(from|to)')"#;
+               !regex_matches(metadata, 'valid_(from|to)')"#;
         let temporal_q = r#"?[source_qualified, target_qualified, rel_type, confidence, metadata] :=
                *relationships[source_qualified, target_qualified, rel_type, confidence, metadata, env],
                regex_matches(metadata, 'valid_(from|to)')"#;


### PR DESCRIPTION
Found during a live dual-engine verification: #256's dedicated temporal queries emitted `not regex_matches(metadata, ...)`. The fake backend learned that spelling, real cozo accepted it via its `not_op` grammar rule — but the **PG translator has no top-level 'not'**, so every `temporal_query` over Postgres failed with `no top-level operator: not regex_matches(...)` (repro'd live on pgvector/pg18).

Cozo's `!` negation atom parses on sqlite AND translates natively to `col !~ pat` in the PG translator (paths.rs already handled the `!` shorthand). One spelling, both engines.

**Live-verified on pgvector/pg18:** `temporal_query` 32ms (count returned), `get` retrieval green, server stable; sqlite regression tests unchanged-green (temporal bounded+correct, 1348/0 lib).