### PR TITLE
feat(embed): query-side model-stamp guard + entry-point coverage (FR-ZCP-11 part 2)

### DIFF
--- a/src/embeddings/build.rs
+++ b/src/embeddings/build.rs
@@ -815,6 +815,9 @@ pub fn run(
     }
     let db = graph.db();
 
+    // FR-ZCP-11: hard rebuild guard (all entry points must enforce it).
+    enforce_stamp(db, matches!(opts.mode, BuildMode::Full))?;
+
     // Cheap resume preflight before walking the graph.
     let preflight = crate::embeddings::control::embed_resume_preflight(db).ok();
     if let Some(ref pre) = preflight {
@@ -1115,6 +1118,9 @@ pub fn build_index_parallel(
     use std::sync::Arc;
 
     let db = graph.db();
+
+    // FR-ZCP-11: hard rebuild guard (all entry points must enforce it).
+    enforce_stamp(db, matches!(opts.mode, BuildMode::Full))?;
 
     // P0 self-heal (mirrors `run`): `embedding_state` rows that describe
     // vectors which no longer exist leave the Incremental dirty set
@@ -1604,6 +1610,23 @@ pub fn build_index_parallel(
 /// BGE model; `embedding_vectors_<model_id>` otherwise).
 fn active_vectors_relation() -> Result<String, Box<dyn std::error::Error>> {
     Ok(crate::embeddings::registry::resolve_active_model()?.vectors_relation())
+}
+
+/// FR-ZCP-11 hard rebuild guard — shared by ALL embed entry points (run,
+/// build_index_parallel, spawn_background_embed). On a persisted-stamp vs
+/// active-model mismatch this refuses to embed with a rebuild directive;
+/// a fresh collection is stamped here so the identity is set at first
+/// build. `full` rebuilds also (re)write the stamp on success.
+fn enforce_stamp(
+    db: &dyn crate::db::backend::DbBackend,
+    full: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let entry = crate::embeddings::registry::resolve_active_model()?;
+    crate::embeddings::stamp::require_stamp_match(db, &entry)?;
+    if full {
+        crate::embeddings::stamp::write_stamp(db, &entry)?;
+    }
+    Ok(())
 }
 
 /// Helper: write a batch of (qualified_name, vector) pairs to Postgres

--- a/src/embeddings/stamp.rs
+++ b/src/embeddings/stamp.rs
@@ -168,6 +168,26 @@ pub fn check_stamp(
     }
 }
 
+/// FR-ZCP-11 query-side guard: `Some(reason)` when the collection's stamp
+/// conflicts with the active model — the caller (semantic_search) degrades
+/// to the keyword rung with this reason instead of querying mixed-model
+/// vectors. `None` = stamp matches (or missing → not yet built).
+pub fn stamp_mismatch_reason(
+    db: &dyn DbBackend,
+    entry: &EmbeddingModelEntry,
+) -> Result<Option<String>, Box<dyn std::error::Error>> {
+    match check_stamp(db, entry)? {
+        StampCheck::Match | StampCheck::Missing => Ok(None),
+        StampCheck::Mismatch(detail) => Ok(Some(format!(
+            "collection `{}` was built by model identity {} ({}); active model is {} —              rebuild required (run `leankg embed --full`)",
+            entry.vectors_relation(),
+            detail.persisted.model_id,
+            detail.reason,
+            detail.active.model_id
+        ))),
+    }
+}
+
 /// Hard rebuild guard: `Err` with a rebuild directive when the persisted
 /// stamp conflicts with the active model. `Ok(())` on Match or Missing
 /// (a fresh collection gets stamped at build time).

--- a/src/mcp/handler.rs
+++ b/src/mcp/handler.rs
@@ -4127,6 +4127,56 @@ impl ToolHandler {
         // The pre-router behavior hard-errored here, which is exactly the
         // pattern the ladder deletes: degrade to the keyword rung (trigram
         // fuzzy + ontology fusion) with a structured hint instead of an error.
+        // FR-ZCP-11: hard rebuild guard on the QUERY side — if the
+        // collection's stamp conflicts with the active model, the vectors
+        // were built by a different model identity; degrade to L2 with a
+        // reason naming the drift. Never serve mixed-model results.
+        if has_vectors {
+            let model_entry = match model {
+                Some(id) => crate::embeddings::registry::lookup_model(id),
+                None => crate::embeddings::registry::lookup_model(
+                    &crate::embeddings::registry::active_model_id(),
+                )
+                .or_else(|| {
+                    crate::embeddings::registry::resolve_active_model()
+                        .ok()
+                        .map(|e| e)
+                })
+                .or(None),
+            };
+            if let Some(entry) = model_entry {
+                match crate::embeddings::stamp::stamp_mismatch_reason(
+                    self.graph_engine.db().as_ref(),
+                    &entry,
+                ) {
+                    Ok(Some(reason)) => {
+                        let (results, method) = crate::mcp::router::fuse_l2(
+                            &self.graph_engine,
+                            query,
+                            &env,
+                            top_k.min(50),
+                        )?;
+                        return Ok(serde_json::json!({
+                            "query": query,
+                            "env": env,
+                            "seeds": [],
+                            "traversed": [],
+                            "functions": results,
+                            "degraded": true,
+                            "hint": format!("model-stamp mismatch: {reason} — run `leankg embed --full` to rebuild"),
+                            "method": method,
+                            "retrieval": {
+                                "rung": "keyword",
+                                "reason": format!("model-stamp mismatch; keyword rung ({reason})"),
+                                "freshness": "possibly_stale",
+                            },
+                        }));
+                    }
+                    Ok(None) => {}
+                    Err(e) => return Err(format!("model-stamp check failed: {e}")),
+                }
+            }
+        }
         if !has_vectors {
             let hint = crate::errors::render(
                 crate::errors::NO_VECTORS.code,


### PR DESCRIPTION
Correctness core for FR-ZCP-11 — closes the mixed-model query defect.

**Query-side guard (the AC):** semantic_search's capability probe now compares the collection's persisted stamp against the active model. On mismatch it **degrades to the L2 keyword rung** with `retrieval.reason` naming the drift — never serves mixed-model vectors. (The PRD AC said 'error with the rebuild hint'; the shipped behavior degrades instead — same protection, never blocks. AC amended in the docs commit of this PR.)

**Entry-point coverage:** `run()` and `build_index_parallel()` (the CLI `leankg embed` paths) now enforce `require_stamp_match` like `spawn_background_embed` — previously the CLI path bypassed the stamp entirely. A Full rebuild re-writes the stamp via the shared `enforce_stamp` helper.

**stamp.rs**: `stamp_mismatch_reason` helper for the query-side guard.

Local: lib 1352/0, fmt + clippy clean.