### PR TITLE
ci: compile all test targets so integration suites can't rot silently

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,12 @@ jobs:
             ${{ runner.os }}-target-${{ hashFiles('**/Cargo.lock') }}-
             ${{ runner.os }}-target-
 
+      - name: Compile all test targets (integration suites must never rot)
+        # `--lib` alone lets integration tests (tests/*.rs) drift out of
+        # compilation — that happened with temporal_query's signature change
+        # (#331) and stayed broken for two releases. Compiling without
+        # running needs no PG container; runtime cost is build-cache only.
+        run: cargo test --no-run --release
       - name: Run unit tests
         run: cargo test --lib
 


### PR DESCRIPTION
The Test Suite job ran `cargo test --lib` only — integration tests (`tests/*.rs`) could drift out of compilation unnoticed. That happened for real: #331 changed `temporal_query`'s signature and three integration suites stopped compiling, broken across two releases until #343 fixed them.

`cargo test --no-run --release` compiles every target (lib + all integration suites) **without running them** — no PG container needed for the gate (the run step stays `--lib`), and the runtime cost is build-cache only.

Catches the E0599/E0308 API-mismatch class that `clippy --all-targets` review of flags wouldn't reliably surface as a hard failure.