### PR TITLE
ci: compile the test targets in dev profile

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,8 +51,10 @@ jobs:
         # `--lib` alone lets integration tests (tests/*.rs) drift out of
         # compilation — that happened with temporal_query's signature change
         # (#331) and stayed broken for two releases. Compiling without
-        # running needs no PG container; runtime cost is build-cache only.
-        run: cargo test --no-run --release
+        # running needs no PG container. Dev profile: catches the same
+        # API-drift class (E0599/E0308) 3-4x faster than release — measured
+        # 13m10s with --release vs 56s for the job pre-step (#345).
+        run: cargo test --no-run
       - name: Run unit tests
         run: cargo test --lib
 


### PR DESCRIPTION
Follow-up to #345 with measured data.

#345's `cargo test --no-run --release` compiled all targets in **release profile** — Test Suite job went from **56s to 13m10s** on the first main push (measured: run 34389400679 vs 34387155045).

The gate's purpose is catching API drift (E0599/E0308) between the lib and its integration suites — the **dev profile catches the same class 3-4x faster**, and the optimized artifacts are irrelevant since nothing runs. This PR drops `--release` from the compile step (the run step stays `cargo test --lib`).