### PR TITLE
fix(db): restore 006_audit_log PG migration — fresh Postgres installs lost the audit ledger

### DIFF
--- a/src/db/pg/migrations.rs
+++ b/src/db/pg/migrations.rs
@@ -48,6 +48,14 @@ pub const MIGRATIONS: &[(&str, &str)] = &[
         include_str!("migrations/005_hnsw_dims_cleanup.sql"),
     ),
     (
+        // #332-follow-up: re-added — dropped in the v4.4.0 sqlite-default
+        // sweep (#268), which left every fresh Postgres install without the
+        // audit ledger (FR-ENT-1 recording silently disabled, audit
+        // export/verify failing at open).
+        "006_audit_log",
+        include_str!("migrations/006_audit_log.sql"),
+    ),
+    (
         "007_trgm_fuzzy",
         include_str!("migrations/007_trgm_fuzzy.sql"),
     ),
@@ -205,6 +213,27 @@ fn reconcile_statements(desired: usize, m: usize, ef: usize) -> Vec<String> {
 
 #[cfg(test)]
 mod tests {
+    /// #332-follow-up regression: 006_audit_log must stay in the PG
+    /// migration set — the v4.4.0 sqlite-default sweep dropped it and every
+    /// fresh Postgres install lost the audit ledger (FR-ENT-1).
+    #[test]
+    fn audit_log_migration_present_and_ordered() {
+        let pos = super::MIGRATIONS
+            .iter()
+            .position(|(id, _)| *id == "006_audit_log")
+            .expect("006_audit_log must be in MIGRATIONS");
+        assert_eq!(
+            super::MIGRATIONS[pos].1,
+            include_str!("migrations/006_audit_log.sql"),
+            "the registered 006 body must be the audit-log DDL"
+        );
+        // Ordering sanity: ids must be ascending (zero-padded → lexicographic
+        // equals numeric).
+        let ids: Vec<&str> = super::MIGRATIONS.iter().map(|(id, _)| *id).collect();
+        let mut sorted = ids.clone();
+        sorted.sort_unstable();
+        assert_eq!(ids, sorted, "migrations must be ordered by id");
+    }
     use super::*;
 
     /// Serialize tests that mutate LEANKG_PG_URL (process-global env).


### PR DESCRIPTION
Found during the dual-engine (sqlite + Postgres) verification sweep.

**Root cause:** the v4.4.0 sqlite-default sweep (#268) dropped `006_audit_log` from the PG `MIGRATIONS` array (005 jumps straight to 007 — the DDL file itself was never deleted). Every **fresh Postgres install** since has had **no `audit_log` table**:

- audit recording silently disabled on first write (`WARN leankg::audit: cannot read audit chain head: db error; audit recording DISABLED for this process`)
- `leankg audit export|verify` fail at open (`cannot read audit ledger: db error`)

**Fix:** re-add the migration array entry (with a comment explaining the drop) + a regression test pinning 006's presence, its body being the actual audit DDL, and id ordering sanity.

**Live-verified on pgvector/pg18 (fresh database):**
- migrate applies 006
- `get` via MCP records an audit entry (no DISABLED warning in the log)
- `audit verify` → `OK: audit chain intact (1 entries verified)`
- `audit export` emits the entry

sqlite untouched — its ledger already worked via #312/\#320. `cargo test --lib` 1349/0, fmt + clippy clean.